### PR TITLE
add BalancesContext with chain and adapterId fields

### DIFF
--- a/scripts/revalidate-contracts.ts
+++ b/scripts/revalidate-contracts.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import { Adapter as DBAdapter, selectAdapter, upsertAdapters } from '../src/db/adapters'
 import { deleteContractsByAdapter, insertContracts } from '../src/db/contracts'
 import pool from '../src/db/pool'
-import { Adapter } from '../src/lib/adapter'
+import { Adapter, BaseContext } from '../src/lib/adapter'
 import { Chain, chains } from '../src/lib/chains'
 import { resolveContractsTokens } from '../src/lib/token'
 
@@ -37,7 +37,9 @@ async function main() {
       adapterChains.map(async (chain) => {
         const prevDbAdapter = await selectAdapter(client, chain, adapter.id)
 
-        const contractsRes = await adapter[chain]!.getContracts(prevDbAdapter?.contractsRevalidateProps || {})
+        const ctx: BaseContext = { chain, adapterId: adapter.id }
+
+        const contractsRes = await adapter[chain]!.getContracts(ctx, prevDbAdapter?.contractsRevalidateProps || {})
 
         const contracts = await resolveContractsTokens(client, contractsRes?.contracts || {}, true)
 

--- a/scripts/run-adapter-balances.ts
+++ b/scripts/run-adapter-balances.ts
@@ -7,7 +7,7 @@ import {
   groupContracts,
 } from '../src/db/contracts'
 import pool from '../src/db/pool'
-import { Adapter, Balance, BaseContext } from '../src/lib/adapter'
+import { Adapter, Balance, BalancesContext } from '../src/lib/adapter'
 import { sanitizeBalances } from '../src/lib/balance'
 import { Chain } from '../src/lib/chains'
 import { getPricedBalances } from '../src/lib/price'
@@ -39,7 +39,7 @@ async function main() {
   const chain = process.argv[3] as Chain
   const address = process.argv[4].toLowerCase()
 
-  const ctx: BaseContext = { address }
+  const ctx: BalancesContext = { address, chain, adapterId }
 
   const module = await import(path.join(__dirname, '..', 'src', 'adapters', adapterId))
   const adapter = module.default as Adapter

--- a/scripts/run-adapter.ts
+++ b/scripts/run-adapter.ts
@@ -4,7 +4,7 @@ import fetch from 'node-fetch'
 import path from 'path'
 
 import pool from '../src/db/pool'
-import { Adapter, BaseContext, PricedBalance } from '../src/lib/adapter'
+import { Adapter, BalancesContext, PricedBalance } from '../src/lib/adapter'
 import { sanitizeBalances } from '../src/lib/balance'
 import { Chain } from '../src/lib/chains'
 import { getPricedBalances } from '../src/lib/price'
@@ -45,7 +45,7 @@ async function main() {
   const chain = process.argv[3] as Chain
   const address = process.argv[4].toLowerCase()
 
-  const ctx: BaseContext = { address }
+  const ctx: BalancesContext = { address, chain, adapterId }
 
   const module = await import(path.join(__dirname, '..', 'src', 'adapters', adapterId))
   const adapter = module.default as Adapter
@@ -53,7 +53,7 @@ async function main() {
   const client = await pool.connect()
 
   try {
-    const contractsRes = await adapter[chain]?.getContracts({})
+    const contractsRes = await adapter[chain]?.getContracts(ctx, {})
 
     const contracts = await resolveContractsTokens(client, contractsRes?.contracts || {}, true)
 

--- a/src/adapters/__template/ethereum/index.ts
+++ b/src/adapters/__template/ethereum/index.ts
@@ -1,8 +1,8 @@
-import { Balance, BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { Balance, BalancesContext, Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
 import { Chain } from '@lib/chains'
 
-export async function getStakeBalances(ctx: BaseContext, chain: Chain, staking: Contract): Promise<Balance[]> {
+export async function getStakeBalances(ctx: BalancesContext, chain: Chain, staking: Contract): Promise<Balance[]> {
   console.log(ctx, chain, staking)
 
   return []

--- a/src/adapters/aave/v2/common/rewards.ts
+++ b/src/adapters/aave/v2/common/rewards.ts
@@ -1,10 +1,10 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { BigNumber } from 'ethers'
 
 export async function getLendingRewardsBalances(
-  ctx: BaseContext,
+  ctx: BalancesContext,
   chain: Chain,
   incentiveController: Contract,
   rewardToken: Contract,

--- a/src/adapters/aave/v2/common/stake.ts
+++ b/src/adapters/aave/v2/common/stake.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { abi, getERC20Details } from '@lib/erc20'
@@ -21,7 +21,7 @@ const ABPT: Contract = {
   decimals: 18,
 }
 
-export async function getStakeBalances(ctx: BaseContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const [balanceOfRes, rewardsRes] = await Promise.all([
@@ -64,7 +64,7 @@ export async function getStakeBalances(ctx: BaseContext, chain: Chain, contract:
 }
 
 export async function getStakeBalancerPoolBalances(
-  ctx: BaseContext,
+  ctx: BalancesContext,
   chain: Chain,
   stakingContract: Contract,
 ): Promise<Balance[]> {

--- a/src/adapters/aave/v3/common/lending.ts
+++ b/src/adapters/aave/v3/common/lending.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { getERC20BalanceOf, getERC20Details } from '@lib/erc20'
@@ -102,7 +102,7 @@ export async function getLendingPoolContracts(
 }
 
 export async function getLendingPoolBalances(
-  ctx: BaseContext,
+  ctx: BalancesContext,
   chain: Chain,
   contracts: Contract[],
 ): Promise<Balance[]> {
@@ -119,7 +119,7 @@ export async function getLendingPoolBalances(
 }
 
 export async function getLendingRewardsBalances(
-  ctx: BaseContext,
+  ctx: BalancesContext,
   chain: Chain,
   incentiveController: Contract,
   contracts: Contract[],
@@ -169,7 +169,7 @@ export async function getLendingRewardsBalances(
   return rewards
 }
 
-export async function getLendingPoolHealthFactor(ctx: BaseContext, chain: Chain, lendingPool: Contract) {
+export async function getLendingPoolHealthFactor(ctx: BalancesContext, chain: Chain, lendingPool: Contract) {
   const userAccountDataRes = await call({
     chain,
     target: lendingPool.address,

--- a/src/adapters/abracadabra/common/mStake.ts
+++ b/src/adapters/abracadabra/common/mStake.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { getERC20Details } from '@lib/erc20'
@@ -47,7 +47,7 @@ export async function getMStakeContract(chain: Chain, contract: Contract): Promi
   return stakeContract
 }
 
-export async function getMStakeBalance(ctx: BaseContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getMStakeBalance(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
   const underlying = contract.underlyings?.[0]
   const reward = contract.rewards?.[0]

--- a/src/adapters/abracadabra/common/markets.ts
+++ b/src/adapters/abracadabra/common/markets.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { Chain } from '@lib/chains'
 import { getERC20Details, resolveERC20Details } from '@lib/erc20'
 import { multicall } from '@lib/multicall'
@@ -67,7 +67,11 @@ export async function getMarketsContracts(chain: Chain, contracts: string[]): Pr
   return marketsContracts
 }
 
-export async function getMarketsBalances(ctx: BaseContext, chain: Chain, contracts: Contract[]): Promise<Balance[]> {
+export async function getMarketsBalances(
+  ctx: BalancesContext,
+  chain: Chain,
+  contracts: Contract[],
+): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const [borrowingTokenRes, lendingBalancesRes, borrowingBalancesRes] = await Promise.all([

--- a/src/adapters/abracadabra/ethereum/sStake.ts
+++ b/src/adapters/abracadabra/ethereum/sStake.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { getERC20Details } from '@lib/erc20'
@@ -37,7 +37,7 @@ export async function getSStakeContract(chain: Chain, contract: Contract): Promi
   return stakeContract
 }
 
-export async function getSStakeBalance(ctx: BaseContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getSStakeBalance(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const [balanceOfRes, totalSupplyRes, balanceOfTokenInUnderlyingRes] = await Promise.all([

--- a/src/adapters/alpaca-finance/common/balances.ts
+++ b/src/adapters/alpaca-finance/common/balances.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { Chain } from '@lib/chains'
 import { abi as erc20Abi } from '@lib/erc20'
 import { multicall } from '@lib/multicall'
@@ -46,7 +46,7 @@ const abi = {
 }
 
 export async function getPoolsBalances(
-  ctx: BaseContext,
+  ctx: BalancesContext,
   chain: Chain,
   pools: Contract[],
   fairLaunch: Contract,

--- a/src/adapters/arrakis/common/balances.ts
+++ b/src/adapters/arrakis/common/balances.ts
@@ -1,11 +1,11 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { Chain } from '@lib/chains'
 import { getERC20BalanceOf } from '@lib/erc20'
 import { multicall } from '@lib/multicall'
 import { Token } from '@lib/token'
 import { BigNumber } from 'ethers'
 
-export async function getLpBalances(ctx: BaseContext, chain: Chain, contracts: Contract[]) {
+export async function getLpBalances(ctx: BalancesContext, chain: Chain, contracts: Contract[]) {
   const balances: Balance[] = []
 
   const balancesRaw = await getERC20BalanceOf(ctx, chain, contracts as Token[])

--- a/src/adapters/atlas-usv/common/stake.ts
+++ b/src/adapters/atlas-usv/common/stake.ts
@@ -1,5 +1,5 @@
 import { Balance, Contract } from '@lib/adapter'
-import { BaseContext } from '@lib/adapter'
+import { BalancesContext } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
@@ -14,7 +14,7 @@ const USV: Token = {
   decimals: 9,
 }
 
-export async function getStakeBalance(ctx: BaseContext, chain: Chain, contract: Contract): Promise<Balance> {
+export async function getStakeBalance(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance> {
   const balanceOfRes = await call({
     chain,
     target: contract.address,

--- a/src/adapters/benqi-staked-avax/avax/stake.ts
+++ b/src/adapters/benqi-staked-avax/avax/stake.ts
@@ -1,5 +1,5 @@
 import { Balance, Contract } from '@lib/adapter'
-import { BaseContext } from '@lib/adapter'
+import { BalancesContext } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { BigNumber } from 'ethers'
@@ -12,7 +12,7 @@ const WAVAX: Contract = {
   decimals: 18,
 }
 
-export async function getStakeBalances(ctx: BaseContext, chain: Chain, contract: Contract): Promise<Balance> {
+export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance> {
   const [balanceOfRes, poolValueRes, totalSupplyRes] = await Promise.all([
     call({
       chain,

--- a/src/adapters/compound/v2/common/rewards.ts
+++ b/src/adapters/compound/v2/common/rewards.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { Token } from '@lib/token'
@@ -13,7 +13,7 @@ const COMP: Token = {
 }
 
 export async function getRewardsBalances(
-  ctx: BaseContext,
+  ctx: BalancesContext,
   chain: Chain,
   comptroller: Contract,
   lens: Contract,

--- a/src/adapters/compound/v3/common/lend.ts
+++ b/src/adapters/compound/v3/common/lend.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { range } from '@lib/array'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
@@ -120,7 +120,7 @@ export async function getAssetsContracts(chain: Chain, contract: Contract): Prom
 }
 
 export async function getLendBorrowBalances(
-  ctx: BaseContext,
+  ctx: BalancesContext,
   chain: Chain,
   assets: Contract[],
   contract: Contract,

--- a/src/adapters/compound/v3/common/rewards.ts
+++ b/src/adapters/compound/v3/common/rewards.ts
@@ -1,11 +1,11 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { getERC20Details } from '@lib/erc20'
 import { BigNumber } from 'ethers'
 
 export async function getRewardBalances(
-  ctx: BaseContext,
+  ctx: BalancesContext,
   chain: Chain,
   rewardContract: Contract,
   coreContract: Contract,

--- a/src/adapters/compound/v3/common/stake.ts
+++ b/src/adapters/compound/v3/common/stake.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
@@ -12,7 +12,7 @@ const USDC: Token = {
   symbol: 'USDC',
 }
 
-export async function getStakeBalances(ctx: BaseContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const balanceOfRes = await call({

--- a/src/adapters/curve/common/gauges.ts
+++ b/src/adapters/curve/common/gauges.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { groupBy } from '@lib/array'
 import { Chain } from '@lib/chains'
 import { Call, multicall } from '@lib/multicall'
@@ -182,7 +182,7 @@ export async function getGaugesContracts(
   return gaugeContracts
 }
 
-export async function getGaugesBalances(ctx: BaseContext, chain: Chain, gauges: Contract[]) {
+export async function getGaugesBalances(ctx: BalancesContext, chain: Chain, gauges: Contract[]) {
   const gaugesBalances: Balance[] = []
   const calls: Call[] = []
 

--- a/src/adapters/curve/ethereum/locker.ts
+++ b/src/adapters/curve/ethereum/locker.ts
@@ -1,5 +1,5 @@
 import { call } from '@defillama/sdk/build/abi'
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { Chain } from '@lib/chains'
 import { Token } from '@lib/token'
 import { BigNumber } from 'ethers'
@@ -23,7 +23,7 @@ const IIICrvToken: Token = {
 }
 
 export async function getLockerBalances(
-  ctx: BaseContext,
+  ctx: BalancesContext,
   chain: Chain,
   contract: Contract,
   feeDistributorContract: Contract,

--- a/src/adapters/euler/common/markets.ts
+++ b/src/adapters/euler/common/markets.ts
@@ -1,4 +1,4 @@
-import { BaseContext, Contract } from '@lib/adapter'
+import { BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { gql, request } from 'graphql-request'
@@ -51,7 +51,7 @@ export async function getMarketsContracts(chain: Chain): Promise<Contract[]> {
   return contracts
 }
 
-export async function getHealthFactor(ctx: BaseContext, chain: Chain, lensContract: Contract): Promise<number> {
+export async function getHealthFactor(ctx: BalancesContext, chain: Chain, lensContract: Contract): Promise<number> {
   const getHealthFactor = await call({
     chain,
     target: lensContract.address,

--- a/src/adapters/euler/ethereum/index.ts
+++ b/src/adapters/euler/ethereum/index.ts
@@ -1,4 +1,4 @@
-import { BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { BalancesContext, Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
 import { getERC20BalanceOf } from '@lib/erc20'
 import { Token } from '@lib/token'
@@ -20,7 +20,7 @@ export const getContracts = async () => {
   }
 }
 
-export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: BaseContext, contracts) => {
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: BalancesContext, contracts) => {
   const [balances, healthFactor] = await Promise.all([
     resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
       markets: (ctx, chain, contracts) => getERC20BalanceOf(ctx, chain, contracts as Token[]),

--- a/src/adapters/floor-dao/ethereum/stake.ts
+++ b/src/adapters/floor-dao/ethereum/stake.ts
@@ -1,5 +1,5 @@
 import { Balance, Contract } from '@lib/adapter'
-import { BaseContext } from '@lib/adapter'
+import { BalancesContext } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
@@ -13,7 +13,7 @@ const FLOOR: Contract = {
   symbol: 'FLOOR ',
 }
 
-export async function getStakeBalances(ctx: BaseContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const balanceOfRes = await call({
@@ -39,7 +39,7 @@ export async function getStakeBalances(ctx: BaseContext, chain: Chain, contract:
 }
 
 export async function getFormattedStakeBalances(
-  ctx: BaseContext,
+  ctx: BalancesContext,
   chain: Chain,
   contract: Contract,
 ): Promise<Balance[]> {

--- a/src/adapters/fraxlend/ethereum/index.ts
+++ b/src/adapters/fraxlend/ethereum/index.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { Balance, BalancesContext, Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
 import { Chain } from '@lib/chains'
 import { getERC20Details } from '@lib/erc20'
@@ -14,7 +14,7 @@ const pools = [
   '0x50E627a1DF8D665524942aD7eC6392b6BA60293a',
 ]
 
-export const getLendBorrowBalances = async (ctx: BaseContext, chain: Chain, pools: Contract[]) => {
+export const getLendBorrowBalances = async (ctx: BalancesContext, chain: Chain, pools: Contract[]) => {
   const balances: Balance[] = []
 
   const [userCollateralBalancesRes, poolTokenBalanceRes, poolCollateralTokenRes] = await Promise.all([
@@ -159,7 +159,7 @@ export const getContracts = async () => {
   }
 }
 
-export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: BaseContext, contracts) => {
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: BalancesContext, contracts) => {
   const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
     pools: getLendBorrowBalances,
   })

--- a/src/adapters/fraxlend/index.ts
+++ b/src/adapters/fraxlend/index.ts
@@ -1,4 +1,4 @@
-import { Adapter, Balance, BaseContext, Contract, GetBalancesHandler, GetContractsHandler } from '@lib/adapter'
+import { Adapter, Balance, BalancesContext, Contract, GetBalancesHandler, GetContractsHandler } from '@lib/adapter'
 import { Chain } from '@lib/chains'
 import { getERC20Details } from '@lib/erc20'
 import { multicall } from '@lib/multicall'
@@ -13,7 +13,7 @@ const pools = [
   '0x50E627a1DF8D665524942aD7eC6392b6BA60293a',
 ]
 
-export const getLendBorrowBalances = async (ctx: BaseContext, chain: Chain, pools: Contract[]) => {
+export const getLendBorrowBalances = async (ctx: BalancesContext, chain: Chain, pools: Contract[]) => {
   const balances: Balance[] = []
 
   try {
@@ -164,7 +164,7 @@ const getContracts: GetContractsHandler = async () => {
   }
 }
 
-const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: BaseContext, { poolsContracts }) => {
+const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: BalancesContext, { poolsContracts }) => {
   const poolTokenBalances = await getLendBorrowBalances(ctx, 'ethereum', poolsContracts as Contract[])
 
   return { balances: [...poolTokenBalances] }

--- a/src/adapters/geist/fantom/index.ts
+++ b/src/adapters/geist/fantom/index.ts
@@ -1,5 +1,5 @@
 import { getLendingPoolHealthFactor } from '@lib/aave/v2/lending'
-import { BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { BalancesContext, Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
 import { Chain } from '@lib/chains'
 import { getLendingPoolBalances, getLendingPoolContracts } from '@lib/geist/lending'
@@ -47,7 +47,7 @@ export const getContracts = async () => {
   }
 }
 
-function getLendingBalances(ctx: BaseContext, chain: Chain, contracts: Contract[]) {
+function getLendingBalances(ctx: BalancesContext, chain: Chain, contracts: Contract[]) {
   return Promise.all([
     getLendingPoolBalances(ctx, chain, contracts, { chefIncentivesController: chefIncentivesControllerContract }),
     getMultiFeeDistributionBalances(ctx, chain, contracts, {

--- a/src/adapters/gmx/common/balances.ts
+++ b/src/adapters/gmx/common/balances.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { abi as erc20Abi } from '@lib/erc20'
@@ -57,7 +57,7 @@ const abi = {
   },
 }
 
-export async function getGMXStakerBalances(ctx: BaseContext, chain: Chain, gmxStaker: Contract) {
+export async function getGMXStakerBalances(ctx: BalancesContext, chain: Chain, gmxStaker: Contract) {
   if (!gmxStaker.underlyings || !gmxStaker.rewards) {
     return []
   }
@@ -107,7 +107,7 @@ export async function getGMXStakerBalances(ctx: BaseContext, chain: Chain, gmxSt
   return balances
 }
 
-export async function getGMXVesterBalance(ctx: BaseContext, chain: Chain, gmxVester: Contract) {
+export async function getGMXVesterBalance(ctx: BalancesContext, chain: Chain, gmxVester: Contract) {
   const gmx = gmxVester.underlyings?.[0]
   if (!gmx) {
     return []
@@ -135,7 +135,7 @@ export async function getGMXVesterBalance(ctx: BaseContext, chain: Chain, gmxVes
   return balance
 }
 
-export async function getGLPStakerBalance(ctx: BaseContext, chain: Chain, glpStaker: Contract) {
+export async function getGLPStakerBalance(ctx: BalancesContext, chain: Chain, glpStaker: Contract) {
   if (!glpStaker.underlyings || !glpStaker.rewards) {
     return []
   }
@@ -171,7 +171,7 @@ export async function getGLPStakerBalance(ctx: BaseContext, chain: Chain, glpSta
   return balance
 }
 
-export async function getGLPVesterBalance(ctx: BaseContext, chain: Chain, glpVester: Contract) {
+export async function getGLPVesterBalance(ctx: BalancesContext, chain: Chain, glpVester: Contract) {
   const [balanceOfRes, claimableRes] = await Promise.all([
     call({ chain, target: glpVester.address, params: [ctx.address], abi: erc20Abi.balanceOf }),
     call({ chain, target: glpVester.address, params: [ctx.address], abi: abi.claimable }),

--- a/src/adapters/hector-network/fantom/farm.ts
+++ b/src/adapters/hector-network/fantom/farm.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { BigNumber } from 'ethers'
@@ -49,7 +49,7 @@ const Curve_fiFactoryUSDMetapool: Contract = {
   rewards: [wFTM],
 }
 
-export async function getFarmingBalances(ctx: BaseContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getFarmingBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const [balanceOfRes, shareRes] = await Promise.all([

--- a/src/adapters/hector-network/fantom/stake.ts
+++ b/src/adapters/hector-network/fantom/stake.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
@@ -12,7 +12,7 @@ const HEC: Contract = {
   symbol: 'HEC',
 }
 
-export async function getsStakeBalances(ctx: BaseContext, chain: Chain, contract: Contract): Promise<Balance> {
+export async function getsStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance> {
   const balanceOfRes = await call({
     chain,
     target: contract.address,
@@ -35,7 +35,7 @@ export async function getsStakeBalances(ctx: BaseContext, chain: Chain, contract
   return balance
 }
 
-export async function getWsStakeBalances(ctx: BaseContext, chain: Chain, contract: Contract): Promise<Balance> {
+export async function getWsStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance> {
   const balanceOfRes = await call({
     chain,
     target: contract.address,

--- a/src/adapters/hex/ethereum/stake.ts
+++ b/src/adapters/hex/ethereum/stake.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { range } from '@lib/array'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
@@ -7,7 +7,7 @@ import { multicall } from '@lib/multicall'
 
 import { getRewardsBalances } from './reward'
 
-export async function getStakeBalances(ctx: BaseContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const stakeCountRes = await call({

--- a/src/adapters/klima-dao/common/stake.ts
+++ b/src/adapters/klima-dao/common/stake.ts
@@ -1,5 +1,5 @@
 import { Balance, Contract } from '@lib/adapter'
-import { BaseContext } from '@lib/adapter'
+import { BalancesContext } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
@@ -14,7 +14,7 @@ const KLIMA: Contract = {
   decimals: 9,
 }
 
-export async function getStakeBalances(ctx: BaseContext, chain: Chain, contract: Contract): Promise<Balance> {
+export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance> {
   const balanceOfRes = await call({
     chain,
     target: contract.address,
@@ -37,7 +37,7 @@ export async function getStakeBalances(ctx: BaseContext, chain: Chain, contract:
   return balance
 }
 
-export async function getFormattedStakeBalances(ctx: BaseContext, chain: Chain, contract: Contract): Promise<Balance> {
+export async function getFormattedStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance> {
   const balanceOfRes = await call({
     chain,
     target: contract.address,

--- a/src/adapters/lido/common/stake.ts
+++ b/src/adapters/lido/common/stake.ts
@@ -1,10 +1,10 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
 import { BigNumber } from 'ethers'
 
-export async function getWStEthStakeBalances(ctx: BaseContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getWStEthStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const balanceOfRes = await call({
@@ -45,7 +45,7 @@ export async function getWStEthStakeBalances(ctx: BaseContext, chain: Chain, con
   return balances
 }
 
-export async function getStEthStakeBalances(ctx: BaseContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getStEthStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const balanceOfRes = await call({
@@ -73,7 +73,7 @@ export async function getStEthStakeBalances(ctx: BaseContext, chain: Chain, cont
   return balances
 }
 
-export async function getStMaticBalances(ctx: BaseContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getStMaticBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const balanceOfRes = await call({

--- a/src/adapters/life-dao/common/stake.ts
+++ b/src/adapters/life-dao/common/stake.ts
@@ -1,5 +1,5 @@
 import { Balance, Contract } from '@lib/adapter'
-import { BaseContext } from '@lib/adapter'
+import { BalancesContext } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
@@ -13,7 +13,7 @@ const LF: Contract = {
   decimals: 9,
 }
 
-export async function getStakeBalances(ctx: BaseContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const balanceOfRes = await call({

--- a/src/adapters/liquity/ethereum/farm.ts
+++ b/src/adapters/liquity/ethereum/farm.ts
@@ -1,11 +1,11 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { Chain } from '@lib/chains'
 import { providers } from '@lib/providers'
 import { BigNumber, ethers } from 'ethers'
 
 import StabilityPoolAbi from '../abis/StabilityPool.json'
 
-export async function getFarmBalance(ctx: BaseContext, chain: Chain, stabilityPool: Contract) {
+export async function getFarmBalance(ctx: BalancesContext, chain: Chain, stabilityPool: Contract) {
   const provider = providers[chain]
 
   const StabilityPool = new ethers.Contract(stabilityPool.address, StabilityPoolAbi, provider)

--- a/src/adapters/liquity/ethereum/lend.ts
+++ b/src/adapters/liquity/ethereum/lend.ts
@@ -1,9 +1,9 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { BigNumber } from 'ethers'
 
-export async function getLendBalances(ctx: BaseContext, chain: Chain, troveManager: Contract) {
+export async function getLendBalances(ctx: BalancesContext, chain: Chain, troveManager: Contract) {
   const balances: Balance[] = []
 
   const troveDetailsRes = await call({

--- a/src/adapters/liquity/ethereum/stake.ts
+++ b/src/adapters/liquity/ethereum/stake.ts
@@ -1,11 +1,11 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { Chain } from '@lib/chains'
 import { providers } from '@lib/providers'
 import { BigNumber, ethers } from 'ethers'
 
 import LQTYStakingAbi from '../abis/LQTYStaking.json'
 
-export async function getStakeBalances(ctx: BaseContext, chain: Chain, lqtyStaking: Contract) {
+export async function getStakeBalances(ctx: BalancesContext, chain: Chain, lqtyStaking: Contract) {
   const provider = providers[chain]
 
   const LQTYStaking = new ethers.Contract(lqtyStaking.address, LQTYStakingAbi, provider)

--- a/src/adapters/looksrare/ethereum/balances.ts
+++ b/src/adapters/looksrare/ethereum/balances.ts
@@ -1,4 +1,4 @@
-import { BaseContext, Contract } from '@lib/adapter'
+import { BalancesContext, Contract } from '@lib/adapter'
 import { Balance } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
@@ -20,7 +20,7 @@ const WETH: Contract = {
   symbols: 'WETH',
 }
 
-export const getStakeBalances = async (ctx: BaseContext, chain: Chain, stakingContract: Contract) => {
+export const getStakeBalances = async (ctx: BalancesContext, chain: Chain, stakingContract: Contract) => {
   const [stakeBalanceOfRes, rewardsBalanceOfRes] = await Promise.all([
     call({
       chain,
@@ -65,7 +65,7 @@ export const getStakeBalances = async (ctx: BaseContext, chain: Chain, stakingCo
   return stakebalance
 }
 
-export const getCompounderBalances = async (ctx: BaseContext, chain: Chain, compounder: Contract) => {
+export const getCompounderBalances = async (ctx: BalancesContext, chain: Chain, compounder: Contract) => {
   const sharesValue = await call({
     chain,
     target: compounder.address,

--- a/src/adapters/makerdao/ethereum/balances.ts
+++ b/src/adapters/makerdao/ethereum/balances.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { Chain } from '@lib/chains'
 import { multicall } from '@lib/multicall'
 import { Token } from '@lib/token'
@@ -37,7 +37,7 @@ export interface BalanceWithExtraProps extends Balance {
 }
 
 export async function getProxiesBalances(
-  ctx: BaseContext,
+  ctx: BalancesContext,
   chain: Chain,
   vat: Contract,
   ilk: Contract,

--- a/src/adapters/makerdao/ethereum/proxies.ts
+++ b/src/adapters/makerdao/ethereum/proxies.ts
@@ -1,4 +1,4 @@
-import { BaseContext, Contract } from '@lib/adapter'
+import { BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { multicall } from '@lib/multicall'
@@ -47,7 +47,7 @@ const abi = {
   },
 }
 
-export async function getInstaDappContracts(ctx: BaseContext, chain: Chain, instaList: Contract): Promise<Contract[]> {
+export async function getInstaDappContracts(ctx: BalancesContext, chain: Chain, instaList: Contract): Promise<Contract[]> {
   const getUserLinkCountFromInstadApp = await call({
     chain,
     target: instaList.address,
@@ -94,7 +94,7 @@ export async function getInstaDappContracts(ctx: BaseContext, chain: Chain, inst
   }))
 }
 
-export async function getMakerContracts(ctx: BaseContext, chain: Chain, proxyRegistry: Contract): Promise<Contract[]> {
+export async function getMakerContracts(ctx: BalancesContext, chain: Chain, proxyRegistry: Contract): Promise<Contract[]> {
   // Check if user's address uses Maker proxies
   const proxiesRes = await call({
     chain,

--- a/src/adapters/maple/ethereum/farm.ts
+++ b/src/adapters/maple/ethereum/farm.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { range } from '@lib/array'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
@@ -75,7 +75,7 @@ export async function getFarmContracts(chain: Chain, contract: Contract): Promis
   return contracts
 }
 
-export async function getFarmBalances(ctx: BaseContext, chain: Chain, contracts: Contract[]): Promise<Balance[]> {
+export async function getFarmBalances(ctx: BalancesContext, chain: Chain, contracts: Contract[]): Promise<Balance[]> {
   const farmBalances: Balance[] = []
 
   const balances = await getERC20BalanceOf(ctx, chain, contracts as Token[])

--- a/src/adapters/nemesis-dao/bsc/balances.ts
+++ b/src/adapters/nemesis-dao/bsc/balances.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
@@ -12,7 +12,7 @@ const NMS: Contract = {
   symbol: 'NMS',
 }
 
-export async function getStakeBalances(ctx: BaseContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const balanceOfRes = await call({

--- a/src/adapters/nexus-mutual/ethereum/index.ts
+++ b/src/adapters/nexus-mutual/ethereum/index.ts
@@ -1,4 +1,4 @@
-import { BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { BalancesContext, Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
 import { Token } from '@lib/token'
 
@@ -31,7 +31,7 @@ export const getContracts = () => {
   }
 }
 
-export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: BaseContext, contracts) => {
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: BalancesContext, contracts) => {
   const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
     StakeNXM: getStakeBalances,
   })

--- a/src/adapters/nexus-mutual/ethereum/stake.ts
+++ b/src/adapters/nexus-mutual/ethereum/stake.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { Token } from '@lib/token'
@@ -18,7 +18,7 @@ const wNXM: Token = {
   symbol: 'wNXM',
 }
 
-export async function getStakeBalances(ctx: BaseContext, chain: Chain, contract: Contract) {
+export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract) {
   const balances: Balance[] = []
 
   const [getStakeBalances, getRewardsBalances] = await Promise.all([

--- a/src/adapters/olympus-dao/common/bond.ts
+++ b/src/adapters/olympus-dao/common/bond.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { range } from '@lib/array'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
@@ -6,7 +6,7 @@ import { getERC20Details } from '@lib/erc20'
 import { multicall } from '@lib/multicall'
 import { BigNumber } from 'ethers'
 
-export async function getBondsBalances(ctx: BaseContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getBondsBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const bondDetailsRes = await multicall({

--- a/src/adapters/olympus-dao/common/stake.ts
+++ b/src/adapters/olympus-dao/common/stake.ts
@@ -1,5 +1,5 @@
 import { Balance, Contract } from '@lib/adapter'
-import { BaseContext } from '@lib/adapter'
+import { BalancesContext } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
@@ -13,7 +13,7 @@ const OHM: Contract = {
   decimals: 9,
 }
 
-export async function getStakeBalances(ctx: BaseContext, chain: Chain, contract: Contract) {
+export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract) {
   const balances: Balance[] = []
 
   const balanceOfRes = await call({
@@ -39,7 +39,7 @@ export async function getStakeBalances(ctx: BaseContext, chain: Chain, contract:
   return balances
 }
 
-export async function getFormattedStakeBalances(ctx: BaseContext, chain: Chain, contract: Contract) {
+export async function getFormattedStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract) {
   const balances: Balance[] = []
 
   const balanceOfRes = await call({

--- a/src/adapters/pancakeswap/bsc/index.ts
+++ b/src/adapters/pancakeswap/bsc/index.ts
@@ -1,4 +1,4 @@
-import { BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { BalancesContext, Contract, GetBalancesHandler } from '@lib/adapter'
 import { getMasterChefBalances, getMasterChefPoolsInfo } from '@lib/masterchef'
 import { Token } from '@lib/token'
 import { isNotNullish } from '@lib/type'
@@ -91,7 +91,7 @@ export const getContracts = async (props: any) => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (
-  ctx: BaseContext,
+  ctx: BalancesContext,
   { pairs, masterChefPools, masterChefPools2 },
 ) => {
   const pairsBalances = await getPairsBalances(ctx, 'bsc', pairs || [])

--- a/src/adapters/radiant/arbitrum/index.ts
+++ b/src/adapters/radiant/arbitrum/index.ts
@@ -1,5 +1,5 @@
 import { getLendingPoolHealthFactor } from '@lib/aave/v2/lending'
-import { BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { BalancesContext, Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
 import { Chain } from '@lib/chains'
 import { getLendingPoolBalances, getLendingPoolContracts } from '@lib/geist/lending'
@@ -47,7 +47,7 @@ export const getContracts = async () => {
   }
 }
 
-function getLendingBalances(ctx: BaseContext, chain: Chain, contracts: Contract[]) {
+function getLendingBalances(ctx: BalancesContext, chain: Chain, contracts: Contract[]) {
   return Promise.all([
     getLendingPoolBalances(ctx, chain, contracts, { chefIncentivesController: chefIncentivesControllerContract }),
     getMultiFeeDistributionBalances(ctx, chain, contracts, {

--- a/src/adapters/rocket-pool/ethereum/index.ts
+++ b/src/adapters/rocket-pool/ethereum/index.ts
@@ -1,4 +1,4 @@
-import { BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { BalancesContext, Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
 import { Chain } from '@lib/chains'
 import { BN_TEN } from '@lib/math'
@@ -49,13 +49,13 @@ const miniPoolManager: Contract = {
   underlyings: [ETH],
 }
 
-function getNodeStakingBalance(ctx: BaseContext, chain: Chain, nodeStaking: Contract) {
+function getNodeStakingBalance(ctx: BalancesContext, chain: Chain, nodeStaking: Contract) {
   return getSingleStakeBalance(ctx, chain, nodeStaking, {
     abi: abi.getNodeRPLStake,
   })
 }
 
-async function getMiniPoolManagerBalance(ctx: BaseContext, chain: Chain, miniPoolManager: Contract) {
+async function getMiniPoolManagerBalance(ctx: BalancesContext, chain: Chain, miniPoolManager: Contract) {
   const balance = await getSingleStakeBalance(ctx, chain, miniPoolManager, {
     abi: abi.getNodeActiveMinipoolCount,
   })

--- a/src/adapters/shibaswap/ethereum/balances.ts
+++ b/src/adapters/shibaswap/ethereum/balances.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext } from '@lib/adapter'
+import { Balance, BalancesContext } from '@lib/adapter'
 import { Chain } from '@lib/chains'
 import { providers } from '@lib/providers'
 import { Token } from '@lib/token'
@@ -14,7 +14,7 @@ const bone: Token = {
   address: '0x9813037ee2218799597d83d4a5b6f3b6778218d9',
 }
 
-export async function getStakerBalances(ctx: BaseContext, chain: Chain, address: string): Promise<Balance[]> {
+export async function getStakerBalances(ctx: BalancesContext, chain: Chain, address: string): Promise<Balance[]> {
   const provider = providers[chain]
   const Staker = new ethers.Contract(address, StakerAbi, provider)
 
@@ -29,7 +29,7 @@ export async function getStakerBalances(ctx: BaseContext, chain: Chain, address:
   ]
 }
 
-export async function getLockerBalances(ctx: BaseContext, chain: Chain, address: string): Promise<Balance[]> {
+export async function getLockerBalances(ctx: BalancesContext, chain: Chain, address: string): Promise<Balance[]> {
   const provider = providers[chain]
   const Locker = new ethers.Contract(address, LockerAbi, provider)
 

--- a/src/adapters/shibaswap/ethereum/index.ts
+++ b/src/adapters/shibaswap/ethereum/index.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { Balance, BalancesContext, Contract, GetBalancesHandler } from '@lib/adapter'
 import { getMasterChefBalances, getMasterChefPoolsInfo } from '@lib/masterchef'
 import { Token } from '@lib/token'
 import { isNotNullish } from '@lib/type'
@@ -82,7 +82,7 @@ export const getContracts = async (props: any) => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (
-  ctx: BaseContext,
+  ctx: BalancesContext,
   { pairs, masterChefPools },
 ) => {
   let balances: Balance[] = []

--- a/src/adapters/spartacus/fantom/stake.ts
+++ b/src/adapters/spartacus/fantom/stake.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
@@ -13,7 +13,7 @@ const SPA: Contract = {
   symbol: 'SPA',
 }
 
-export async function getStakeBalances(ctx: BaseContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const balanceOfRes = await call({

--- a/src/adapters/spartacus/fantom/vest.ts
+++ b/src/adapters/spartacus/fantom/vest.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { Chain } from '@lib/chains'
 import { multicall } from '@lib/multicall'
 import { BigNumber } from 'ethers'
@@ -12,7 +12,7 @@ const SPA: Contract = {
   symbol: 'SPA',
 }
 
-export async function getVestBalances(ctx: BaseContext, chain: Chain, contracts: Contract[]): Promise<Balance[]> {
+export async function getVestBalances(ctx: BalancesContext, chain: Chain, contracts: Contract[]): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const calls = contracts.map((contract) => ({

--- a/src/adapters/spiritswap/fantom/index.ts
+++ b/src/adapters/spiritswap/fantom/index.ts
@@ -1,4 +1,4 @@
-import { BaseContext, GetBalancesHandler } from '@lib/adapter'
+import { BalancesContext, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
 import { getPairsContracts } from '@lib/uniswap/v2/factory'
 import { getPairsBalances } from '@lib/uniswap/v2/pair'
@@ -23,7 +23,7 @@ export const getContracts = async (props: any) => {
   }
 }
 
-export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: BaseContext, contracts) => {
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: BalancesContext, contracts) => {
   const balances = await resolveBalances<typeof getContracts>(ctx, 'fantom', contracts, {
     pairs: getPairsBalances,
   })

--- a/src/adapters/spool/ethereum/genesis.ts
+++ b/src/adapters/spool/ethereum/genesis.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { Chain } from '@lib/chains'
 import { multicall } from '@lib/multicall'
 import { Token } from '@lib/token'
@@ -11,7 +11,7 @@ const Spool: Token = {
   symbol: 'SPOOL',
 }
 
-export async function getYieldBalances(ctx: BaseContext, chain: Chain, pools: Contract[]) {
+export async function getYieldBalances(ctx: BalancesContext, chain: Chain, pools: Contract[]) {
   const balances: Balance[] = []
 
   const [getDeposit, getEarned] = await Promise.all([

--- a/src/adapters/spool/ethereum/index.ts
+++ b/src/adapters/spool/ethereum/index.ts
@@ -1,4 +1,4 @@
-import { BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { BalancesContext, Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
 import { Token } from '@lib/token'
 
@@ -65,7 +65,7 @@ export const getContracts = () => {
   }
 }
 
-export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: BaseContext, contracts) => {
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: BalancesContext, contracts) => {
   const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
     spoolStaking: getStakeBalances,
     genesisPools: getYieldBalances,

--- a/src/adapters/spool/ethereum/stake.ts
+++ b/src/adapters/spool/ethereum/stake.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { Token } from '@lib/token'
@@ -11,7 +11,7 @@ const Spool: Token = {
   symbol: 'SPOOL',
 }
 
-export async function getStakeBalances(ctx: BaseContext, chain: Chain, contract: Contract) {
+export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract) {
   const balances: Balance[] = []
 
   const [getBalances, getEarned] = await Promise.all([

--- a/src/adapters/stargate/common/stake.ts
+++ b/src/adapters/stargate/common/stake.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { getERC20Details } from '@lib/erc20'
@@ -40,7 +40,7 @@ interface IStakeOptions {
   pendingRewardAbi: object
 }
 
-export async function getStakeBalances(ctx: BaseContext, chain: Chain, lpStaking: Contract, options?: IStakeOptions) {
+export async function getStakeBalances(ctx: BalancesContext, chain: Chain, lpStaking: Contract, options?: IStakeOptions) {
   const balances: Balance[] = []
 
   const poolCountRes = await call({

--- a/src/adapters/sushiswap/ethereum/index.ts
+++ b/src/adapters/sushiswap/ethereum/index.ts
@@ -1,4 +1,4 @@
-import { BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { BalancesContext, Contract, GetBalancesHandler } from '@lib/adapter'
 import { getMasterChefBalances, getMasterChefPoolsInfo } from '@lib/masterchef'
 import { Token } from '@lib/token'
 import { isNotNullish } from '@lib/type'
@@ -67,7 +67,7 @@ export const getContracts = async (props: any) => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (
-  ctx: BaseContext,
+  ctx: BalancesContext,
   { pairs, masterChefPools },
 ) => {
   const pairsBalances = await getPairsBalances(ctx, 'ethereum', pairs || [])

--- a/src/adapters/synthetix/common/lend.ts
+++ b/src/adapters/synthetix/common/lend.ts
@@ -1,10 +1,10 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { BigNumber } from 'ethers'
 
 export async function getLendBorrowBalances(
-  ctx: BaseContext,
+  ctx: BalancesContext,
   chain: Chain,
   synthetixContract: Contract,
   feePoolContract: Contract,

--- a/src/adapters/synthetix/common/vest.ts
+++ b/src/adapters/synthetix/common/vest.ts
@@ -1,11 +1,11 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
 import { BigNumber } from 'ethers'
 
 export async function getVestBalances(
-  ctx: BaseContext,
+  ctx: BalancesContext,
   chain: Chain,
   escrow: Contract,
   liquidator: Contract,

--- a/src/adapters/templedao/ethereum/balances.ts
+++ b/src/adapters/templedao/ethereum/balances.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
@@ -16,7 +16,7 @@ const TEMPLE: Contract = {
 }
 
 export async function getStakeBalances(
-  ctx: BaseContext,
+  ctx: BalancesContext,
   chain: Chain,
   contract: Contract,
   templeStaking: Contract,
@@ -62,7 +62,7 @@ export async function getStakeBalances(
   return balances
 }
 
-export async function getLockedBalances(ctx: BaseContext, chain: Chain, contracts: Contract[]): Promise<Balance[]> {
+export async function getLockedBalances(ctx: BalancesContext, chain: Chain, contracts: Contract[]): Promise<Balance[]> {
   const calls = contracts.map((contract) => ({
     target: contract.address,
     params: [],

--- a/src/adapters/traderjoe/avax/balances.ts
+++ b/src/adapters/traderjoe/avax/balances.ts
@@ -1,4 +1,4 @@
-import { BaseContext } from '@lib/adapter'
+import { BalancesContext } from '@lib/adapter'
 import { Balance, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
@@ -47,7 +47,7 @@ const JOE: Token = {
   coingeckoId: 'joe',
 }
 
-export async function getStakeBalance(ctx: BaseContext, chain: Chain) {
+export async function getStakeBalance(ctx: BalancesContext, chain: Chain) {
   const balances: Balance[] = []
 
   const [sJOEbalanceOfRes, veJOEbalanceOfRes, rJOEbalanceOfRes] = await Promise.all([

--- a/src/adapters/truefi/ethereum/farm.ts
+++ b/src/adapters/truefi/ethereum/farm.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { Chain } from '@lib/chains'
 import { multicall } from '@lib/multicall'
 import { BigNumber } from 'ethers'
@@ -13,7 +13,7 @@ const TRU: Contract = {
 
 const trueMultiFarm = '0xec6c3fd795d6e6f202825ddb56e01b3c128b0b10'
 
-export async function getFarmBalances(ctx: BaseContext, chain: Chain, pools: Contract[]) {
+export async function getFarmBalances(ctx: BalancesContext, chain: Chain, pools: Contract[]) {
   const balances: Balance[] = []
 
   const calls = pools.map((pool) => ({

--- a/src/adapters/truefi/ethereum/index.ts
+++ b/src/adapters/truefi/ethereum/index.ts
@@ -1,4 +1,4 @@
-import { BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { BalancesContext, Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
 import { Chain } from '@lib/chains'
 
@@ -14,7 +14,7 @@ export const getContracts = async () => {
   }
 }
 
-async function getAllBalances(ctx: BaseContext, chain: Chain, pools: Contract[]) {
+async function getAllBalances(ctx: BalancesContext, chain: Chain, pools: Contract[]) {
   const poolsSupplies = await getPoolsSupplies(chain, pools)
   return Promise.all([getFarmBalances(ctx, chain, poolsSupplies), getStakeBalances(ctx, chain, poolsSupplies)])
 }

--- a/src/adapters/truefi/ethereum/stake.ts
+++ b/src/adapters/truefi/ethereum/stake.ts
@@ -1,10 +1,10 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
 import { multicall } from '@lib/multicall'
 import { BigNumber } from 'ethers'
 
-export async function getStakeBalances(ctx: BaseContext, chain: Chain, pools: Contract[]) {
+export async function getStakeBalances(ctx: BalancesContext, chain: Chain, pools: Contract[]) {
   const balances: Balance[] = []
 
   const calls = pools.map((pool) => ({

--- a/src/adapters/uniswap/ethereum/index.ts
+++ b/src/adapters/uniswap/ethereum/index.ts
@@ -1,4 +1,4 @@
-import { BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { BalancesContext, Contract, GetBalancesHandler } from '@lib/adapter'
 import { getPairsBalances } from '@lib/uniswap/v2/pair'
 import { gql, request } from 'graphql-request'
 
@@ -67,7 +67,7 @@ export const getContracts = async () => {
   }
 }
 
-export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: BaseContext, { pairs }) => {
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: BalancesContext, { pairs }) => {
   const lpBalances = await getPairsBalances(ctx, 'ethereum', pairs || [])
 
   return {

--- a/src/adapters/uwu-lend/ethereum/index.ts
+++ b/src/adapters/uwu-lend/ethereum/index.ts
@@ -1,5 +1,5 @@
 import { getLendingPoolHealthFactor } from '@lib/aave/v2/lending'
-import { BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { BalancesContext, Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
 import { Chain } from '@lib/chains'
 import { getLendingPoolBalances, getLendingPoolContracts } from '@lib/geist/lending'
@@ -48,7 +48,7 @@ export const getContracts = async () => {
   }
 }
 
-function getLendingBalances(ctx: BaseContext, chain: Chain, contracts: Contract[]) {
+function getLendingBalances(ctx: BalancesContext, chain: Chain, contracts: Contract[]) {
   return Promise.all([
     getLendingPoolBalances(ctx, chain, contracts, {
       chefIncentivesController: chefIncentivesControllerContract,

--- a/src/adapters/uwu-lend/ethereum/lock.ts
+++ b/src/adapters/uwu-lend/ethereum/lock.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { Chain } from '@lib/chains'
 import { getERC20Details } from '@lib/erc20'
 import { providers } from '@lib/providers'
@@ -13,7 +13,7 @@ export interface GetMultiFeeDistributionBalancesParams {
 }
 
 export async function getMultiFeeDistributionBalances(
-  ctx: BaseContext,
+  ctx: BalancesContext,
   chain: Chain,
   lendingPoolContracts: Contract[],
   { multiFeeDistributionAddress }: GetMultiFeeDistributionBalancesParams,

--- a/src/adapters/valas/bsc/index.ts
+++ b/src/adapters/valas/bsc/index.ts
@@ -1,5 +1,5 @@
 import { getLendingPoolHealthFactor } from '@adapters/aave/v3/common/lending'
-import { BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { BalancesContext, Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
 import { Chain } from '@lib/chains'
 import { getLendingPoolBalances, getLendingPoolContracts } from '@lib/geist/lending'
@@ -47,7 +47,7 @@ export const getContracts = async () => {
   }
 }
 
-function getLendingBalances(ctx: BaseContext, chain: Chain, contracts: Contract[]) {
+function getLendingBalances(ctx: BalancesContext, chain: Chain, contracts: Contract[]) {
   return Promise.all([
     getLendingPoolBalances(ctx, chain, contracts, { chefIncentivesController: chefIncentivesControllerContract }),
     getMultiFeeDistributionBalances(ctx, chain, contracts, {

--- a/src/adapters/vector/avax/farm.ts
+++ b/src/adapters/vector/avax/farm.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { range } from '@lib/array'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
@@ -151,7 +151,7 @@ export async function getFarmContracts(chain: Chain, masterChef: Contract) {
 }
 
 export async function getFarmBalances(
-  ctx: BaseContext,
+  ctx: BalancesContext,
   chain: Chain,
   contracts: FarmContract[],
   masterChef: Contract,
@@ -230,7 +230,7 @@ export async function getFarmBalances(
   return balances
 }
 
-const getExtraRewards = async (ctx: BaseContext, chain: Chain, balance: FarmBalance): Promise<Balance[]> => {
+const getExtraRewards = async (ctx: BalancesContext, chain: Chain, balance: FarmBalance): Promise<Balance[]> => {
   const pendingRewardsTokensRes = await multicall({
     chain,
     // There is no logic in the contracts to know the number of tokens in advance. Among all the contracts checked, 7 seems to be the maximum number of extra tokens used.

--- a/src/adapters/vector/avax/locker.ts
+++ b/src/adapters/vector/avax/locker.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { range } from '@lib/array'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
@@ -15,7 +15,7 @@ const VTX: Token = {
   symbol: 'VTX',
 }
 
-export async function getLockerBalances(ctx: BaseContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getLockerBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
   const [userTotalDepositRes, rewarderAddressRes, userExtraLockedSlots] = await Promise.all([
     call({
@@ -114,7 +114,7 @@ export async function getLockerBalances(ctx: BaseContext, chain: Chain, contract
   return balances
 }
 
-const lockedRewardsBalances = async (ctx: BaseContext, chain: Chain, rewarder: string): Promise<Balance[]> => {
+const lockedRewardsBalances = async (ctx: BalancesContext, chain: Chain, rewarder: string): Promise<Balance[]> => {
   const pendingRewardsTokensRes = await multicall({
     chain,
     // There is no logic in the contracts to know the number of tokens in advance. Among all the contracts checked, 7 seems to be the maximum number of extra tokens used.

--- a/src/adapters/venus/bsc/lend.ts
+++ b/src/adapters/venus/bsc/lend.ts
@@ -1,11 +1,11 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { getMarketsBalances } from '@lib/compound/v2/lending'
 import { BigNumber } from 'ethers'
 
 export async function getLendBorrowBalances(
-  ctx: BaseContext,
+  ctx: BalancesContext,
   chain: Chain,
   contracts: Contract[],
   comptroller: Contract,

--- a/src/adapters/venus/bsc/rewards.ts
+++ b/src/adapters/venus/bsc/rewards.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { Token } from '@lib/token'
@@ -12,7 +12,7 @@ const XVS: Token = {
 }
 
 export async function getRewardsBalances(
-  ctx: BaseContext,
+  ctx: BalancesContext,
   chain: Chain,
   comptroller: Contract,
   lens: Contract,

--- a/src/adapters/venus/bsc/stake.ts
+++ b/src/adapters/venus/bsc/stake.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { Token } from '@lib/token'
@@ -18,7 +18,7 @@ const VAI: Token = {
   address: '0x4BD17003473389A42DAF6a0a729f6Fdb328BbBd7',
 }
 
-export async function getStakeBalances(ctx: BaseContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const [stakeBalanceRes, pendingXVSRes] = await Promise.all([

--- a/src/adapters/wallet/index.ts
+++ b/src/adapters/wallet/index.ts
@@ -1,4 +1,4 @@
-import { Adapter, Balance, BaseContext, GetBalancesHandler } from '@lib/adapter'
+import { Adapter, Balance, BalancesContext, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
 import { Chain, chains } from '@lib/chains'
 import { getERC20BalanceOf } from '@lib/erc20'
@@ -7,7 +7,7 @@ import { Token } from '@lib/token'
 import { chains as tokensByChain } from '@llamafolio/tokens'
 import { ethers } from 'ethers'
 
-async function getCoinBalance(ctx: BaseContext, chain: Chain, token?: Token) {
+async function getCoinBalance(ctx: BalancesContext, chain: Chain, token?: Token) {
   if (!token) {
     return null
   }

--- a/src/adapters/wepiggy/common/rewards.ts
+++ b/src/adapters/wepiggy/common/rewards.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { Token } from '@lib/token'
@@ -12,7 +12,7 @@ const WPC: Token = {
   symbol: 'WPC',
 }
 
-export async function getMarketsRewards(ctx: BaseContext, chain: Chain, piggyDistribution: Contract): Promise<Balance> {
+export async function getMarketsRewards(ctx: BalancesContext, chain: Chain, piggyDistribution: Contract): Promise<Balance> {
   const pendingWPCRewardsRes = await call({
     chain,
     target: piggyDistribution.address,

--- a/src/adapters/wonderland/avax/stake.ts
+++ b/src/adapters/wonderland/avax/stake.ts
@@ -1,5 +1,5 @@
 import { Balance, Contract } from '@lib/adapter'
-import { BaseContext } from '@lib/adapter'
+import { BalancesContext } from '@lib/adapter'
 import { range } from '@lib/array'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
@@ -16,7 +16,7 @@ const TIME: Contract = {
   symbol: 'TIME',
 }
 
-export async function getFormattedStakeBalance(ctx: BaseContext, chain: Chain, wMEMO: Contract): Promise<Balance> {
+export async function getFormattedStakeBalance(ctx: BalancesContext, chain: Chain, wMEMO: Contract): Promise<Balance> {
   const balanceOfRes = await call({
     chain,
     block: ctx.blockHeight?.[chain],
@@ -56,7 +56,7 @@ export async function getFormattedStakeBalance(ctx: BaseContext, chain: Chain, w
   return balance
 }
 
-export async function getStakeBalance(ctx: BaseContext, chain: Chain, wMemoFarm: Contract): Promise<Balance> {
+export async function getStakeBalance(ctx: BalancesContext, chain: Chain, wMemoFarm: Contract): Promise<Balance> {
   const rewards: Balance[] = []
 
   const [balanceOfRes, rewardTokenLengthRes] = await Promise.all([

--- a/src/adapters/wonderland/wonderland.test.ts
+++ b/src/adapters/wonderland/wonderland.test.ts
@@ -1,4 +1,5 @@
-import { AdapterTest, BaseContext, parseBalancesTest } from '@lib/adapter'
+// TODO: fix
+import { AdapterTest, BalancesContext, parseBalancesTest } from '@lib/adapter'
 
 import adapter from '.'
 
@@ -24,7 +25,7 @@ describe('wonderland test', () => {
     const contracts = await adapter.getContracts({})
 
     for (const test of testCases) {
-      const ctx: BaseContext = { address: test.address, blockHeight: test.blockHeight }
+      const ctx: BalancesContext = { address: test.address, blockHeight: test.blockHeight }
 
       const balancesConfig = await adapter.getBalances(ctx, contracts.contracts)
 

--- a/src/handlers/getBalancesTokens.ts
+++ b/src/handlers/getBalancesTokens.ts
@@ -2,7 +2,7 @@ import walletAdapter from '@adapters/wallet'
 import { getAllTokensInteractions, groupContracts } from '@db/contracts'
 import pool from '@db/pool'
 import { badRequest, serverError, success } from '@handlers/response'
-import { BaseContext, PricedBalance } from '@lib/adapter'
+import { BalancesContext, PricedBalance } from '@lib/adapter'
 import { groupBy } from '@lib/array'
 import { sanitizeBalances, sortBalances, sumBalances } from '@lib/balance'
 import { isHex } from '@lib/buf'
@@ -53,8 +53,6 @@ export const handler: APIGatewayProxyHandler = async (event, context) => {
     return badRequest('Invalid address parameter, expected hex')
   }
 
-  const ctx: BaseContext = { address }
-
   const client = await pool.connect()
 
   try {
@@ -75,6 +73,8 @@ export const handler: APIGatewayProxyHandler = async (event, context) => {
             const hrstart = process.hrtime()
 
             const contracts = groupContracts(tokensByChain[chain]) || []
+
+            const ctx: BalancesContext = { address, chain: chain as Chain, adapterId: walletAdapter.id }
 
             const balancesConfig = await handler.getBalances(ctx, contracts)
 

--- a/src/handlers/revalidateAdapters.ts
+++ b/src/handlers/revalidateAdapters.ts
@@ -9,6 +9,7 @@ import {
 import { deleteContractsByAdapter, insertContracts } from '@db/contracts'
 import pool from '@db/pool'
 import { badRequest, serverError, success } from '@handlers/response'
+import { BaseContext } from '@lib/adapter'
 import { Chain, chains } from '@lib/chains'
 import { invokeLambda, wrapScheduledLambda } from '@lib/lambda'
 import { resolveContractsTokens } from '@lib/token'
@@ -98,7 +99,9 @@ export const revalidateAdapterContracts: APIGatewayProxyHandler = async (event, 
   try {
     const prevDbAdapter = await selectAdapter(client, chain, adapter.id)
 
-    const config = await adapter[chain]!.getContracts(prevDbAdapter?.contractsRevalidateProps || {})
+    const ctx: BaseContext = { chain, adapterId: adapter.id }
+
+    const config = await adapter[chain]!.getContracts(ctx, prevDbAdapter?.contractsRevalidateProps || {})
 
     const contracts = await resolveContractsTokens(client, config.contracts || {}, true)
 

--- a/src/handlers/updateBalances.ts
+++ b/src/handlers/updateBalances.ts
@@ -16,7 +16,7 @@ import {
   formatBalance,
 } from '@handlers/getBalances'
 import { badRequest, serverError, success } from '@handlers/response'
-import { Balance, BalancesConfig, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesConfig, BalancesContext, Contract } from '@lib/adapter'
 import { groupBy } from '@lib/array'
 import { sanitizeBalances, sumBalances } from '@lib/balance'
 import { isHex, strToBuf } from '@lib/buf'
@@ -53,9 +53,7 @@ export const websocketUpdateAdaptersHandler: APIGatewayProxyHandler = async (eve
     return badRequest('Missing connectionId parameter')
   }
 
-  const ctx: BaseContext = { address }
-
-  console.log('Update balances of address', ctx.address)
+  console.log('Update balances of address', address)
 
   const client = await pool.connect()
 
@@ -93,8 +91,8 @@ export const websocketUpdateAdaptersHandler: APIGatewayProxyHandler = async (eve
     // Fetch all protocols (with their associated contracts) that the user interacted with
     // and all unique tokens he received
     const [contracts, tokens] = await Promise.all([
-      getAllContractsInteractionsTokenTransfers(client, ctx.address),
-      getAllTokensInteractions(client, ctx.address),
+      getAllContractsInteractionsTokenTransfers(client, address),
+      getAllTokensInteractions(client, address),
     ])
 
     const contractsByAdapterId: { [key: string]: Contract[] } = {}
@@ -131,6 +129,8 @@ export const websocketUpdateAdaptersHandler: APIGatewayProxyHandler = async (eve
 
               const contracts =
                 groupContracts(contractsByAdapterId[adapterId].filter((contract) => contract.chain === chain.id)) || []
+
+              const ctx: BalancesContext = { address, chain: chain.id, adapterId }
 
               const balancesConfig = await handler.getBalances(ctx, contracts)
 

--- a/src/lib/aave/v2/lending.ts
+++ b/src/lib/aave/v2/lending.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { getERC20BalanceOf } from '@lib/erc20'
@@ -175,7 +175,7 @@ export async function getLendingPoolContracts(chain: Chain, lendingPool: Contrac
   return contracts
 }
 
-export async function getLendingPoolBalances(ctx: BaseContext, chain: Chain, contracts: Contract[]) {
+export async function getLendingPoolBalances(ctx: BalancesContext, chain: Chain, contracts: Contract[]) {
   try {
     const balances: Balance[] = await getERC20BalanceOf(ctx, chain, contracts as Token[])
 
@@ -195,7 +195,7 @@ export async function getLendingPoolBalances(ctx: BaseContext, chain: Chain, con
   }
 }
 
-export async function getLendingPoolHealthFactor(ctx: BaseContext, chain: Chain, lendingPool: Contract) {
+export async function getLendingPoolHealthFactor(ctx: BalancesContext, chain: Chain, lendingPool: Contract) {
   try {
     const userAccountDataRes = await call({
       chain,

--- a/src/lib/adapter.ts
+++ b/src/lib/adapter.ts
@@ -4,8 +4,13 @@ import { Chain } from '@lib/chains'
 import { BigNumber } from 'ethers'
 
 export interface BaseContext {
-  address: string
+  chain: Chain
+  adapterId: string
   blockHeight?: { [k: string]: number }
+}
+
+export interface BalancesContext extends BaseContext {
+  address: string
 }
 
 export type ContractType = 'reward' | 'debt' | 'underlying'
@@ -98,10 +103,13 @@ export interface ContractsConfig {
 /**
  * Pass previous `revalidateProps` passed to `getContracts` handler to know where the previous revalidate process ended.
  */
-export type GetContractsHandler = (props: { [key: string]: any }) => ContractsConfig | Promise<ContractsConfig>
+export type GetContractsHandler = (
+  ctx: BaseContext,
+  props: { [key: string]: any },
+) => ContractsConfig | Promise<ContractsConfig>
 
 export type GetBalancesHandler<C extends GetContractsHandler> = (
-  ctx: BaseContext,
+  ctx: BalancesContext,
   // each key can be undefined as the account may not have interacted with these contracts
   contracts: Partial<Awaited<ReturnType<C>>['contracts']>,
 ) => BalancesConfig | Promise<BalancesConfig>

--- a/src/lib/balance.ts
+++ b/src/lib/balance.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseBalance, BaseContext, BaseContract, ContractType, GetContractsHandler } from '@lib/adapter'
+import { Balance, BalancesContext, BaseBalance, BaseContract, ContractType, GetContractsHandler } from '@lib/adapter'
 import { Chain } from '@lib/chains'
 import { getERC20BalanceOf } from '@lib/erc20'
 import { BN_TEN, BN_ZERO } from '@lib/math'
@@ -8,7 +8,7 @@ import { Token } from '@lib/token'
 import { isNotNullish } from '@lib/type'
 import { ethers } from 'ethers'
 
-export async function getBalances(ctx: BaseContext, contracts: BaseContract[]) {
+export async function getBalances(ctx: BalancesContext, contracts: BaseContract[]) {
   const coins: Token[] = []
   const tokensByChain: { [key: string]: Token[] } = {}
 
@@ -153,12 +153,12 @@ export function sanitizeBalances(balances: Balance[]) {
 }
 
 export async function resolveBalances<C extends GetContractsHandler>(
-  ctx: BaseContext,
+  ctx: BalancesContext,
   chain: Chain,
   contracts: Partial<Awaited<ReturnType<C>>['contracts']>,
   resolvers: {
     [key in keyof Partial<Awaited<ReturnType<C>>['contracts']>]: (
-      ctx: BaseContext,
+      ctx: BalancesContext,
       chain: Chain,
       contracts: Awaited<ReturnType<C>>['contracts'][key],
     ) =>

--- a/src/lib/compound/v2/lending.ts
+++ b/src/lib/compound/v2/lending.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { Chain } from '@lib/chains'
 import { getERC20BalanceOf } from '@lib/erc20'
@@ -109,7 +109,11 @@ export async function getMarketsContracts(
   return contracts
 }
 
-export async function getMarketsBalances(ctx: BaseContext, chain: Chain, contracts: Contract[]): Promise<Balance[]> {
+export async function getMarketsBalances(
+  ctx: BalancesContext,
+  chain: Chain,
+  contracts: Contract[],
+): Promise<Balance[]> {
   const cTokenByAddress: { [key: string]: Contract } = {}
   for (const contract of contracts) {
     cTokenByAddress[contract.address] = contract

--- a/src/lib/erc20.ts
+++ b/src/lib/erc20.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext } from '@lib/adapter'
+import { Balance, BalancesContext } from '@lib/adapter'
 import { Chain } from '@lib/chains'
 import { Call, multicall, MultiCallResult } from '@lib/multicall'
 import { Token } from '@lib/token'
@@ -59,7 +59,7 @@ export const abi = {
   },
 }
 
-export async function getERC20BalanceOf(ctx: BaseContext, chain: Chain, tokens: Token[]): Promise<Balance[]> {
+export async function getERC20BalanceOf(ctx: BalancesContext, chain: Chain, tokens: Token[]): Promise<Balance[]> {
   const balances = await multicall({
     chain,
     calls: tokens.map((token) => ({

--- a/src/lib/geist/lending.ts
+++ b/src/lib/geist/lending.ts
@@ -2,7 +2,7 @@ import {
   getLendingPoolBalances as getAaveLendingPoolBalances,
   getLendingPoolContracts as getAaveLendingPoolContracts,
 } from '@lib/aave/v2/lending'
-import { Balance, BaseContext, Contract, RewardBalance } from '@lib/adapter'
+import { Balance, BalancesContext, Contract, RewardBalance } from '@lib/adapter'
 import { range } from '@lib/array'
 import { Chain } from '@lib/chains'
 import { multicall } from '@lib/multicall'
@@ -79,7 +79,7 @@ export interface GetLendingPoolBalancesParams {
 }
 
 export async function getLendingPoolBalances(
-  ctx: BaseContext,
+  ctx: BalancesContext,
   chain: Chain,
   contracts: Contract[],
   { chefIncentivesController }: GetLendingPoolBalancesParams,

--- a/src/lib/geist/stake.ts
+++ b/src/lib/geist/stake.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract, RewardBalance } from '@lib/adapter'
+import { Balance, BalancesContext, Contract, RewardBalance } from '@lib/adapter'
 import { Chain } from '@lib/chains'
 import { getERC20Details } from '@lib/erc20'
 import { multicall } from '@lib/multicall'
@@ -15,7 +15,7 @@ export interface GetMultiFeeDistributionBalancesParams {
 }
 
 export async function getMultiFeeDistributionBalances(
-  ctx: BaseContext,
+  ctx: BalancesContext,
   chain: Chain,
   lendingPoolContracts: Contract[],
   params: GetMultiFeeDistributionBalancesParams,

--- a/src/lib/masterchef/index.ts
+++ b/src/lib/masterchef/index.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext } from '@lib/adapter'
+import { Balance, BalancesContext } from '@lib/adapter'
 import { Chain } from '@lib/chains'
 import { multicall } from '@lib/multicall'
 import { providers } from '@lib/providers'
@@ -55,7 +55,7 @@ export interface GetMasterChefBalancesParams {
 }
 
 export async function getMasterChefBalances(
-  ctx: BaseContext,
+  ctx: BalancesContext,
   { chain, masterChefAddress, tokens, rewardToken, pendingRewardName }: GetMasterChefBalancesParams,
 ) {
   const provider = providers[chain]

--- a/src/lib/pools.ts
+++ b/src/lib/pools.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { multicallBalances } from '@lib/balance'
 import { Chain } from '@lib/chains'
 import { abi as erc20Abi, getERC20BalanceOf } from '@lib/erc20'
@@ -20,7 +20,7 @@ export interface GetPoolsBalancesParams {
  * @param params
  */
 export async function getPoolsBalances(
-  ctx: BaseContext,
+  ctx: BalancesContext,
   chain: Chain,
   pools: Contract[],
   params: GetPoolsBalancesParams,
@@ -121,7 +121,7 @@ export interface GetStakingPoolsBalancesParams extends GetPoolsBalancesParams {
  * @param params
  */
 export async function getStakingPoolsBalances(
-  ctx: BaseContext,
+  ctx: BalancesContext,
   chain: Chain,
   pools: Contract[],
   params: GetStakingPoolsBalancesParams,

--- a/src/lib/stake.ts
+++ b/src/lib/stake.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call, TCall } from '@lib/call'
 import { Category } from '@lib/category'
 import { Chain } from '@lib/chains'
@@ -7,7 +7,7 @@ import { Token } from '@lib/token'
 import { BigNumber } from 'ethers'
 
 export async function getSingleStakeBalance(
-  ctx: BaseContext,
+  ctx: BalancesContext,
   chain: Chain,
   contract: Contract,
   callOptions?: Partial<TCall>,
@@ -31,7 +31,7 @@ export async function getSingleStakeBalance(
   return balance
 }
 
-export async function getSingleStakeBalances(ctx: BaseContext, chain: Chain, contracts: Contract[]) {
+export async function getSingleStakeBalances(ctx: BalancesContext, chain: Chain, contracts: Contract[]) {
   const balances = await getERC20BalanceOf(ctx, chain, contracts as Token[])
   return balances.map((bal) => ({ ...bal, category: 'stake' as Category }))
 }

--- a/src/lib/uniswap/v2/pair.ts
+++ b/src/lib/uniswap/v2/pair.ts
@@ -1,4 +1,4 @@
-import { Balance, BaseContext, Contract } from '@lib/adapter'
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { Chain } from '@lib/chains'
 import { getERC20BalanceOf } from '@lib/erc20'
 import { multicall } from '@lib/multicall'
@@ -44,7 +44,7 @@ export const abi = {
  * Retrieves pairs balances (with underlyings) of Uniswap V2 like Pair.
  * `amount`, `underlyings[0]` (token0) and `underlyings[1]` (token1) must be defined.
  */
-export async function getPairsBalances(ctx: BaseContext, chain: Chain, contracts: Contract[]): Promise<Balance[]> {
+export async function getPairsBalances(ctx: BalancesContext, chain: Chain, contracts: Contract[]): Promise<Balance[]> {
   const balances = await getERC20BalanceOf(ctx, chain, contracts as Token[])
 
   return getUnderlyingBalances(chain, balances)


### PR DESCRIPTION
<!-- 🦙🦙 Thanks for contributing ! 🦙🦙 -->

<!-- Please specify the adapter id in the title -->

<!-- If you're creating a new adapter, please make sure the `links` field is well specified: this info will help us review it -->

## Summary

<!-- Which issues will be closed? (if applicable) -->

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

Part 1 of https://github.com/llamafolio/llamafolio-api/issues/239

- add `chain` and `adapterId` fields in `BaseContext`  and pass it to `getContracts`. BaseContext is not aware of the current user
- add `BalancesContext` which is aware of the current user and replace all `BaseContext` by `BalancesContext`

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
