### PR TITLE
fix prices api price_timestamp in seconds

### DIFF
--- a/src/lib/price.ts
+++ b/src/lib/price.ts
@@ -106,6 +106,9 @@ export async function getPricedBalances(
     return {
       ...price,
       ...balance,
+      priceTimestamp: price.timestamp
+        ? new Date(price.timestamp * 1000)
+        : undefined,
       balanceUSD: mulPrice(balance.amount, decimals, price.price),
       claimableUSD: (balance as RewardBalance).claimable
         ? mulPrice(


### PR DESCRIPTION
Javascript times are in ms

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
