### PR TITLE
feat: getContracts props

### DIFF
--- a/scripts/revalidate-contracts.ts
+++ b/scripts/revalidate-contracts.ts
@@ -41,11 +41,15 @@ async function main() {
 
         const contractsRes = await adapter[chain]!.getContracts(ctx, prevDbAdapter?.contractsRevalidateProps || {})
 
-        const contracts = await resolveContractsTokens(client, contractsRes?.contracts || {}, true)
+        const [contracts, props] = await Promise.all([
+          resolveContractsTokens(client, contractsRes?.contracts || {}, true),
+          resolveContractsTokens(client, contractsRes?.props || {}, true),
+        ])
 
         return {
           ...contractsRes,
           contracts,
+          props,
         }
       }),
     )
@@ -64,6 +68,7 @@ async function main() {
         chain: adapterChains[i],
         contractsExpireAt: expire_at,
         contractsRevalidateProps: config.revalidateProps,
+        contractsProps: config.props,
         createdAt: now,
       }
     })

--- a/scripts/run-adapter-balances.ts
+++ b/scripts/run-adapter-balances.ts
@@ -1,6 +1,7 @@
 import millify from 'millify'
 import path from 'path'
 
+import { selectAdapterProps } from '../src/db/adapters'
 import {
   getAllChainTokensInteractions,
   getChainContractsInteractionsTokenTransfers,
@@ -47,14 +48,20 @@ async function main() {
   const client = await pool.connect()
 
   try {
-    const contracts =
+    const [contracts, adapterProps] = await Promise.all([
       adapter.id === 'wallet'
-        ? await getAllChainTokensInteractions(client, chain, ctx.address)
-        : await getChainContractsInteractionsTokenTransfers(client, chain, ctx.address, adapter.id)
+        ? getAllChainTokensInteractions(client, chain, ctx.address)
+        : getChainContractsInteractionsTokenTransfers(client, chain, ctx.address, adapter.id),
+      selectAdapterProps(client, adapterId),
+    ])
 
     console.log(`Interacted with ${contracts.length} contracts`)
 
-    const balancesRes = await adapter[chain]?.getBalances(ctx, groupContracts(contracts) || [])
+    const balancesRes = await adapter[chain]?.getBalances(
+      ctx,
+      groupContracts(contracts) || [],
+      adapterProps?.contractsProps || {},
+    )
     const sanitizedBalances = sanitizeBalances(balancesRes?.balances || [])
 
     const pricedBalances = await getPricedBalances(sanitizedBalances)

--- a/scripts/run-adapter.ts
+++ b/scripts/run-adapter.ts
@@ -55,9 +55,12 @@ async function main() {
   try {
     const contractsRes = await adapter[chain]?.getContracts(ctx, {})
 
-    const contracts = await resolveContractsTokens(client, contractsRes?.contracts || {}, true)
+    const [contracts, props] = await Promise.all([
+      resolveContractsTokens(client, contractsRes?.contracts || {}, true),
+      resolveContractsTokens(client, contractsRes?.props || {}, true),
+    ])
 
-    const balancesRes = await adapter[chain]?.getBalances(ctx, contracts)
+    const balancesRes = await adapter[chain]?.getBalances(ctx, contracts, props)
     const sanitizedBalances = sanitizeBalances(balancesRes?.balances || [])
 
     const yieldsRes = await fetch('https://yields.llama.fi/poolsOld')

--- a/src/adapters/lusd-chickenbonds/ethereum/bondNFT.ts
+++ b/src/adapters/lusd-chickenbonds/ethereum/bondNFT.ts
@@ -1,7 +1,6 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { range } from '@lib/array'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { BN_ZERO } from '@lib/math'
 import { multicall } from '@lib/multicall'
 import { isNotNullish, isSuccess } from '@lib/type'
@@ -50,7 +49,7 @@ const abi = {
   },
 }
 
-export async function getActiveBondsBalances(ctx: BalancesContext, _chain: Chain, bondNFT: Contract) {
+export async function getActiveBondsBalances(ctx: BalancesContext, bondNFT: Contract) {
   const LUSD = bondNFT.underlyings?.[0]
   const bLUSD = bondNFT.rewards?.[0]
   if (!LUSD || !bLUSD) {

--- a/src/adapters/lusd-chickenbonds/ethereum/chickenBondManager.ts
+++ b/src/adapters/lusd-chickenbonds/ethereum/chickenBondManager.ts
@@ -2,7 +2,10 @@ import { BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { multicall } from '@lib/multicall'
 
-const chickenBondManager = '0x57619FE9C539f890b19c61812226F9703ce37137'
+export const chickenBondManager: Contract = {
+  chain: 'ethereum',
+  address: '0x57619FE9C539f890b19c61812226F9703ce37137',
+}
 
 const abi = {
   bondNFT: {
@@ -39,17 +42,17 @@ export async function getBondNFTContract() {
   const [bondNFTRes, lusdTokenRes, bLUSDTokenRes] = await Promise.all([
     call({
       chain: 'ethereum',
-      target: chickenBondManager,
+      target: chickenBondManager.address,
       abi: abi.bondNFT,
     }),
     call({
       chain: 'ethereum',
-      target: chickenBondManager,
+      target: chickenBondManager.address,
       abi: abi.lusdToken,
     }),
     call({
       chain: 'ethereum',
-      target: chickenBondManager,
+      target: chickenBondManager.address,
       abi: abi.bLUSDToken,
     }),
   ])
@@ -68,7 +71,7 @@ export function getAccruedBLUSD(ctx: BalancesContext, tokenIDs: number[]) {
   return multicall({
     chain: ctx.chain,
     calls: tokenIDs.map((tokenID) => ({
-      target: chickenBondManager,
+      target: chickenBondManager.address,
       params: [tokenID],
     })),
     abi: abi.calcAccruedBLUSD,

--- a/src/adapters/lusd-chickenbonds/ethereum/index.ts
+++ b/src/adapters/lusd-chickenbonds/ethereum/index.ts
@@ -2,19 +2,20 @@ import { GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
 
 import { getActiveBondsBalances } from './bondNFT'
-import { getBondNFTContract } from './chickenBondManager'
+import { chickenBondManager, getBondNFTContract } from './chickenBondManager'
 
 export const getContracts = async () => {
   const bondNFT = await getBondNFTContract()
 
   return {
-    contracts: { bondNFT },
+    contracts: { chickenBondManager },
+    props: { bondNFT },
   }
 }
 
-export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts, props) => {
   const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
-    bondNFT: getActiveBondsBalances,
+    chickenBondManager: (ctx) => getActiveBondsBalances(ctx, props.bondNFT),
   })
 
   return {

--- a/src/handlers/getBalancesTokens.ts
+++ b/src/handlers/getBalancesTokens.ts
@@ -76,7 +76,7 @@ export const handler: APIGatewayProxyHandler = async (event, context) => {
 
             const ctx: BalancesContext = { address, chain: chain as Chain, adapterId: walletAdapter.id }
 
-            const balancesConfig = await handler.getBalances(ctx, contracts)
+            const balancesConfig = await handler.getBalances(ctx, contracts, {})
 
             const hrend = process.hrtime(hrstart)
 

--- a/src/handlers/revalidateAdapters.ts
+++ b/src/handlers/revalidateAdapters.ts
@@ -103,7 +103,10 @@ export const revalidateAdapterContracts: APIGatewayProxyHandler = async (event, 
 
     const config = await adapter[chain]!.getContracts(ctx, prevDbAdapter?.contractsRevalidateProps || {})
 
-    const contracts = await resolveContractsTokens(client, config.contracts || {}, true)
+    const [contracts, props] = await Promise.all([
+      resolveContractsTokens(client, config.contracts || {}, true),
+      resolveContractsTokens(client, config.props || {}, true),
+    ])
 
     let expire_at: Date | undefined = undefined
     if (config.revalidate) {
@@ -116,6 +119,7 @@ export const revalidateAdapterContracts: APIGatewayProxyHandler = async (event, 
       chain,
       contractsExpireAt: expire_at,
       contractsRevalidateProps: config.revalidateProps,
+      contractsProps: props,
       createdAt: new Date(),
     }
 

--- a/src/lib/adapter.ts
+++ b/src/lib/adapter.ts
@@ -96,6 +96,7 @@ export interface BalancesConfig {
 
 export interface ContractsConfig {
   contracts: { [key: string]: Contract | Contract[] | RawContract | RawContract[] | undefined }
+  props?: { [key: string]: Contract | Contract[] | RawContract | RawContract[] | undefined }
   revalidate?: number
   revalidateProps?: { [key: string]: any }
 }
@@ -105,13 +106,14 @@ export interface ContractsConfig {
  */
 export type GetContractsHandler = (
   ctx: BaseContext,
-  props: { [key: string]: any },
+  revalidateProps: { [key: string]: any },
 ) => ContractsConfig | Promise<ContractsConfig>
 
 export type GetBalancesHandler<C extends GetContractsHandler> = (
   ctx: BalancesContext,
   // each key can be undefined as the account may not have interacted with these contracts
   contracts: Partial<Awaited<ReturnType<C>>['contracts']>,
+  props: Awaited<ReturnType<C>>['props'],
 ) => BalancesConfig | Promise<BalancesConfig>
 
 export interface AdapterHandler {


### PR DESCRIPTION
<!-- 🦙🦙 Thanks for contributing ! 🦙🦙 -->

<!-- Please specify the adapter id in the title -->

<!-- If you're creating a new adapter, please make sure the `links` field is well specified: this info will help us review it -->

## Summary

<!-- Which issues will be closed? (if applicable) -->

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

Add support for `getContracts` props attribute.

Unlike `contracts` - which are only passed when the account interacted with the smart contract - `props` are always passed to `getBalances`. This allows us to cache extra contracts and use them to retrieve balances

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
