### PR TITLE
update defillama sdk providers

### DIFF
--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -1,3 +1,4 @@
+import { setProvider } from '@defillama/sdk/build/general'
 import { Chain, chains } from '@lib/chains'
 import { providers as ethersProviders } from 'ethers'
 
@@ -17,5 +18,8 @@ function createProvider(name: string, rpcs: string[], chainId: number) {
 export const providers: { [chain in Chain]: ethersProviders.BaseProvider } = Object.assign({})
 
 for (const chain of chains) {
-  providers[chain.id] = createProvider(chain.id, chain.rpcUrl, chain.chainId)
+  const provider = createProvider(chain.id, chain.rpcUrl, chain.chainId)
+  providers[chain.id] = provider
+  // update defillama sdk providers (used by calls and multicalls)
+  setProvider(chain.id, provider)
 }


### PR DESCRIPTION
<!-- 🦙🦙 Thanks for contributing ! 🦙🦙 -->

<!-- Please specify the adapter id in the title -->

<!-- If you're creating a new adapter, please make sure the `links` field is well specified: this info will help us review it -->

## Summary

<!-- Which issues will be closed? (if applicable) -->

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

Fix: https://github.com/llamafolio/llamafolio-api/issues/179

`call` and `multicall` is using the providers defined internally in the SDK. Use `setProvider` to use our own providers

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
