### PR TITLE
fix geist missing underlyings

### DIFF
--- a/src/adapters/geist/index.ts
+++ b/src/adapters/geist/index.ts
@@ -65,7 +65,8 @@ const getBalances: GetBalancesHandler<typeof getContracts> = async (
     "fantom",
     contracts,
     {
-      multiFeeDistributionAddress: multiFeeDistributionContract.address,
+      multiFeeDistribution: multiFeeDistributionContract,
+      lendingPool: lendingPoolContract,
       stakingToken: geistToken,
     }
   );

--- a/src/adapters/radiant/index.ts
+++ b/src/adapters/radiant/index.ts
@@ -65,7 +65,8 @@ const getBalances: GetBalancesHandler<typeof getContracts> = async (
     "arbitrum",
     contracts,
     {
-      multiFeeDistributionAddress: multiFeeDistributionContract.address,
+      multiFeeDistribution: multiFeeDistributionContract,
+      lendingPool: lendingPoolContract,
       stakingToken: radiantToken,
     }
   );

--- a/src/adapters/valas/index.ts
+++ b/src/adapters/valas/index.ts
@@ -65,7 +65,8 @@ const getBalances: GetBalancesHandler<typeof getContracts> = async (
     "bsc",
     contracts,
     {
-      multiFeeDistributionAddress: multiFeeDistributionContract.address,
+      multiFeeDistribution: multiFeeDistributionContract,
+      lendingPool: lendingPoolContract,
       stakingToken: valasToken,
     }
   );

--- a/src/lib/aave/v2/lending.ts
+++ b/src/lib/aave/v2/lending.ts
@@ -141,6 +141,7 @@ export async function getLendingPoolContracts(
       }
     }
 
+    // TODO: 1 multicall to get all ERC20 details at once
     const [underlyingTokens, aTokens, stableDebtTokens, variableDebtTokens] =
       await Promise.all([
         getERC20Details(chain, underlyingTokensAddresses),

--- a/src/lib/adapter.ts
+++ b/src/lib/adapter.ts
@@ -20,14 +20,6 @@ export interface BasePricedBalance extends BaseBalance {
   timestamp: number;
 }
 
-export interface RewardBalance extends BaseBalance {
-  // claimable amount. Can be lower than balance amount but not higher.
-  // ex: vested reward of 1000 but only 100 currently claimable.
-  claimable: BigNumber;
-  // TODO: rewards interface
-  rates?: any;
-}
-
 export interface Balance extends BaseBalance {
   // optional rewards
   rewards?: BaseBalance[];
@@ -35,6 +27,14 @@ export interface Balance extends BaseBalance {
   // ex: aToken -> token (AAVE)
   // ex: Uniswap Pair -> [token0, token1]
   underlyings?: BaseBalance[];
+}
+
+export interface RewardBalance extends Balance {
+  // claimable amount. Can be lower than balance amount but not higher.
+  // ex: vested reward of 1000 but only 100 currently claimable.
+  claimable: BigNumber;
+  // TODO: rewards interface
+  rates?: any;
 }
 
 export interface PricedBalance extends BasePricedBalance {

--- a/src/lib/map.ts
+++ b/src/lib/map.ts
@@ -11,15 +11,23 @@ export interface Contract {
 export class ContractsMap<V> {
   _chains = new Map<Chain | string, Map<string, V>>();
 
-  constructor(iterable?: Iterable<[Contract, V]>) {
+  constructor(iterable?: Iterable<[Contract, V] | Contract>) {
     if (iterable) {
-      for (const [key, value] of iterable) {
-        this.set(key, value);
+      for (const kv of iterable) {
+        if (Array.isArray(kv)) {
+          this.set(kv[0], kv[1]);
+        } else {
+          this.add(kv);
+        }
       }
     }
   }
 
-  set(key: Contract, value: V) {
+  set(key: Contract, value?: V) {
+    if (value === undefined) {
+      value = key as V;
+    }
+
     const chain = key.chain;
     const address = key.address.toLowerCase();
     if (!this._chains.has(chain)) {


### PR DESCRIPTION
<!-- 🦙🦙 Thanks for contributing ! 🦙🦙 -->

<!-- Please specify the adapter id in the title -->

<!-- If you're creating a new adapter, please make sure the `links` field is well specified: this info will help us review it -->

## Summary

<!-- Which issues will be closed? (if applicable) -->

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

Fix: https://github.com/llamafolio/llamafolio-api/issues/93

The issue was it was relying on pools that the user interacted with to map aTokens -> tokens
but it didn't work if the user never interacted with them (for instance if the user never claimed its tokens from the MultiFeeDistribution)

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
