### PR TITLE
add tokens endpoint

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -61,22 +61,6 @@ provider:
       maxAge: 31536000
 
 functions:
-  getBalances:
-    handler: src/handlers/getBalances.handler
-    description: Get address balances
-    events:
-      - httpApi:
-          method: get
-          path: /balances/{address}
-
-  getHistory:
-    handler: src/handlers/getHistory.handler
-    description: Get address history
-    events:
-      - httpApi:
-          method: get
-          path: /history/{address}
-
   getAdapters:
     handler: src/handlers/getAdapters.handler
     description: Get adapters
@@ -85,13 +69,13 @@ functions:
           method: get
           path: /adapters
 
-  getContract:
-    handler: src/handlers/getContracts.getContract
-    description: Get contract
+  getBalances:
+    handler: src/handlers/getBalances.handler
+    description: Get address balances
     events:
       - httpApi:
           method: get
-          path: /contracts/{address}
+          path: /balances/{address}
 
   getCategories:
     handler: src/handlers/getCategories.handler
@@ -101,13 +85,21 @@ functions:
           method: get
           path: /categories
 
-  getSyncStatus:
-    handler: src/handlers/getSyncStatus.handler
-    description: Get sync status
+  getContract:
+    handler: src/handlers/getContracts.getContract
+    description: Get contract
     events:
       - httpApi:
           method: get
-          path: /sync_status
+          path: /contracts/{address}
+
+  getHistory:
+    handler: src/handlers/getHistory.handler
+    description: Get address history
+    events:
+      - httpApi:
+          method: get
+          path: /history/{address}
 
   getInfoStats:
     handler: src/handlers/getInfoStats.handler
@@ -124,6 +116,22 @@ functions:
       - httpApi:
           method: get
           path: /labels/{address}
+
+  getSyncStatus:
+    handler: src/handlers/getSyncStatus.handler
+    description: Get sync status
+    events:
+      - httpApi:
+          method: get
+          path: /sync_status
+
+  getTokens:
+    handler: src/handlers/getTokens.handler
+    description: Get tokens
+    events:
+      - httpApi:
+          method: get
+          path: /tokens/{address}
 
   scheduledRevalidateAdaptersContracts:
     handler: src/handlers/revalidateAdapters.scheduledRevalidateAdaptersContracts

--- a/src/handlers/getLabels.ts
+++ b/src/handlers/getLabels.ts
@@ -3,7 +3,7 @@ import { success } from "@handlers/response";
 import { getLabel } from "@llamafolio/labels";
 
 /**
- * Get label of given address
+ * Get labels of given addresses
  */
 export const handler: APIGatewayProxyHandler = async (event) => {
   const addresses = event.pathParameters?.address?.split(",") ?? [];

--- a/src/handlers/getTokens.ts
+++ b/src/handlers/getTokens.ts
@@ -1,0 +1,46 @@
+import { APIGatewayProxyHandler } from "aws-lambda";
+import { success } from "@handlers/response";
+import { Token } from "@lib/token";
+import { getToken } from "@llamafolio/tokens";
+
+/**
+ * Get tokens of given addresses
+ * Tokens are comma separated and should be prefixed by their chain: `{chain}:{address}`
+ * Or only the name of the chain to get the native coin. Ex: `arbitrum,avax,ethereum`
+ * (Chain 'ethereum' is used by default if no chain is specified)
+ */
+export const handler: APIGatewayProxyHandler = async (event) => {
+  const chainAddresses = event.pathParameters?.address?.split(",") ?? [];
+  const data: { [key: string]: Token } = {};
+
+  for (const chainAddress of chainAddresses) {
+    const split = chainAddress.split(":");
+    let chain = "ethereum";
+    let address: string | undefined;
+
+    // chain or address
+    if (split.length === 1) {
+      if (split[0].startsWith("0x")) {
+        address = split[0];
+      } else {
+        chain = split[0];
+      }
+    } else {
+      chain = split[0];
+      address = split[1];
+    }
+
+    const token = getToken(chain, address?.toLowerCase()) as Token;
+
+    if (token) {
+      data[chainAddress] = token;
+    }
+  }
+
+  return success(
+    {
+      data,
+    },
+    { maxAge: 10 * 60 }
+  );
+};


### PR DESCRIPTION
<!-- 🦙🦙 Thanks for contributing ! 🦙🦙 -->

<!-- Please specify the adapter id in the title -->

<!-- If you're creating a new adapter, please make sure the `links` field is well specified: this info will help us review it -->

## Summary

<!-- Which issues will be closed? (if applicable) -->

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

Add `/tokens` endpoint to retrieve tokens info from `llamafolio-tokens`

Patterns:

- `{api_url}/tokens/ethereum:0x123,avax:0x123`: '{chain}:{address}'
- `{api_url}/tokens/0x123,avax`:  default chain is 'ethereum', can get native chain coin by specifying name of the chain instead

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
