### PR TITLE
fix sync_status endpoint use count estimate

### DIFF
--- a/docs/new-chain.sql
+++ b/docs/new-chain.sql
@@ -18,7 +18,10 @@ declare
 BEGIN 
   FOR rec IN tables LOOP
     multichainQuery := multichainQuery ||
-        format('SELECT count(*) as count, max(number) as max, %L::varchar as chain from %I.blocks', rec._chain, rec._chain) || 
+        format('select reltuples::bigint as count,
+			   (select max(number) from %I.blocks) as max,
+			   %L::varchar as chain
+			   from pg_class where oid = ''%I.blocks''::regclass', rec._chain, rec._chain, rec._chain) || 
         ' union all ';
   END LOOP;
   

--- a/docs/queries.sql
+++ b/docs/queries.sql
@@ -18,7 +18,10 @@ declare
 BEGIN 
   FOR rec IN tables LOOP
     multichainQuery := multichainQuery ||
-        format('SELECT count(*) as count, max(number) as max, %L::varchar as chain from %I.blocks', rec._chain, rec._chain) || 
+        format('select reltuples::bigint as count,
+			   (select max(number) from %I.blocks) as max,
+			   %L::varchar as chain
+			   from pg_class where oid = ''%I.blocks''::regclass', rec._chain, rec._chain, rec._chain) || 
         ' union all ';
   END LOOP;
   

--- a/serverless.yml
+++ b/serverless.yml
@@ -101,6 +101,14 @@ functions:
           method: get
           path: /categories
 
+  getSyncStatus:
+    handler: src/handlers/getSyncStatus.handler
+    description: Get sync status
+    events:
+      - httpApi:
+          method: get
+          path: /sync_status
+
   getInfoStats:
     handler: src/handlers/getInfoStats.handler
     description: Get stats on supported protocols, chains and tokens
@@ -130,8 +138,6 @@ functions:
       - websocket:
           route: updateBalances
       - websocket:
-          route: getSyncStatus
-      - websocket:
           # Fallback
           route: $default
 
@@ -144,11 +150,6 @@ functions:
     handler: src/handlers/updateBalances.websocketUpdateAdapterBalancesHandler
     role: handleWebsocketRequestsRole
     timeout: 300
-
-  websocketGetSyncStatus:
-    handler: src/handlers/getSyncStatus.websocketHandler
-    role: handleWebsocketRequestsRole
-    timeout: 120
 
 custom:
   stage: ${opt:stage, self:provider.stage}

--- a/src/handlers/websocket.ts
+++ b/src/handlers/websocket.ts
@@ -60,13 +60,6 @@ export const handleRequests: APIGatewayProxyHandler = async (event) => {
       );
       break;
 
-    case "getSyncStatus":
-      await invokeLambda(
-        `llamafolio-api-${process.env.stage}-websocketGetSyncStatus`,
-        { connectionId: connectionId }
-      );
-      break;
-
     case "$default":
     default:
       const apiGatewayManagementApi = new ApiGatewayManagementApi({


### PR DESCRIPTION
<!-- 🦙🦙 Thanks for contributing ! 🦙🦙 -->

<!-- Please specify the adapter id in the title -->

<!-- If you're creating a new adapter, please make sure the `links` field is well specified: this info will help us review it -->

## Summary

<!-- Which issues will be closed? (if applicable) -->

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

- use SQL count estimate instead of actual `count`. This is less accurate but much faster
- Remove websocket endpoint as it's not limited by API Gateway v2 any longer

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
