### PR TITLE
resolve balances helper

### DIFF
--- a/src/adapters/rocket-pool/index.ts
+++ b/src/adapters/rocket-pool/index.ts
@@ -1,26 +1,88 @@
-import { Adapter, GetBalancesHandler } from '@lib/adapter'
-import { getERC20BalanceOf } from '@lib/erc20'
-import { Token } from '@lib/token'
+import { Adapter, BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+import { Chain } from '@lib/chains'
+import { BN_TEN } from '@lib/math'
+import { getSingleStakeBalance } from '@lib/stake'
+import { ETH, Token } from '@lib/token'
+import { BigNumber } from 'ethers'
 
-const rETH: Token = {
+const abi = {
+  getNodeRPLStake: {
+    inputs: [{ internalType: 'address', name: '_nodeAddress', type: 'address' }],
+    name: 'getNodeRPLStake',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  getNodeActiveMinipoolCount: {
+    inputs: [{ internalType: 'address', name: '_nodeAddress', type: 'address' }],
+    name: 'getNodeActiveMinipoolCount',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+}
+
+const RPL: Token = {
   chain: 'ethereum',
-  address: '0xae78736cd615f374d3085123a210448e74fc6393',
-  symbol: 'rETH',
+  address: '0xd33526068d116ce69f19a9ee46f0bd304f21a51f',
+  symbol: 'RPL',
   decimals: 18,
-  coingeckoId: 'rocket-pool-eth',
+  coingeckoId: 'rocket-pool',
+}
+
+const nodeStaking: Contract = {
+  name: 'Staking',
+  chain: 'ethereum',
+  decimals: 18,
+  symbol: 'RPL',
+  address: '0x3019227b2b8493e45bf5d25302139c9a2713bf15',
+  underlyings: [RPL],
+}
+
+const miniPoolManager: Contract = {
+  name: 'Mini Pool Manager',
+  chain: 'ethereum',
+  address: '0x6293b8abc1f36afb22406be5f96d893072a8cf3a',
+  decimals: 18,
+  symbol: 'ETH',
+  underlyings: [ETH],
+}
+
+function getNodeStakingBalance(ctx: BaseContext, chain: Chain, nodeStaking: Contract) {
+  return getSingleStakeBalance(ctx, chain, nodeStaking, {
+    abi: abi.getNodeRPLStake,
+  })
+}
+
+async function getMiniPoolManagerBalance(ctx: BaseContext, chain: Chain, miniPoolManager: Contract) {
+  const balance = await getSingleStakeBalance(ctx, chain, miniPoolManager, {
+    abi: abi.getNodeActiveMinipoolCount,
+  })
+
+  // 16 ETH required (not 32)
+  // See: https://rocketpool.net/#stake-run-node
+  balance.amount = balance.amount.mul(BigNumber.from('16').mul(BN_TEN.pow(18)))
+
+  return balance
 }
 
 const getContracts = () => {
   return {
-    contracts: { rETH },
+    contracts: { miniPoolManager, nodeStaking },
   }
 }
 
-const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, { rETH }) => {
-  const balances = await getERC20BalanceOf(ctx, 'ethereum', [rETH] as Token[])
+const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  console.log(contracts)
+
+  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+    miniPoolManager: getMiniPoolManagerBalance,
+    nodeStaking: getNodeStakingBalance,
+  })
 
   return {
-    balances: balances.map((bal) => ({ ...bal, category: 'stake' })),
+    balances,
   }
 }
 

--- a/src/lib/stake.ts
+++ b/src/lib/stake.ts
@@ -1,0 +1,37 @@
+import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { call, TCall } from '@lib/call'
+import { Category } from '@lib/category'
+import { Chain } from '@lib/chains'
+import { abi as erc20ABI, getERC20BalanceOf } from '@lib/erc20'
+import { Token } from '@lib/token'
+import { BigNumber } from 'ethers'
+
+export async function getSingleStakeBalance(
+  ctx: BaseContext,
+  chain: Chain,
+  contract: Contract,
+  callOptions?: Partial<TCall>,
+) {
+  const amountRes = await call({
+    chain,
+    abi: erc20ABI.balanceOf,
+    target: contract.address,
+    params: [ctx.address],
+    ...callOptions,
+  })
+
+  const amount = BigNumber.from(amountRes.output)
+
+  const balance: Balance = {
+    ...(contract as Balance),
+    amount,
+    category: 'stake',
+  }
+
+  return balance
+}
+
+export async function getSingleStakeBalances(ctx: BaseContext, chain: Chain, contracts: Contract[]) {
+  const balances = await getERC20BalanceOf(ctx, chain, contracts as Token[])
+  return balances.map((bal) => ({ ...bal, category: 'stake' as Category }))
+}

--- a/src/lib/token.ts
+++ b/src/lib/token.ts
@@ -13,3 +13,12 @@ export interface Token {
   // ex: WETH -> ETH
   priceSubstitute?: string
 }
+
+export const ETH: Token = {
+  chain: 'ethereum',
+  address: '0x0000000000000000000000000000000000000000',
+  symbol: 'ETH',
+  decimals: 18,
+  coingeckoId: 'ethereum',
+  native: true,
+}


### PR DESCRIPTION
<!-- 🦙🦙 Thanks for contributing ! 🦙🦙 -->

<!-- Please specify the adapter id in the title -->

<!-- If you're creating a new adapter, please make sure the `links` field is well specified: this info will help us review it -->

## Summary

<!-- Which issues will be closed? (if applicable) -->

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

`resolveBalances` allows us to map contracts keys to "resolvers". 

A "resolver" is a function that returns a balance given some contract(s).

`resoleBalances` makes sure to call resolvers with the right contracts and only if the account interacted with them. It runs resolvers in parallel and flattens + filter nullish balances.

Check Rocket Pool example

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
