### PR TITLE
feat: run update balances of adapters that define props attribute

### DIFF
--- a/scripts/revalidate-contracts.ts
+++ b/scripts/revalidate-contracts.ts
@@ -43,7 +43,7 @@ async function main() {
 
         const [contracts, props] = await Promise.all([
           resolveContractsTokens(client, contractsRes?.contracts || {}, true),
-          resolveContractsTokens(client, contractsRes?.props || {}, true),
+          contractsRes?.props ? resolveContractsTokens(client, contractsRes?.props, true) : undefined,
         ])
 
         return {

--- a/src/adapters/makerdao/ethereum/index.ts
+++ b/src/adapters/makerdao/ethereum/index.ts
@@ -50,16 +50,17 @@ const Vat: Contract = {
 
 export const getContracts = () => {
   return {
-    contracts: { MakerProxyRegistry, InstadAppProxyRegistry, getCdps, cdpManager, Vat, IlkRegistry, Spot },
+    contracts: { MakerProxyRegistry, InstadAppProxyRegistry },
+    props: { MakerProxyRegistry, InstadAppProxyRegistry },
   }
 }
 
-export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, _contracts, props) => {
   const proxies = (
     await Promise.all(
       [
-        contracts.MakerProxyRegistry ? getMakerContracts(ctx, 'ethereum', MakerProxyRegistry) : null,
-        contracts.InstadAppProxyRegistry ? getInstaDappContracts(ctx, 'ethereum', InstadAppProxyRegistry) : null,
+        props.MakerProxyRegistry ? getMakerContracts(ctx, 'ethereum', MakerProxyRegistry) : null,
+        props.InstadAppProxyRegistry ? getInstaDappContracts(ctx, 'ethereum', InstadAppProxyRegistry) : null,
       ].filter(isNotNullish),
     )
   ).flat()

--- a/src/db/adapters.ts
+++ b/src/db/adapters.ts
@@ -132,14 +132,24 @@ export async function selectAdapterProps(client: PoolClient, adapterId: string, 
  * @param adapters [adapterId, chain] array
  */
 export async function selectAdaptersProps(client: PoolClient, adapters: [string, Chain][]) {
-  const fmt = format(
-    `select a.id, a.chain, a.contracts_props from adapters a join (values %L) as v (id, chain) on a.id = v.id and a.chain = v.chain;`,
-    adapters,
+  const adaptersRes = await client.query(
+    format(
+      `select a.id, a.chain, a.contracts_props from adapters a join (values %L) as v (id, chain) on a.id = v.id and a.chain = v.chain;`,
+      adapters,
+    ),
+    [],
   )
 
-  const adaptersRes = await client.query(fmt, [])
-
   return fromPartialStorage(adaptersRes.rows)
+}
+
+export async function selectDefinedAdaptersContractsProps(client: PoolClient) {
+  const adaptersRes = await client.query(
+    `select id, chain, contracts_props from adapters where contracts_props is not null;`,
+    [],
+  )
+
+  return fromPartialStorage(adaptersRes.rows) as Pick<Adapter, 'id' | 'chain' | 'contractsProps'>[]
 }
 
 export async function selectLatestCreatedAdapters(client: PoolClient, limit = 5) {

--- a/src/handlers/revalidateAdapters.ts
+++ b/src/handlers/revalidateAdapters.ts
@@ -105,7 +105,7 @@ export const revalidateAdapterContracts: APIGatewayProxyHandler = async (event, 
 
     const [contracts, props] = await Promise.all([
       resolveContractsTokens(client, config.contracts || {}, true),
-      resolveContractsTokens(client, config.props || {}, true),
+      config.props ? resolveContractsTokens(client, config.props, true) : undefined,
     ])
 
     let expire_at: Date | undefined = undefined


### PR DESCRIPTION
<!-- 🦙🦙 Thanks for contributing ! 🦙🦙 -->

<!-- Please specify the adapter id in the title -->

<!-- If you're creating a new adapter, please make sure the `links` field is well specified: this info will help us review it -->

## Summary

<!-- Which issues will be closed? (if applicable) -->

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

See: https://github.com/llamafolio/llamafolio-api/pull/262

Always run `getBalances` if `props` are defined in `getContracts`. This allows us to "force" run an adapter even if the user has not interacted with any of the contracts defined in `contracts` (like in LlamaPay for instance)

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
