### PR TITLE
getBalances partial contracts

### DIFF
--- a/src/lib/adapter.ts
+++ b/src/lib/adapter.ts
@@ -106,7 +106,8 @@ export type GetContractsHandler = () => ContractsConfig | Promise<ContractsConfi
 
 export type GetBalancesHandler<C extends GetContractsHandler> = (
   ctx: BaseContext,
-  contracts: Awaited<ReturnType<C>>['contracts'],
+  // each key can be undefined as the account may not have interacted with these contracts
+  contracts: Partial<Awaited<ReturnType<C>>['contracts']>,
 ) => BalancesConfig | Promise<BalancesConfig>
 
 export interface Adapter {


### PR DESCRIPTION
<!-- 🦙🦙 Thanks for contributing ! 🦙🦙 -->

<!-- Please specify the adapter id in the title -->

<!-- If you're creating a new adapter, please make sure the `links` field is well specified: this info will help us review it -->

## Summary

<!-- Which issues will be closed? (if applicable) -->

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

Made possible by https://github.com/llamafolio/llamafolio-api/commit/58866ba631f51fb202c232fda94bc54094645acf

This is how the system works internally: it only passes contracts to `getBalances` if the account interacted with them. So sometimes it's undefined 🤷 

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
