### PR TITLE
add support to return objects in getContracts

### DIFF
--- a/scripts/run-adapter.ts
+++ b/scripts/run-adapter.ts
@@ -4,6 +4,7 @@ import { BigNumber } from "ethers";
 import millify from "millify";
 
 import { Adapter, Balance, BaseContext } from "../src/lib/adapter";
+import { groupContracts } from "../src/db/contracts";
 import { getPricedBalances } from "../src/lib/price";
 
 type CategoryBalances = {
@@ -51,7 +52,10 @@ async function main() {
 
   const contractsRes = await adapter.getContracts();
 
-  const balancesRes = await adapter.getBalances(ctx, contractsRes.contracts);
+  const balancesRes = await adapter.getBalances(
+    ctx,
+    groupContracts(contractsRes.contracts) || []
+  );
 
   const yieldsRes = await fetch("https://yields.llama.fi/poolsOld");
   const yieldsData = (await yieldsRes.json()).data;
@@ -131,7 +135,6 @@ async function main() {
         yieldsByPoolAddress[key] ||
         yieldsByPoolAddress[subKey] ||
         yieldsByKeys[nonAddressKey];
-
 
       const d = {
         chain: balance.chain,

--- a/scripts/run-balances.ts
+++ b/scripts/run-balances.ts
@@ -5,6 +5,7 @@ import { getPricedBalances } from "../src/lib/price";
 import {
   getAllTokensInteractions,
   getContractsInteractions,
+  groupContracts,
 } from "../src/db/contracts";
 
 function help() {}
@@ -41,7 +42,10 @@ async function main() {
 
     console.log("Contracts:", JSON.stringify(contracts, null, 2));
 
-    const balancesConfig = await adapter.getBalances(ctx, contracts || []);
+    const balancesConfig = await adapter.getBalances(
+      ctx,
+      groupContracts(contracts) || []
+    );
 
     const pricedBalances = await getPricedBalances(balancesConfig.balances);
 

--- a/scripts/update-balances.ts
+++ b/scripts/update-balances.ts
@@ -5,6 +5,7 @@ import {
 } from "../src/db/contracts";
 import pool from "../src/db/pool";
 import { insertBalances } from "../src/db/balances";
+import { groupContracts } from "../src/db/contracts";
 import { adapterById } from "../src/adapters";
 import { BaseContext, Contract } from "../src/lib/adapter";
 import { strToBuf } from "../src/lib/buf";
@@ -65,7 +66,8 @@ async function main() {
 
             const hrstart = process.hrtime();
 
-            const contracts = contractsByAdapterId[adapterId] || [];
+            const contracts =
+              groupContracts(contractsByAdapterId[adapterId]) || [];
             const balancesConfig = await adapter.getBalances(ctx, contracts);
 
             const hrend = process.hrtime(hrstart);

--- a/src/handlers/updateBalances.ts
+++ b/src/handlers/updateBalances.ts
@@ -2,6 +2,7 @@ import { APIGatewayProxyHandler } from "aws-lambda";
 import format from "pg-format";
 import { strToBuf, isHex } from "@lib/buf";
 import pool from "@db/pool";
+import { groupContracts } from "@db/contracts";
 import { BaseContext, Contract } from "@lib/adapter";
 import { getPricedBalances } from "@lib/price";
 import { adapterById } from "@adapters/index";
@@ -106,7 +107,8 @@ export const websocketUpdateAdaptersHandler: APIGatewayProxyHandler = async (
 
             const hrstart = process.hrtime();
 
-            const contracts = contractsByAdapterId[adapterId] || [];
+            const contracts =
+              groupContracts(contractsByAdapterId[adapterId]) || [];
             const balancesConfig = await adapter.getBalances(ctx, contracts);
 
             const hrend = process.hrtime(hrstart);

--- a/src/lib/adapter.ts
+++ b/src/lib/adapter.ts
@@ -83,7 +83,7 @@ export interface Adapter {
   getContracts: () => ContractsConfig | Promise<ContractsConfig>;
   getBalances: (
     ctx: BaseContext,
-    contracts: BaseContract[]
+    contracts: Contract[] | { [key: string]: Contract | Contract[] }
   ) => BalancesConfig | Promise<BalancesConfig>;
 }
 


### PR DESCRIPTION
<!-- 🦙🦙 Thanks for contributing ! 🦙🦙 -->

<!-- Please specify the adapter id in the title -->

<!-- If you're creating a new adapter, please make sure the `links` field is well specified: this info will help us review it -->

## Summary

<!-- Which issues will be closed? (if applicable) -->

<!-- What changes are being made? -->



<!-- Why are these changes necessary? -->

Add support for returning contracts Object in `getContracts`. This simplifies a lot of the code to degroup / regroup contracts

### Before
<img width="568" alt="Screenshot 2022-10-14 at 16 45 35" src="https://user-images.githubusercontent.com/99134502/195875611-9bf32d63-148f-40b5-83d8-da3bb5d0e6bc.png">

### After
<img width="552" alt="Screenshot 2022-10-14 at 16 44 23" src="https://user-images.githubusercontent.com/99134502/195875621-fa1b0b35-6f4b-4a5e-92ea-338d89ee80b1.png">

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
