### PR TITLE
refactor: resolveBalances remove extra chain arg

### DIFF
--- a/src/adapters/__template/ethereum/index.ts
+++ b/src/adapters/__template/ethereum/index.ts
@@ -1,9 +1,8 @@
 import { Balance, BalancesContext, Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
-import { Chain } from '@lib/chains'
 
-export async function getStakeBalances(ctx: BalancesContext, chain: Chain, staking: Contract): Promise<Balance[]> {
-  console.log(ctx, chain, staking)
+export async function getStakeBalances(ctx: BalancesContext, staking: Contract): Promise<Balance[]> {
+  console.log(ctx, staking)
 
   return []
 }
@@ -18,7 +17,7 @@ const staking: Contract = {
 
 export const getContracts = async () => {
   return {
-    // All contracts `getBalances` will look at, grouped by keys
+    // Contracts grouped by keys. They will be passed to `getBalances`, filtered by user interaction
     contracts: { staking },
     // Optional revalidate time (in seconds).
     // Contracts returned by the adapter are cached by default and can be updated by interval with this parameter.
@@ -31,7 +30,7 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   // Any method to check all the contracts retrieved above.
   // This function will be run each time a user queries his balances.
   // As static contracts info are filled in getContracts, this should ideally only fetch the current amount of each contract (+ underlyings and rewards)
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     staking: getStakeBalances,
   })
 

--- a/src/adapters/aave/v2/avax/index.ts
+++ b/src/adapters/aave/v2/avax/index.ts
@@ -36,12 +36,12 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'avax', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: getLendingPoolBalances,
     incentiveController: (...args) => getLendingRewardsBalances(...args, WAVAX, contracts.pools || []),
   })
 
-  const healthFactor = await getLendingPoolHealthFactor(ctx, 'avax', lendingPool)
+  const healthFactor = await getLendingPoolHealthFactor(ctx, lendingPool)
 
   return {
     balances,

--- a/src/adapters/aave/v2/common/rewards.ts
+++ b/src/adapters/aave/v2/common/rewards.ts
@@ -1,11 +1,9 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { BigNumber } from 'ethers'
 
 export async function getLendingRewardsBalances(
   ctx: BalancesContext,
-  chain: Chain,
   incentiveController: Contract,
   rewardToken: Contract,
   contracts: Contract[],
@@ -17,7 +15,7 @@ export async function getLendingRewardsBalances(
   const rewards: Balance[] = []
 
   const userRewardsRes = await call({
-    chain,
+    chain: ctx.chain,
     target: incentiveController.address,
     params: [assetsAddressesList, ctx.address],
     abi: {

--- a/src/adapters/aave/v2/ethereum/index.ts
+++ b/src/adapters/aave/v2/ethereum/index.ts
@@ -65,14 +65,14 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: getLendingPoolBalances,
     incentiveController: (...args) => getLendingRewardsBalances(...args, stkAAVE, contracts.pools || []),
     stkAAVE: getStakeBalances,
     stkABPT: getStakeBalancerPoolBalances,
   })
 
-  const healthFactor = await getLendingPoolHealthFactor(ctx, 'ethereum', lendingPool)
+  const healthFactor = await getLendingPoolHealthFactor(ctx, lendingPool)
 
   return {
     balances,

--- a/src/adapters/aave/v2/polygon/index.ts
+++ b/src/adapters/aave/v2/polygon/index.ts
@@ -36,12 +36,12 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'polygon', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: getLendingPoolBalances,
     incentiveController: (...args) => getLendingRewardsBalances(...args, WMATIC, contracts.pools || []),
   })
 
-  const healthFactor = await getLendingPoolHealthFactor(ctx, 'polygon', lendingPool)
+  const healthFactor = await getLendingPoolHealthFactor(ctx, lendingPool)
 
   return {
     balances,

--- a/src/adapters/aave/v3/arbitrum/index.ts
+++ b/src/adapters/aave/v3/arbitrum/index.ts
@@ -40,12 +40,12 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'arbitrum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: getLendingPoolBalances,
     incentiveController: (...args) => getLendingRewardsBalances(...args, contracts.pools || []),
   })
 
-  const healthFactor = await getLendingPoolHealthFactor(ctx, 'arbitrum', lendingPool)
+  const healthFactor = await getLendingPoolHealthFactor(ctx, lendingPool)
 
   return {
     balances,

--- a/src/adapters/aave/v3/avax/index.ts
+++ b/src/adapters/aave/v3/avax/index.ts
@@ -40,12 +40,12 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'avax', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: getLendingPoolBalances,
     incentiveController: (...args) => getLendingRewardsBalances(...args, contracts.pools || []),
   })
 
-  const healthFactor = await getLendingPoolHealthFactor(ctx, 'avax', lendingPool)
+  const healthFactor = await getLendingPoolHealthFactor(ctx, lendingPool)
 
   return {
     balances,

--- a/src/adapters/aave/v3/common/lending.ts
+++ b/src/adapters/aave/v3/common/lending.ts
@@ -99,12 +99,8 @@ export async function getLendingPoolContracts(
   return contracts
 }
 
-export async function getLendingPoolBalances(
-  ctx: BalancesContext,
-  chain: Chain,
-  contracts: Contract[],
-): Promise<Balance[]> {
-  const balances: Balance[] = await getERC20BalanceOf(ctx, chain, contracts as Token[])
+export async function getLendingPoolBalances(ctx: BalancesContext, contracts: Contract[]): Promise<Balance[]> {
+  const balances: Balance[] = await getERC20BalanceOf(ctx, contracts as Token[])
 
   // use the same amount for underlyings
   for (const balance of balances) {
@@ -118,7 +114,6 @@ export async function getLendingPoolBalances(
 
 export async function getLendingRewardsBalances(
   ctx: BalancesContext,
-  chain: Chain,
   incentiveController: Contract,
   contracts: Contract[],
 ): Promise<Balance[]> {
@@ -126,7 +121,7 @@ export async function getLendingRewardsBalances(
   const assets: any = contracts.map((contract: Contract) => contract.address)
 
   const rewardsListsRes = await call({
-    chain,
+    chain: ctx.chain,
     target: incentiveController.address,
     params: [assets, ctx.address],
     abi: {
@@ -155,7 +150,7 @@ export async function getLendingRewardsBalances(
   const rewardsLists = rewardsListsRes.output
 
   const rewardsAddress = rewardsLists.rewardsList
-  const rewardsTokens = await getERC20Details(chain, rewardsAddress)
+  const rewardsTokens = await getERC20Details(ctx.chain, rewardsAddress)
   const rewardsBalances = BigNumber.from(rewardsLists.unclaimedAmounts[0])
 
   rewards.push({
@@ -167,9 +162,9 @@ export async function getLendingRewardsBalances(
   return rewards
 }
 
-export async function getLendingPoolHealthFactor(ctx: BalancesContext, chain: Chain, lendingPool: Contract) {
+export async function getLendingPoolHealthFactor(ctx: BalancesContext, lendingPool: Contract) {
   const userAccountDataRes = await call({
-    chain,
+    chain: ctx.chain,
     target: lendingPool.address,
     params: [ctx.address],
     abi: {

--- a/src/adapters/aave/v3/fantom/index.ts
+++ b/src/adapters/aave/v3/fantom/index.ts
@@ -40,12 +40,12 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'fantom', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: getLendingPoolBalances,
     incentiveController: (...args) => getLendingRewardsBalances(...args, contracts.pools || []),
   })
 
-  const healthFactor = await getLendingPoolHealthFactor(ctx, 'fantom', lendingPool)
+  const healthFactor = await getLendingPoolHealthFactor(ctx, lendingPool)
 
   return {
     balances,

--- a/src/adapters/aave/v3/polygon/index.ts
+++ b/src/adapters/aave/v3/polygon/index.ts
@@ -40,12 +40,12 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'polygon', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: getLendingPoolBalances,
     incentiveController: (...args) => getLendingRewardsBalances(...args, contracts.pools || []),
   })
 
-  const healthFactor = await getLendingPoolHealthFactor(ctx, 'polygon', lendingPool)
+  const healthFactor = await getLendingPoolHealthFactor(ctx, lendingPool)
 
   return {
     balances,

--- a/src/adapters/abracadabra/avax/index.ts
+++ b/src/adapters/abracadabra/avax/index.ts
@@ -34,7 +34,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'avax', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     mStakeContracts: getMStakeBalance,
     marketsContracts: getMarketsBalances,
   })

--- a/src/adapters/abracadabra/common/mStake.ts
+++ b/src/adapters/abracadabra/common/mStake.ts
@@ -47,14 +47,14 @@ export async function getMStakeContract(chain: Chain, contract: Contract): Promi
   return stakeContract
 }
 
-export async function getMStakeBalance(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getMStakeBalance(ctx: BalancesContext, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
   const underlying = contract.underlyings?.[0]
   const reward = contract.rewards?.[0]
 
   const [balanceOfRes, pendingRewardsRes] = await Promise.all([
     call({
-      chain,
+      chain: ctx.chain,
       target: contract.address,
       params: [ctx.address],
       abi: {
@@ -71,7 +71,7 @@ export async function getMStakeBalance(ctx: BalancesContext, chain: Chain, contr
     }),
 
     call({
-      chain,
+      chain: ctx.chain,
       target: contract.address,
       params: [ctx.address],
       abi: {

--- a/src/adapters/abracadabra/common/markets.ts
+++ b/src/adapters/abracadabra/common/markets.ts
@@ -67,16 +67,12 @@ export async function getMarketsContracts(chain: Chain, contracts: string[]): Pr
   return marketsContracts
 }
 
-export async function getMarketsBalances(
-  ctx: BalancesContext,
-  chain: Chain,
-  contracts: Contract[],
-): Promise<Balance[]> {
+export async function getMarketsBalances(ctx: BalancesContext, contracts: Contract[]): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const [borrowingTokenRes, lendingBalancesRes, borrowingBalancesRes] = await Promise.all([
     multicall({
-      chain,
+      chain: ctx.chain,
       calls: contracts.map((contract) => ({
         target: contract.address,
         params: [],
@@ -91,7 +87,7 @@ export async function getMarketsBalances(
     }),
 
     multicall({
-      chain,
+      chain: ctx.chain,
       calls: contracts.map((contract) => ({
         target: contract.address,
         params: [ctx.address],
@@ -106,7 +102,7 @@ export async function getMarketsBalances(
     }),
 
     multicall({
-      chain,
+      chain: ctx.chain,
       calls: contracts.map((contract) => ({
         target: contract.address,
         params: [ctx.address],
@@ -123,7 +119,7 @@ export async function getMarketsBalances(
 
   const borrowingToken = borrowingTokenRes.filter((res) => res.success).map((res) => res.output)
 
-  const underlyingBorrowingTokens = await getERC20Details(chain, borrowingToken)
+  const underlyingBorrowingTokens = await getERC20Details(ctx.chain, borrowingToken)
 
   const lendingBalances = lendingBalancesRes.filter((res) => res.success).map((res) => BigNumber.from(res.output))
 
@@ -136,7 +132,7 @@ export async function getMarketsBalances(
     }
 
     const lendingBalance: Balance = {
-      chain,
+      chain: ctx.chain,
       address: contract.address,
       symbol: contract.symbol,
       decimals: contract.decimals,
@@ -159,7 +155,7 @@ export async function getMarketsBalances(
     }
 
     const borrowingBalance: Balance = {
-      chain,
+      chain: ctx.chain,
       address: underlyingBorrowingToken.address,
       symbol: underlyingBorrowingToken.symbol,
       decimals: underlyingBorrowingToken.decimals,

--- a/src/adapters/abracadabra/ethereum/index.ts
+++ b/src/adapters/abracadabra/ethereum/index.ts
@@ -62,7 +62,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     mStakeContracts: getMStakeBalance,
     sStakeContracts: getSStakeBalance,
     marketsContracts: getMarketsBalances,

--- a/src/adapters/abracadabra/ethereum/sStake.ts
+++ b/src/adapters/abracadabra/ethereum/sStake.ts
@@ -37,19 +37,19 @@ export async function getSStakeContract(chain: Chain, contract: Contract): Promi
   return stakeContract
 }
 
-export async function getSStakeBalance(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getSStakeBalance(ctx: BalancesContext, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const [balanceOfRes, totalSupplyRes, balanceOfTokenInUnderlyingRes] = await Promise.all([
     call({
-      chain,
+      chain: ctx.chain,
       target: contract.address,
       params: [ctx.address],
       abi: abi.balanceOf,
     }),
 
     call({
-      chain,
+      chain: ctx.chain,
       target: contract.address,
       params: [],
       abi: {
@@ -62,7 +62,7 @@ export async function getSStakeBalance(ctx: BalancesContext, chain: Chain, contr
     }),
 
     call({
-      chain,
+      chain: ctx.chain,
       target: SPELL.address,
       params: [contract.address],
       abi: abi.balanceOf,
@@ -76,7 +76,7 @@ export async function getSStakeBalance(ctx: BalancesContext, chain: Chain, contr
   const formattedBalanceOf = balanceOf.mul(balanceOfTokenInUnderlying).div(totalSupply)
 
   const balance: Balance = {
-    chain,
+    chain: ctx.chain,
     decimals: contract.decimals,
     address: contract.address,
     symbol: contract.symbol,

--- a/src/adapters/abracadabra/fantom/index.ts
+++ b/src/adapters/abracadabra/fantom/index.ts
@@ -36,7 +36,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'fantom', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     mStakeContracts: getMStakeBalance,
     marketsContracts: getMarketsBalances,
   })

--- a/src/adapters/alpaca-finance/bsc/index.ts
+++ b/src/adapters/alpaca-finance/bsc/index.ts
@@ -10,7 +10,7 @@ const fairLaunch: Contract = {
   address: '0xA625AB01B08ce023B2a342Dbb12a16f2C8489A8F',
 }
 
-const alpaca: Contract = {
+const ALPACA: Contract = {
   chain: 'bsc',
   address: '0x8f0528ce5ef7b51152a59745befdd91d97091d2f',
   decimals: 18,
@@ -26,8 +26,8 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'bsc', contracts, {
-    pools: (ctx, chain, pools) => getPoolsBalances(ctx, chain, pools, fairLaunch, alpaca),
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    pools: (ctx, pools) => getPoolsBalances(ctx, pools, fairLaunch, ALPACA),
   })
 
   return {

--- a/src/adapters/alpaca-finance/common/balances.ts
+++ b/src/adapters/alpaca-finance/common/balances.ts
@@ -1,5 +1,4 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
-import { Chain } from '@lib/chains'
 import { abi as erc20Abi } from '@lib/erc20'
 import { multicall } from '@lib/multicall'
 import { isSuccess } from '@lib/type'
@@ -47,7 +46,6 @@ const abi = {
 
 export async function getPoolsBalances(
   ctx: BalancesContext,
-  chain: Chain,
   pools: Contract[],
   fairLaunch: Contract,
   alpaca: Contract,
@@ -70,11 +68,11 @@ export async function getPoolsBalances(
   }))
 
   const [userInfosRes, pendingRewardsRes, totalTokensRes, totalSuppliesRes, balancesOfRes] = await Promise.all([
-    multicall({ chain, calls, abi: abi.userInfo }),
-    multicall({ chain, calls, abi: abi.pendingAlpaca }),
-    multicall({ chain, calls: supplyCalls, abi: abi.totalToken }),
-    multicall({ chain, calls: supplyCalls, abi: abi.totalSupply }),
-    multicall({ chain, calls: balanceOfCalls, abi: erc20Abi.balanceOf }),
+    multicall({ chain: ctx.chain, calls, abi: abi.userInfo }),
+    multicall({ chain: ctx.chain, calls, abi: abi.pendingAlpaca }),
+    multicall({ chain: ctx.chain, calls: supplyCalls, abi: abi.totalToken }),
+    multicall({ chain: ctx.chain, calls: supplyCalls, abi: abi.totalSupply }),
+    multicall({ chain: ctx.chain, calls: balanceOfCalls, abi: erc20Abi.balanceOf }),
   ])
 
   for (let i = 0; i < pools.length; i++) {

--- a/src/adapters/alpaca-finance/fantom/index.ts
+++ b/src/adapters/alpaca-finance/fantom/index.ts
@@ -10,7 +10,7 @@ const MiniFL: Contract = {
   address: '0x838B7F64Fa89d322C563A6f904851A13a164f84C',
 }
 
-const AlpacaFTM: Contract = {
+const ALPACA: Contract = {
   chain: 'fantom',
   address: '0xad996a45fd2373ed0b10efa4a8ecb9de445a4302',
   decimals: 18,
@@ -26,7 +26,9 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'fantom', contracts, { pools: getPoolsBalances })
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    pools: (ctx, pools) => getPoolsBalances(ctx, pools, MiniFL, ALPACA),
+  })
 
   return {
     balances,

--- a/src/adapters/apeswap-amm/bsc/index.ts
+++ b/src/adapters/apeswap-amm/bsc/index.ts
@@ -24,7 +24,9 @@ export const getContracts = async (props: any) => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'bsc', contracts, { pairs: getPairsBalances })
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    pairs: getPairsBalances,
+  })
 
   return {
     balances,

--- a/src/adapters/apeswap-amm/ethereum/index.ts
+++ b/src/adapters/apeswap-amm/ethereum/index.ts
@@ -24,7 +24,9 @@ export const getContracts = async (props: any) => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, { pairs: getPairsBalances })
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    pairs: getPairsBalances,
+  })
 
   return {
     balances,

--- a/src/adapters/apeswap-amm/polygon/index.ts
+++ b/src/adapters/apeswap-amm/polygon/index.ts
@@ -24,7 +24,9 @@ export const getContracts = async (props: any) => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'polygon', contracts, { pairs: getPairsBalances })
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    pairs: getPairsBalances,
+  })
 
   return {
     balances,

--- a/src/adapters/apeswap-lending/bsc/index.ts
+++ b/src/adapters/apeswap-lending/bsc/index.ts
@@ -24,7 +24,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'bsc', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     markets: getMarketsBalances,
   })
 

--- a/src/adapters/arrakis/common/balances.ts
+++ b/src/adapters/arrakis/common/balances.ts
@@ -1,14 +1,13 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
-import { Chain } from '@lib/chains'
 import { getERC20BalanceOf } from '@lib/erc20'
 import { multicall } from '@lib/multicall'
 import { Token } from '@lib/token'
 import { BigNumber } from 'ethers'
 
-export async function getLpBalances(ctx: BalancesContext, chain: Chain, contracts: Contract[]) {
+export async function getLpBalances(ctx: BalancesContext, contracts: Contract[]) {
   const balances: Balance[] = []
 
-  const balancesRaw = await getERC20BalanceOf(ctx, chain, contracts as Token[])
+  const balancesRaw = await getERC20BalanceOf(ctx, contracts as Token[])
 
   const nonZeroBalances = balancesRaw.filter((balance) => balance.amount.gt(0))
 
@@ -19,7 +18,7 @@ export async function getLpBalances(ctx: BalancesContext, chain: Chain, contract
 
   const [underlyingBalancesRes, totalSupplyRes] = await Promise.all([
     multicall({
-      chain,
+      chain: ctx.chain,
       calls,
       abi: {
         inputs: [],
@@ -42,7 +41,7 @@ export async function getLpBalances(ctx: BalancesContext, chain: Chain, contract
     }),
 
     multicall({
-      chain: chain,
+      chain: ctx.chain,
       calls: calls,
       abi: {
         inputs: [],

--- a/src/adapters/arrakis/ethereum/index.ts
+++ b/src/adapters/arrakis/ethereum/index.ts
@@ -21,7 +21,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     vaults: getLpBalances,
   })
 

--- a/src/adapters/arrakis/optimism/index.ts
+++ b/src/adapters/arrakis/optimism/index.ts
@@ -21,7 +21,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'optimism', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     vaults: getLpBalances,
   })
 

--- a/src/adapters/arrakis/polygon/index.ts
+++ b/src/adapters/arrakis/polygon/index.ts
@@ -21,7 +21,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'polygon', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     vaults: getLpBalances,
   })
 

--- a/src/adapters/atlas-usv/avax/index.ts
+++ b/src/adapters/atlas-usv/avax/index.ts
@@ -27,7 +27,7 @@ export const getContracts = () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'avax', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     sUSV: getStakeBalance,
   })
 

--- a/src/adapters/atlas-usv/bsc/index.ts
+++ b/src/adapters/atlas-usv/bsc/index.ts
@@ -27,7 +27,7 @@ export const getContracts = () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'bsc', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     sUSV: getStakeBalance,
   })
 

--- a/src/adapters/atlas-usv/common/stake.ts
+++ b/src/adapters/atlas-usv/common/stake.ts
@@ -1,7 +1,6 @@
 import { Balance, Contract } from '@lib/adapter'
 import { BalancesContext } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
 import { Token } from '@lib/token'
 import { BigNumber } from 'ethers/lib/ethers'
@@ -14,9 +13,9 @@ const USV: Token = {
   decimals: 9,
 }
 
-export async function getStakeBalance(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance> {
+export async function getStakeBalance(ctx: BalancesContext, contract: Contract): Promise<Balance> {
   const balanceOfRes = await call({
-    chain,
+    chain: ctx.chain,
     target: contract.address,
     params: [ctx.address],
     abi: abi.balanceOf,

--- a/src/adapters/atlas-usv/ethereum/index.ts
+++ b/src/adapters/atlas-usv/ethereum/index.ts
@@ -27,7 +27,7 @@ export const getContracts = () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     sUSV: getStakeBalance,
   })
 

--- a/src/adapters/atlas-usv/polygon/index.ts
+++ b/src/adapters/atlas-usv/polygon/index.ts
@@ -27,7 +27,7 @@ export const getContracts = () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'polygon', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     sUSV: getStakeBalance,
   })
 

--- a/src/adapters/benqi-lending/avax/index.ts
+++ b/src/adapters/benqi-lending/avax/index.ts
@@ -23,7 +23,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'avax', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     markets: getMarketsBalances,
   })
 

--- a/src/adapters/benqi-staked-avax/avax/index.ts
+++ b/src/adapters/benqi-staked-avax/avax/index.ts
@@ -29,7 +29,7 @@ export const getContracts = () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'avax', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     sAVAX: getStakeBalances,
   })
 

--- a/src/adapters/benqi-staked-avax/avax/stake.ts
+++ b/src/adapters/benqi-staked-avax/avax/stake.ts
@@ -1,7 +1,6 @@
 import { Balance, Contract } from '@lib/adapter'
 import { BalancesContext } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { BigNumber } from 'ethers'
 
 const WAVAX: Contract = {
@@ -12,10 +11,10 @@ const WAVAX: Contract = {
   decimals: 18,
 }
 
-export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance> {
+export async function getStakeBalances(ctx: BalancesContext, contract: Contract): Promise<Balance> {
   const [balanceOfRes, poolValueRes, totalSupplyRes] = await Promise.all([
     call({
-      chain,
+      chain: ctx.chain,
       target: contract.address,
       params: ctx.address,
       abi: {
@@ -28,7 +27,7 @@ export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contr
     }),
 
     call({
-      chain,
+      chain: ctx.chain,
       target: contract.address,
       params: [],
       abi: {
@@ -41,7 +40,7 @@ export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contr
     }),
 
     call({
-      chain,
+      chain: ctx.chain,
       target: contract.address,
       params: [],
       abi: {

--- a/src/adapters/compound/v2/common/rewards.ts
+++ b/src/adapters/compound/v2/common/rewards.ts
@@ -1,6 +1,5 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { Token } from '@lib/token'
 import { BigNumber } from 'ethers'
 
@@ -14,14 +13,13 @@ const COMP: Token = {
 
 export async function getRewardsBalances(
   ctx: BalancesContext,
-  chain: Chain,
   comptroller: Contract,
   lens: Contract,
 ): Promise<Balance[]> {
   const rewards: Balance[] = []
 
   const compAllocatedRewardsRes = await call({
-    chain,
+    chain: ctx.chain,
     target: lens.address,
     params: [COMP.address, comptroller.address, ctx.address],
     abi: {
@@ -58,7 +56,7 @@ export async function getRewardsBalances(
   const compAllocatedRewards = BigNumber.from(compAllocatedRewardsRes.output.allocated)
 
   rewards.push({
-    chain,
+    chain: ctx.chain,
     address: COMP.address,
     decimals: COMP.decimals,
     symbol: COMP.symbol,

--- a/src/adapters/compound/v2/ethereum/index.ts
+++ b/src/adapters/compound/v2/ethereum/index.ts
@@ -44,7 +44,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     markets: getMarketsBalances,
     Comptroller: (...args) => getRewardsBalances(...args, CompoundLens),
   })

--- a/src/adapters/compound/v3/common/lend.ts
+++ b/src/adapters/compound/v3/common/lend.ts
@@ -121,7 +121,6 @@ export async function getAssetsContracts(chain: Chain, contract: Contract): Prom
 
 export async function getLendBorrowBalances(
   ctx: BalancesContext,
-  chain: Chain,
   assets: Contract[],
   contract: Contract,
 ): Promise<Balance[]> {
@@ -129,7 +128,7 @@ export async function getLendBorrowBalances(
 
   const [userCollateralBalancesRes, userBorrowBalancesRes] = await Promise.all([
     multicall({
-      chain,
+      chain: ctx.chain,
       calls: assets.map((asset) => ({
         target: contract.address,
         params: [ctx.address, asset.address],
@@ -138,7 +137,7 @@ export async function getLendBorrowBalances(
     }),
 
     call({
-      chain,
+      chain: ctx.chain,
       target: contract.address,
       params: [ctx.address],
       abi: abi.borrowBalanceOf,
@@ -156,7 +155,7 @@ export async function getLendBorrowBalances(
     const userCollateralBalance = userCollateralBalances[i]
 
     const supply: BalanceWithExtraProps = {
-      chain,
+      chain: ctx.chain,
       decimals: asset.decimals,
       symbol: asset.symbol,
       address: asset.address,
@@ -169,7 +168,7 @@ export async function getLendBorrowBalances(
   }
 
   const borrow: Balance = {
-    chain,
+    chain: ctx.chain,
     decimals: USDC.decimals,
     symbol: USDC.symbol,
     address: USDC.address,

--- a/src/adapters/compound/v3/common/rewards.ts
+++ b/src/adapters/compound/v3/common/rewards.ts
@@ -1,19 +1,17 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { getERC20Details } from '@lib/erc20'
 import { BigNumber } from 'ethers'
 
 export async function getRewardBalances(
   ctx: BalancesContext,
-  chain: Chain,
   rewardContract: Contract,
   coreContract: Contract,
 ): Promise<Balance[]> {
   const rewards: Balance[] = []
 
   const pendingCompRewardsRes = await call({
-    chain,
+    chain: ctx.chain,
     target: rewardContract.address,
     params: [coreContract.address, ctx.address],
     abi: {
@@ -41,11 +39,11 @@ export async function getRewardBalances(
   const pendingCompRewardsToken = pendingCompRewardsRes.output.token
   const pendingCompRewardsBalance = BigNumber.from(pendingCompRewardsRes.output.owed)
 
-  const tokens = await getERC20Details(chain, [pendingCompRewardsToken])
+  const tokens = await getERC20Details(ctx.chain, [pendingCompRewardsToken])
   const token = tokens[0]
 
   rewards.push({
-    chain,
+    chain: ctx.chain,
     decimals: token.decimals,
     symbol: token.symbol,
     address: token.address,

--- a/src/adapters/compound/v3/common/stake.ts
+++ b/src/adapters/compound/v3/common/stake.ts
@@ -1,6 +1,5 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
 import { Token } from '@lib/token'
 import { BigNumber } from 'ethers'
@@ -12,11 +11,11 @@ const USDC: Token = {
   symbol: 'USDC',
 }
 
-export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getStakeBalances(ctx: BalancesContext, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const balanceOfRes = await call({
-    chain,
+    chain: ctx.chain,
     target: contract.address,
     params: [ctx.address],
     abi: abi.balanceOf,
@@ -25,7 +24,7 @@ export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contr
   const amount = BigNumber.from(balanceOfRes.output)
 
   balances.push({
-    chain,
+    chain: ctx.chain,
     address: USDC.address,
     decimals: USDC.decimals,
     symbol: USDC.symbol,

--- a/src/adapters/compound/v3/ethereum/index.ts
+++ b/src/adapters/compound/v3/ethereum/index.ts
@@ -34,7 +34,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     CompoundUSDCv3: getStakeBalances,
     assets: (...args) => getLendBorrowBalances(...args, CompoundUSDCv3),
     CompoundRewards: (...args) => getRewardBalances(...args, CompoundUSDCv3),

--- a/src/adapters/concentrator/ethereum/ifo.ts
+++ b/src/adapters/concentrator/ethereum/ifo.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 
-import { Balance } from '@lib/adapter'
+import { Balance, BalancesContext } from '@lib/adapter'
 import { getERC20Details } from '@lib/erc20'
 import { multicall } from '@lib/multicall'
 import { providers } from '@lib/providers'
@@ -8,7 +8,7 @@ import { BigNumber, ethers } from 'ethers'
 
 import ConcentratorIFOAbi from '../abis/IFO.json'
 
-export async function getIFOBalances(ctx, chain) {
+export async function getIFOBalances(ctx: BalancesContext) {
   const provider = providers['ethereum']
 
   const ifoContract = new ethers.Contract('0x3cf54f3a1969be9916dad548f3c084331c4450b5', ConcentratorIFOAbi, provider)

--- a/src/adapters/concentrator/ethereum/index.ts
+++ b/src/adapters/concentrator/ethereum/index.ts
@@ -18,7 +18,7 @@ export const getContracts = () => {
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, { concentratorIFOContract }) => {
   if (concentratorIFOContract) {
     return {
-      balances: await getIFOBalances(ctx, 'ethereum'),
+      balances: await getIFOBalances(ctx),
     }
   }
 

--- a/src/adapters/convex/ethereum/balances.ts
+++ b/src/adapters/convex/ethereum/balances.ts
@@ -1,29 +1,28 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
-import { Chain } from '@lib/chains'
 import { getUnderlyingsBalancesInPool } from '@lib/convex/underlyings'
 import { getERC20BalanceOf } from '@lib/erc20'
 import { Token } from '@lib/token'
 
 import { getCRVCVXRewards } from './rewards'
 
-export async function getPoolsBalances(ctx: BalancesContext, chain: Chain, contracts: Contract[]) {
+export async function getPoolsBalances(ctx: BalancesContext, contracts: Contract[]) {
   const balances: Balance[] = []
-  const nonZeroPools: Contract[] = (await getERC20BalanceOf(ctx, chain, contracts as Token[])).filter((pool) =>
+  const nonZeroPools: Contract[] = (await getERC20BalanceOf(ctx, contracts as Token[])).filter((pool) =>
     pool.amount.gt(0),
   )
 
   for (const nonZeroPool of nonZeroPools) {
     const underlyiedPoolBalances = await getUnderlyingsBalancesInPool(
-      chain,
+      ctx.chain,
       nonZeroPool,
       nonZeroPool.lpToken,
       nonZeroPool.poolAddress,
     )
 
-    const rewardsBalances = (nonZeroPool.rewards = await getCRVCVXRewards(ctx, chain, nonZeroPool))
+    const rewardsBalances = (nonZeroPool.rewards = await getCRVCVXRewards(ctx, nonZeroPool))
 
     balances.push({
-      chain,
+      chain: ctx.chain,
       address: nonZeroPool.address,
       symbol: underlyiedPoolBalances.map((underlying) => underlying.symbol).join('-'),
       decimals: nonZeroPool.decimals,

--- a/src/adapters/convex/ethereum/index.ts
+++ b/src/adapters/convex/ethereum/index.ts
@@ -60,7 +60,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: getPoolsBalances,
     cvxCRVStaker: getStakeBalances,
     locker: getLockerBalances,

--- a/src/adapters/convex/ethereum/stake.ts
+++ b/src/adapters/convex/ethereum/stake.ts
@@ -1,6 +1,5 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
 import { BigNumber } from 'ethers'
 
@@ -13,24 +12,24 @@ const cvxCRV: Contract = {
   decimals: 18,
 }
 
-export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract) {
+export async function getStakeBalances(ctx: BalancesContext, contract: Contract) {
   const balances: Balance[] = []
 
   const [getBalanceOf, getRewards] = await Promise.all([
     call({
-      chain,
+      chain: ctx.chain,
       target: contract.address,
       params: [ctx.address],
       abi: abi.balanceOf,
     }),
 
-    getCRVCVXRewards(ctx, chain, contract),
+    getCRVCVXRewards(ctx, contract),
   ])
 
   const balanceOf = BigNumber.from(getBalanceOf.output)
 
   balances.push({
-    chain,
+    chain: ctx.chain,
     address: cvxCRV.address,
     symbol: cvxCRV.symbol,
     decimals: cvxCRV.decimals,

--- a/src/adapters/curve/arbitrum/index.ts
+++ b/src/adapters/curve/arbitrum/index.ts
@@ -28,8 +28,8 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'arbitrum', contracts, {
-    pools: (ctx, chain, pools) => getPoolsBalances(ctx, chain, pools, { getPoolAddress: (contract) => contract.pool }),
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    pools: (ctx, pools) => getPoolsBalances(ctx, pools, { getPoolAddress: (contract) => contract.pool }),
     gauges: getGaugesBalances,
   })
 

--- a/src/adapters/curve/avax/index.ts
+++ b/src/adapters/curve/avax/index.ts
@@ -28,8 +28,8 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'avax', contracts, {
-    pools: (ctx, chain, pools) => getPoolsBalances(ctx, chain, pools, { getPoolAddress: (contract) => contract.pool }),
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    pools: (ctx, pools) => getPoolsBalances(ctx, pools, { getPoolAddress: (contract) => contract.pool }),
     gauges: getGaugesBalances,
   })
 

--- a/src/adapters/curve/common/gauges.ts
+++ b/src/adapters/curve/common/gauges.ts
@@ -182,11 +182,11 @@ export async function getGaugesContracts(
   return gaugeContracts
 }
 
-export async function getGaugesBalances(ctx: BalancesContext, chain: Chain, gauges: Contract[]) {
+export async function getGaugesBalances(ctx: BalancesContext, gauges: Contract[]) {
   const gaugesBalances: Balance[] = []
   const calls: Call[] = []
 
-  const gaugesBalancesRes = await getStakingPoolsBalances(ctx, chain, gauges, {
+  const gaugesBalancesRes = await getStakingPoolsBalances(ctx, gauges, {
     getLPTokenAddress: (contract) => contract.lpToken,
     getPoolAddress: (contract) => contract.pool,
   })
@@ -198,7 +198,7 @@ export async function getGaugesBalances(ctx: BalancesContext, chain: Chain, gaug
     }
   }
 
-  const claimableRewards = await multicall({ chain, calls, abi: abi.claimable_reward })
+  const claimableRewards = await multicall({ chain: ctx.chain, calls, abi: abi.claimable_reward })
 
   for (let gaugeIdx = 0; gaugeIdx < gaugesBalancesRes.length; gaugeIdx++) {
     const rewards = gaugesBalancesRes[gaugeIdx].rewards || []

--- a/src/adapters/curve/ethereum/index.ts
+++ b/src/adapters/curve/ethereum/index.ts
@@ -50,8 +50,8 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
-    pools: (ctx, chain, pools) => getPoolsBalances(ctx, chain, pools, { getPoolAddress: (contract) => contract.pool }),
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    pools: (ctx, pools) => getPoolsBalances(ctx, pools, { getPoolAddress: (contract) => contract.pool }),
     gauges: getGaugesBalances,
     locker: (...args) => getLockerBalances(...args, feeDistributor),
   })

--- a/src/adapters/curve/ethereum/locker.ts
+++ b/src/adapters/curve/ethereum/locker.ts
@@ -1,6 +1,5 @@
 import { call } from '@defillama/sdk/build/abi'
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
-import { Chain } from '@lib/chains'
 import { Token } from '@lib/token'
 import { BigNumber } from 'ethers'
 
@@ -24,7 +23,6 @@ const IIICrvToken: Token = {
 
 export async function getLockerBalances(
   ctx: BalancesContext,
-  chain: Chain,
   contract: Contract,
   feeDistributorContract: Contract,
 ): Promise<BalanceWithExtraProps[]> {
@@ -32,7 +30,7 @@ export async function getLockerBalances(
 
   const [lockerBalanceRes, claimableBalanceRes] = await Promise.all([
     call({
-      chain,
+      chain: ctx.chain,
       target: contract.address,
       params: [ctx.address],
       abi: {
@@ -59,7 +57,7 @@ export async function getLockerBalances(
     }),
 
     call({
-      chain,
+      chain: ctx.chain,
       target: feeDistributorContract.address,
       params: [ctx.address],
       abi: {
@@ -87,7 +85,7 @@ export async function getLockerBalances(
   const claimableBalance = BigNumber.from(claimableBalanceRes.output)
 
   balances.push({
-    chain,
+    chain: ctx.chain,
     symbol: CRVToken.symbol,
     decimals: CRVToken.decimals,
     address: CRVToken.address,

--- a/src/adapters/curve/fantom/index.ts
+++ b/src/adapters/curve/fantom/index.ts
@@ -28,8 +28,8 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'fantom', contracts, {
-    pools: (ctx, chain, pools) => getPoolsBalances(ctx, chain, pools, { getPoolAddress: (contract) => contract.pool }),
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    pools: (ctx, pools) => getPoolsBalances(ctx, pools, { getPoolAddress: (contract) => contract.pool }),
     gauges: getGaugesBalances,
   })
 

--- a/src/adapters/curve/optimism/index.ts
+++ b/src/adapters/curve/optimism/index.ts
@@ -28,8 +28,8 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'optimism', contracts, {
-    pools: (ctx, chain, pools) => getPoolsBalances(ctx, chain, pools, { getPoolAddress: (contract) => contract.pool }),
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    pools: (ctx, pools) => getPoolsBalances(ctx, pools, { getPoolAddress: (contract) => contract.pool }),
     gauges: getGaugesBalances,
   })
 

--- a/src/adapters/curve/polygon/index.ts
+++ b/src/adapters/curve/polygon/index.ts
@@ -28,8 +28,8 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'polygon', contracts, {
-    pools: (ctx, chain, pools) => getPoolsBalances(ctx, chain, pools, { getPoolAddress: (contract) => contract.pool }),
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    pools: (ctx, pools) => getPoolsBalances(ctx, pools, { getPoolAddress: (contract) => contract.pool }),
     gauges: getGaugesBalances,
   })
 

--- a/src/adapters/euler/common/markets.ts
+++ b/src/adapters/euler/common/markets.ts
@@ -51,13 +51,9 @@ export async function getMarketsContracts(chain: Chain): Promise<Contract[]> {
   return contracts
 }
 
-export async function getHealthFactor(
-  ctx: BalancesContext,
-  chain: Chain,
-  lensContract: Contract,
-): Promise<number | undefined> {
+export async function getHealthFactor(ctx: BalancesContext, lensContract: Contract): Promise<number | undefined> {
   const getHealthFactor = await call({
-    chain,
+    chain: ctx.chain,
     target: lensContract.address,
     params: [ctx.address],
     abi: {

--- a/src/adapters/euler/ethereum/index.ts
+++ b/src/adapters/euler/ethereum/index.ts
@@ -22,10 +22,10 @@ export const getContracts = async () => {
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: BalancesContext, contracts) => {
   const [balances, healthFactor] = await Promise.all([
-    resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
-      markets: (ctx, chain, contracts) => getERC20BalanceOf(ctx, chain, contracts as Token[]),
+    resolveBalances<typeof getContracts>(ctx, contracts, {
+      markets: (ctx, contracts) => getERC20BalanceOf(ctx, contracts as Token[]),
     }),
-    getHealthFactor(ctx, 'ethereum', lens),
+    getHealthFactor(ctx, lens),
   ])
 
   return {

--- a/src/adapters/floor-dao/ethereum/index.ts
+++ b/src/adapters/floor-dao/ethereum/index.ts
@@ -36,7 +36,7 @@ export const getContracts = () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     sFLOOR: getStakeBalances,
     gFLOOR: getFormattedStakeBalances,
   })

--- a/src/adapters/floor-dao/ethereum/stake.ts
+++ b/src/adapters/floor-dao/ethereum/stake.ts
@@ -1,7 +1,6 @@
 import { Balance, Contract } from '@lib/adapter'
 import { BalancesContext } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
 import { BigNumber } from 'ethers/lib/ethers'
 
@@ -13,11 +12,11 @@ const FLOOR: Contract = {
   symbol: 'FLOOR ',
 }
 
-export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getStakeBalances(ctx: BalancesContext, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const balanceOfRes = await call({
-    chain,
+    chain: ctx.chain,
     target: contract.address,
     params: [ctx.address],
     abi: abi.balanceOf,
@@ -26,7 +25,7 @@ export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contr
   const amount = BigNumber.from(balanceOfRes.output)
 
   balances.push({
-    chain,
+    chain: ctx.chain,
     address: contract.address,
     symbol: contract.symbol,
     decimals: 9,
@@ -38,15 +37,11 @@ export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contr
   return balances
 }
 
-export async function getFormattedStakeBalances(
-  ctx: BalancesContext,
-  chain: Chain,
-  contract: Contract,
-): Promise<Balance[]> {
+export async function getFormattedStakeBalances(ctx: BalancesContext, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const balanceOfRes = await call({
-    chain,
+    chain: ctx.chain,
     target: contract.address,
     params: [ctx.address],
     abi: abi.balanceOf,
@@ -55,7 +50,7 @@ export async function getFormattedStakeBalances(
   const balanceOf = balanceOfRes.output
 
   const formattedBalanceOfRes = await call({
-    chain,
+    chain: ctx.chain,
     target: contract.address,
     params: [balanceOf],
     abi: {
@@ -70,7 +65,7 @@ export async function getFormattedStakeBalances(
   const formattedBalanceOf = BigNumber.from(formattedBalanceOfRes.output)
 
   balances.push({
-    chain,
+    chain: ctx.chain,
     address: contract.address,
     symbol: contract.symbol,
     decimals: 9,

--- a/src/adapters/fraxlend/ethereum/index.ts
+++ b/src/adapters/fraxlend/ethereum/index.ts
@@ -24,7 +24,7 @@ export const getContracts: GetContractsHandler = async (ctx) => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: BalancesContext, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pairs: (...args) => getLendBorrowBalances(...args, FRAX),
   })
 

--- a/src/adapters/fraxlend/ethereum/lend.ts
+++ b/src/adapters/fraxlend/ethereum/lend.ts
@@ -1,5 +1,4 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
-import { Chain } from '@lib/chains'
 import { multicall } from '@lib/multicall'
 import { isSuccess } from '@lib/type'
 import { BigNumber } from 'ethers'
@@ -18,11 +17,11 @@ const abi = {
   },
 }
 
-export const getLendBorrowBalances = async (ctx: BalancesContext, chain: Chain, pairs: Contract[], FRAX: Contract) => {
+export const getLendBorrowBalances = async (ctx: BalancesContext, pairs: Contract[], FRAX: Contract) => {
   const balances: Balance[] = []
 
   const userSnapshotsRes = await multicall({
-    chain,
+    chain: ctx.chain,
     calls: pairs.map((pair) => ({
       target: pair.address,
       params: [ctx.address],
@@ -40,7 +39,7 @@ export const getLendBorrowBalances = async (ctx: BalancesContext, chain: Chain, 
       const userCollateralBalance = BigNumber.from(userSnapshotRes.output._userCollateralBalance)
 
       const asset: Balance = {
-        chain,
+        chain: ctx.chain,
         decimals: pair.decimals,
         symbol: pair.symbol,
         address: pair.address,
@@ -52,7 +51,7 @@ export const getLendBorrowBalances = async (ctx: BalancesContext, chain: Chain, 
       balances.push(asset)
 
       const collateral: Balance = {
-        chain,
+        chain: ctx.chain,
         decimals: pair.decimals,
         symbol: pair.symbol,
         address: pair.address,
@@ -64,7 +63,7 @@ export const getLendBorrowBalances = async (ctx: BalancesContext, chain: Chain, 
       balances.push(collateral)
 
       const borrow: Balance = {
-        chain,
+        chain: ctx.chain,
         decimals: pair.decimals,
         symbol: pair.symbol,
         address: pair.address,

--- a/src/adapters/geist/fantom/index.ts
+++ b/src/adapters/geist/fantom/index.ts
@@ -1,7 +1,6 @@
 import { getLendingPoolHealthFactor } from '@lib/aave/v2/lending'
 import { BalancesContext, Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
-import { Chain } from '@lib/chains'
 import { getLendingPoolBalances, getLendingPoolContracts } from '@lib/geist/lending'
 import { getMultiFeeDistributionBalances } from '@lib/geist/stake'
 import { Token } from '@lib/token'
@@ -48,10 +47,10 @@ export const getContracts = async () => {
   }
 }
 
-function getLendingBalances(ctx: BalancesContext, chain: Chain, pools: Contract[], allPools: Contract[]) {
+function getLendingBalances(ctx: BalancesContext, pools: Contract[], allPools: Contract[]) {
   return Promise.all([
-    getLendingPoolBalances(ctx, chain, pools, { chefIncentivesController: chefIncentivesControllerContract }),
-    getMultiFeeDistributionBalances(ctx, chain, allPools, {
+    getLendingPoolBalances(ctx, pools, { chefIncentivesController: chefIncentivesControllerContract }),
+    getMultiFeeDistributionBalances(ctx, allPools, {
       multiFeeDistribution: multiFeeDistributionContract,
       lendingPool: lendingPoolContract,
       stakingToken: geistToken,
@@ -61,10 +60,10 @@ function getLendingBalances(ctx: BalancesContext, chain: Chain, pools: Contract[
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts, props) => {
   const [balances, healthFactor] = await Promise.all([
-    resolveBalances<typeof getContracts>(ctx, 'fantom', contracts, {
-      pools: (ctx, chain, pools) => getLendingBalances(ctx, chain, pools, props.pools || []),
+    resolveBalances<typeof getContracts>(ctx, contracts, {
+      pools: (ctx, pools) => getLendingBalances(ctx, pools, props.pools || []),
     }),
-    getLendingPoolHealthFactor(ctx, 'fantom', lendingPoolContract),
+    getLendingPoolHealthFactor(ctx, lendingPoolContract),
   ])
 
   return {

--- a/src/adapters/gmx/arbitrum/index.ts
+++ b/src/adapters/gmx/arbitrum/index.ts
@@ -19,7 +19,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'arbitrum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     gmxVester: getGMXVesterBalance,
     gmxStaker: getGMXStakerBalances,
     glpStaker: getGLPStakerBalance,

--- a/src/adapters/gmx/avax/index.ts
+++ b/src/adapters/gmx/avax/index.ts
@@ -19,7 +19,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'avax', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     gmxVester: getGMXVesterBalance,
     gmxStaker: getGMXStakerBalances,
     glpStaker: getGLPStakerBalance,

--- a/src/adapters/granary-finance/avax/index.ts
+++ b/src/adapters/granary-finance/avax/index.ts
@@ -20,10 +20,10 @@ export const getContracts = async () => {
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
   const [balances, healthFactor] = await Promise.all([
-    resolveBalances<typeof getContracts>(ctx, 'avax', contracts, {
+    resolveBalances<typeof getContracts>(ctx, contracts, {
       pools: getLendingPoolBalances,
     }),
-    getLendingPoolHealthFactor(ctx, 'avax', lendingPool),
+    getLendingPoolHealthFactor(ctx, lendingPool),
   ])
 
   return {

--- a/src/adapters/granary-finance/ethereum/index.ts
+++ b/src/adapters/granary-finance/ethereum/index.ts
@@ -20,10 +20,10 @@ export const getContracts = async () => {
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
   const [balances, healthFactor] = await Promise.all([
-    resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+    resolveBalances<typeof getContracts>(ctx, contracts, {
       pools: getLendingPoolBalances,
     }),
-    getLendingPoolHealthFactor(ctx, 'ethereum', lendingPool),
+    getLendingPoolHealthFactor(ctx, lendingPool),
   ])
 
   return {

--- a/src/adapters/granary-finance/fantom/index.ts
+++ b/src/adapters/granary-finance/fantom/index.ts
@@ -20,10 +20,10 @@ export const getContracts = async () => {
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
   const [balances, healthFactor] = await Promise.all([
-    resolveBalances<typeof getContracts>(ctx, 'fantom', contracts, {
+    resolveBalances<typeof getContracts>(ctx, contracts, {
       pools: getLendingPoolBalances,
     }),
-    getLendingPoolHealthFactor(ctx, 'fantom', lendingPool),
+    getLendingPoolHealthFactor(ctx, lendingPool),
   ])
 
   return {

--- a/src/adapters/granary-finance/optimism/index.ts
+++ b/src/adapters/granary-finance/optimism/index.ts
@@ -20,10 +20,10 @@ export const getContracts = async () => {
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
   const [balances, healthFactor] = await Promise.all([
-    resolveBalances<typeof getContracts>(ctx, 'optimism', contracts, {
+    resolveBalances<typeof getContracts>(ctx, contracts, {
       pools: getLendingPoolBalances,
     }),
-    getLendingPoolHealthFactor(ctx, 'optimism', lendingPool),
+    getLendingPoolHealthFactor(ctx, lendingPool),
   ])
 
   return {

--- a/src/adapters/hector-network/fantom/farm.ts
+++ b/src/adapters/hector-network/fantom/farm.ts
@@ -1,6 +1,5 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { BigNumber } from 'ethers'
 
 const Helper: Contract = {
@@ -49,12 +48,12 @@ const Curve_fiFactoryUSDMetapool: Contract = {
   rewards: [wFTM],
 }
 
-export async function getFarmingBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getFarmingBalances(ctx: BalancesContext, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const [balanceOfRes, shareRes] = await Promise.all([
     call({
-      chain,
+      chain: ctx.chain,
       target: contract.address,
       params: [ctx.address],
       abi: {
@@ -88,7 +87,7 @@ export async function getFarmingBalances(ctx: BalancesContext, chain: Chain, con
     }),
 
     call({
-      chain,
+      chain: ctx.chain,
       target: Helper.address,
       params: [],
       abi: {
@@ -122,7 +121,7 @@ export async function getFarmingBalances(ctx: BalancesContext, chain: Chain, con
 
   balances.push({
     address: Curve_fiFactoryUSDMetapool.address,
-    chain,
+    chain: ctx.chain,
     amount,
     symbol: `TOR-DAI-USDC`,
     decimals: 18,

--- a/src/adapters/hector-network/fantom/index.ts
+++ b/src/adapters/hector-network/fantom/index.ts
@@ -83,7 +83,7 @@ export const getContracts = () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'fantom', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     sHEC: getsStakeBalances,
     wsHEC: getWsStakeBalances,
     StakingGateway: getFarmingBalances,

--- a/src/adapters/hector-network/fantom/stake.ts
+++ b/src/adapters/hector-network/fantom/stake.ts
@@ -1,6 +1,5 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
 import { BigNumber } from 'ethers'
 
@@ -12,9 +11,9 @@ const HEC: Contract = {
   symbol: 'HEC',
 }
 
-export async function getsStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance> {
+export async function getsStakeBalances(ctx: BalancesContext, contract: Contract): Promise<Balance> {
   const balanceOfRes = await call({
-    chain,
+    chain: ctx.chain,
     target: contract.address,
     params: [ctx.address],
     abi: abi.balanceOf,
@@ -23,7 +22,7 @@ export async function getsStakeBalances(ctx: BalancesContext, chain: Chain, cont
   const amount = BigNumber.from(balanceOfRes.output)
 
   const balance: Balance = {
-    chain,
+    chain: ctx.chain,
     address: contract.address,
     symbol: contract.symbol,
     decimals: 9,
@@ -35,9 +34,9 @@ export async function getsStakeBalances(ctx: BalancesContext, chain: Chain, cont
   return balance
 }
 
-export async function getWsStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance> {
+export async function getWsStakeBalances(ctx: BalancesContext, contract: Contract): Promise<Balance> {
   const balanceOfRes = await call({
-    chain,
+    chain: ctx.chain,
     target: contract.address,
     params: [ctx.address],
     abi: abi.balanceOf,
@@ -46,7 +45,7 @@ export async function getWsStakeBalances(ctx: BalancesContext, chain: Chain, con
   const balanceOf = balanceOfRes.output
 
   const formattedBalanceOfRes = await call({
-    chain,
+    chain: ctx.chain,
     target: contract.address,
     params: [balanceOf],
     abi: {
@@ -61,7 +60,7 @@ export async function getWsStakeBalances(ctx: BalancesContext, chain: Chain, con
   const amount = BigNumber.from(formattedBalanceOfRes.output)
 
   const balance: Balance = {
-    chain,
+    chain: ctx.chain,
     address: contract.address,
     symbol: contract.symbol,
     decimals: 9,

--- a/src/adapters/hex/ethereum/index.ts
+++ b/src/adapters/hex/ethereum/index.ts
@@ -18,7 +18,7 @@ export const getContracts = () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     HEX: getStakeBalances,
   })
 

--- a/src/adapters/hex/ethereum/stake.ts
+++ b/src/adapters/hex/ethereum/stake.ts
@@ -1,17 +1,16 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { range } from '@lib/array'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { sumBN } from '@lib/math'
 import { multicall } from '@lib/multicall'
 
 import { getRewardsBalances } from './reward'
 
-export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getStakeBalances(ctx: BalancesContext, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const stakeCountRes = await call({
-    chain,
+    chain: ctx.chain,
     target: contract.address,
     params: [ctx.address],
     abi: {
@@ -26,7 +25,7 @@ export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contr
   })
 
   const findStakesAndIndexesRes = await multicall({
-    chain,
+    chain: ctx.chain,
     calls: range(0, stakeCountRes.output).map((i) => ({
       target: contract.address,
       params: [ctx.address, i],
@@ -66,18 +65,18 @@ export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contr
 
   const amount = sumBN(stakesAndIndexes.map((balance) => balance.stake))
 
-  const rewards = await getRewardsBalances(chain, contract, stakesAndIndexes)
+  const rewards = await getRewardsBalances(ctx.chain, contract, stakesAndIndexes)
   const totalRewards = sumBN(rewards)
 
   balances.push({
-    chain,
+    chain: ctx.chain,
     decimals: contract.decimals,
     symbol: contract.symbol,
     address: contract.address,
     amount,
     rewards: [
       {
-        chain,
+        chain: ctx.chain,
         decimals: contract.decimals,
         symbol: contract.symbol,
         address: contract.address,

--- a/src/adapters/hundred-finance/arbitrum/index.ts
+++ b/src/adapters/hundred-finance/arbitrum/index.ts
@@ -27,7 +27,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'arbitrum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: getMarketsBalances,
   })
 

--- a/src/adapters/hundred-finance/ethereum/index.ts
+++ b/src/adapters/hundred-finance/ethereum/index.ts
@@ -27,7 +27,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: getMarketsBalances,
   })
 

--- a/src/adapters/hundred-finance/fantom/index.ts
+++ b/src/adapters/hundred-finance/fantom/index.ts
@@ -27,7 +27,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'fantom', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: getMarketsBalances,
   })
 

--- a/src/adapters/hundred-finance/optimism/index.ts
+++ b/src/adapters/hundred-finance/optimism/index.ts
@@ -27,7 +27,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'optimism', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: getMarketsBalances,
   })
 

--- a/src/adapters/hundred-finance/polygon/index.ts
+++ b/src/adapters/hundred-finance/polygon/index.ts
@@ -27,7 +27,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'polygon', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: getMarketsBalances,
   })
 

--- a/src/adapters/inverse-finance/ethereum/index.ts
+++ b/src/adapters/inverse-finance/ethereum/index.ts
@@ -23,7 +23,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: getMarketsBalances,
   })
 

--- a/src/adapters/iron-bank/avax/index.ts
+++ b/src/adapters/iron-bank/avax/index.ts
@@ -19,7 +19,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'avax', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     markets: getMarketsBalances,
   })
 

--- a/src/adapters/iron-bank/ethereum/index.ts
+++ b/src/adapters/iron-bank/ethereum/index.ts
@@ -19,7 +19,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     markets: getMarketsBalances,
   })
 

--- a/src/adapters/iron-bank/fantom/index.ts
+++ b/src/adapters/iron-bank/fantom/index.ts
@@ -19,7 +19,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'fantom', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     markets: getMarketsBalances,
   })
 

--- a/src/adapters/iron-bank/optimism/index.ts
+++ b/src/adapters/iron-bank/optimism/index.ts
@@ -19,7 +19,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'optimism', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     markets: getMarketsBalances,
   })
 

--- a/src/adapters/klima-dao/common/stake.ts
+++ b/src/adapters/klima-dao/common/stake.ts
@@ -1,7 +1,6 @@
 import { Balance, Contract } from '@lib/adapter'
 import { BalancesContext } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
 import { BigNumber } from 'ethers/lib/ethers'
 
@@ -14,9 +13,9 @@ const KLIMA: Contract = {
   decimals: 9,
 }
 
-export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance> {
+export async function getStakeBalances(ctx: BalancesContext, contract: Contract): Promise<Balance> {
   const balanceOfRes = await call({
-    chain,
+    chain: ctx.chain,
     target: contract.address,
     params: [ctx.address],
     abi: abi.balanceOf,
@@ -25,7 +24,7 @@ export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contr
   const amount = BigNumber.from(balanceOfRes.output)
 
   const balance: Balance = {
-    chain,
+    chain: ctx.chain,
     address: contract.address,
     decimals: contract.decimals,
     symbol: contract.symbol,
@@ -37,9 +36,9 @@ export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contr
   return balance
 }
 
-export async function getFormattedStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance> {
+export async function getFormattedStakeBalances(ctx: BalancesContext, contract: Contract): Promise<Balance> {
   const balanceOfRes = await call({
-    chain,
+    chain: ctx.chain,
     target: contract.address,
     params: [ctx.address],
     abi: abi.balanceOf,
@@ -48,7 +47,7 @@ export async function getFormattedStakeBalances(ctx: BalancesContext, chain: Cha
   const balanceOf = balanceOfRes.output
 
   const formattedBalanceOfRes = await call({
-    chain,
+    chain: ctx.chain,
     target: contract.address,
     params: [balanceOf],
     abi: {
@@ -63,7 +62,7 @@ export async function getFormattedStakeBalances(ctx: BalancesContext, chain: Cha
   const formattedBalanceOf = BigNumber.from(formattedBalanceOfRes.output)
 
   const balance: Balance = {
-    chain,
+    chain: ctx.chain,
     address: contract.address,
     symbol: contract.symbol,
     decimals: 9,

--- a/src/adapters/klima-dao/polygon/index.ts
+++ b/src/adapters/klima-dao/polygon/index.ts
@@ -36,7 +36,7 @@ export const getContracts = () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'polygon', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     sKLIMA: getStakeBalances,
     wsKLIMA: getFormattedStakeBalances,
   })

--- a/src/adapters/lido/arbitrum/index.ts
+++ b/src/adapters/lido/arbitrum/index.ts
@@ -30,7 +30,7 @@ export const getContracts = () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'arbitrum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     wstETHArbitrum: getWStEthStakeBalances,
   })
 

--- a/src/adapters/lido/common/stake.ts
+++ b/src/adapters/lido/common/stake.ts
@@ -1,14 +1,13 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
 import { BigNumber } from 'ethers'
 
-export async function getWStEthStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getWStEthStakeBalances(ctx: BalancesContext, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const balanceOfRes = await call({
-    chain,
+    chain: ctx.chain,
     target: contract.address,
     params: [ctx.address],
     abi: abi.balanceOf,
@@ -32,7 +31,7 @@ export async function getWStEthStakeBalances(ctx: BalancesContext, chain: Chain,
 
   if (underlying) {
     balances.push({
-      chain,
+      chain: ctx.chain,
       decimals: contract.decimals,
       symbol: contract.symbol,
       address: contract.address,
@@ -45,11 +44,11 @@ export async function getWStEthStakeBalances(ctx: BalancesContext, chain: Chain,
   return balances
 }
 
-export async function getStEthStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getStEthStakeBalances(ctx: BalancesContext, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const balanceOfRes = await call({
-    chain,
+    chain: ctx.chain,
     target: contract.address,
     params: [ctx.address],
     abi: abi.balanceOf,
@@ -60,7 +59,7 @@ export async function getStEthStakeBalances(ctx: BalancesContext, chain: Chain, 
 
   if (underlying) {
     balances.push({
-      chain,
+      chain: ctx.chain,
       decimals: contract.decimals,
       symbol: contract.symbol,
       address: contract.address,
@@ -73,18 +72,18 @@ export async function getStEthStakeBalances(ctx: BalancesContext, chain: Chain, 
   return balances
 }
 
-export async function getStMaticBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getStMaticBalances(ctx: BalancesContext, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const balanceOfRes = await call({
-    chain,
+    chain: ctx.chain,
     target: contract.address,
     params: [ctx.address],
     abi: abi.balanceOf,
   })
 
   const converterWStEthToStEthRes = await call({
-    chain,
+    chain: ctx.chain,
     target: contract.address,
     params: [balanceOfRes.output],
     abi: {
@@ -105,7 +104,7 @@ export async function getStMaticBalances(ctx: BalancesContext, chain: Chain, con
 
   if (underlying) {
     balances.push({
-      chain,
+      chain: ctx.chain,
       decimals: contract.decimals,
       symbol: contract.symbol,
       address: contract.address,

--- a/src/adapters/lido/ethereum/index.ts
+++ b/src/adapters/lido/ethereum/index.ts
@@ -63,7 +63,7 @@ export const getContracts = () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     stETH: getStEthStakeBalances,
     wstETH: getWStEthStakeBalances,
     stMATICEthereum: getStMaticBalances,

--- a/src/adapters/lido/optimism/index.ts
+++ b/src/adapters/lido/optimism/index.ts
@@ -30,7 +30,7 @@ export const getContracts = () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'optimism', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     wstETHOptimism: getWStEthStakeBalances,
   })
 

--- a/src/adapters/life-dao/avax/index.ts
+++ b/src/adapters/life-dao/avax/index.ts
@@ -27,7 +27,7 @@ export const getContracts = () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'avax', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     sLF: getStakeBalances,
   })
 

--- a/src/adapters/life-dao/common/stake.ts
+++ b/src/adapters/life-dao/common/stake.ts
@@ -1,7 +1,6 @@
 import { Balance, Contract } from '@lib/adapter'
 import { BalancesContext } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
 import { BigNumber } from 'ethers/lib/ethers'
 
@@ -13,11 +12,11 @@ const LF: Contract = {
   decimals: 9,
 }
 
-export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getStakeBalances(ctx: BalancesContext, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const balanceOfRes = await call({
-    chain,
+    chain: ctx.chain,
     target: contract.address,
     params: [ctx.address],
     abi: abi.balanceOf,
@@ -26,7 +25,7 @@ export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contr
   const amount = BigNumber.from(balanceOfRes.output)
 
   balances.push({
-    chain,
+    chain: ctx.chain,
     address: contract.address,
     decimals: contract.decimals,
     symbol: contract.symbol,

--- a/src/adapters/liquity/ethereum/farm.ts
+++ b/src/adapters/liquity/ethereum/farm.ts
@@ -1,12 +1,11 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
-import { Chain } from '@lib/chains'
 import { providers } from '@lib/providers'
 import { BigNumber, ethers } from 'ethers'
 
 import StabilityPoolAbi from '../abis/StabilityPool.json'
 
-export async function getFarmBalance(ctx: BalancesContext, chain: Chain, stabilityPool: Contract) {
-  const provider = providers[chain]
+export async function getFarmBalance(ctx: BalancesContext, stabilityPool: Contract) {
+  const provider = providers[ctx.chain]
 
   const StabilityPool = new ethers.Contract(stabilityPool.address, StabilityPoolAbi, provider)
 
@@ -19,7 +18,7 @@ export async function getFarmBalance(ctx: BalancesContext, chain: Chain, stabili
   const amount = BigNumber.from(LUSDBalance)
 
   const balance: Balance = {
-    chain: chain,
+    chain: ctx.chain,
     category: 'farm',
     address: stabilityPool.address,
     symbol: 'LUSD',
@@ -28,7 +27,7 @@ export async function getFarmBalance(ctx: BalancesContext, chain: Chain, stabili
     stable: true,
     underlyings: [
       {
-        chain,
+        chain: ctx.chain,
         address: '0x5f98805a4e8be255a32880fdec7f6728c6568ba0',
         name: 'LUSD',
         symbol: 'LUSD',
@@ -39,14 +38,14 @@ export async function getFarmBalance(ctx: BalancesContext, chain: Chain, stabili
     ],
     rewards: [
       {
-        chain,
+        chain: ctx.chain,
         symbol: 'LQTY',
         decimals: 18,
         address: '0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d',
         amount: BigNumber.from(LQTYBalance),
       },
       {
-        chain,
+        chain: ctx.chain,
         symbol: 'ETH',
         decimals: 18,
         address: '0x0000000000000000000000000000000000000000',

--- a/src/adapters/liquity/ethereum/index.ts
+++ b/src/adapters/liquity/ethereum/index.ts
@@ -57,7 +57,7 @@ export const getContracts = () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     stabilityPool: getFarmBalance,
     troveManager: getLendBalances,
     lqtyStaking: getStakeBalances,

--- a/src/adapters/liquity/ethereum/lend.ts
+++ b/src/adapters/liquity/ethereum/lend.ts
@@ -1,13 +1,12 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { BigNumber } from 'ethers'
 
-export async function getLendBalances(ctx: BalancesContext, chain: Chain, troveManager: Contract) {
+export async function getLendBalances(ctx: BalancesContext, troveManager: Contract) {
   const balances: Balance[] = []
 
   const troveDetailsRes = await call({
-    chain,
+    chain: ctx.chain,
     target: troveManager.address,
     params: [ctx.address],
     abi: {
@@ -54,7 +53,7 @@ export async function getLendBalances(ctx: BalancesContext, chain: Chain, troveM
   const troveDetails = troveDetailsRes.output
 
   balances.push({
-    chain: chain,
+    chain: ctx.chain,
     category: 'lend',
     symbol: 'ETH',
     decimals: 18,
@@ -63,7 +62,7 @@ export async function getLendBalances(ctx: BalancesContext, chain: Chain, troveM
   })
 
   balances.push({
-    chain: chain,
+    chain: ctx.chain,
     category: 'borrow',
     symbol: 'LUSD',
     decimals: 18,

--- a/src/adapters/liquity/ethereum/stake.ts
+++ b/src/adapters/liquity/ethereum/stake.ts
@@ -1,12 +1,11 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
-import { Chain } from '@lib/chains'
 import { providers } from '@lib/providers'
 import { BigNumber, ethers } from 'ethers'
 
 import LQTYStakingAbi from '../abis/LQTYStaking.json'
 
-export async function getStakeBalances(ctx: BalancesContext, chain: Chain, lqtyStaking: Contract) {
-  const provider = providers[chain]
+export async function getStakeBalances(ctx: BalancesContext, lqtyStaking: Contract) {
+  const provider = providers[ctx.chain]
 
   const LQTYStaking = new ethers.Contract(lqtyStaking.address, LQTYStakingAbi, provider)
 
@@ -19,7 +18,7 @@ export async function getStakeBalances(ctx: BalancesContext, chain: Chain, lqtyS
   const amount = BigNumber.from(LQTYBalance)
 
   const balance: Balance = {
-    chain: chain,
+    chain: ctx.chain,
     category: 'stake',
     address: lqtyStaking.address,
     symbol: 'LQTY',
@@ -27,7 +26,7 @@ export async function getStakeBalances(ctx: BalancesContext, chain: Chain, lqtyS
     amount,
     underlyings: [
       {
-        chain,
+        chain: ctx.chain,
         address: '0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D',
         name: 'LQTY',
         symbol: 'LQTY',
@@ -37,7 +36,7 @@ export async function getStakeBalances(ctx: BalancesContext, chain: Chain, lqtyS
     ],
     rewards: [
       {
-        chain,
+        chain: ctx.chain,
         symbol: 'LUSD',
         decimals: 18,
         address: '0x5f98805a4e8be255a32880fdec7f6728c6568ba0',
@@ -45,7 +44,7 @@ export async function getStakeBalances(ctx: BalancesContext, chain: Chain, lqtyS
         stable: true,
       },
       {
-        chain,
+        chain: ctx.chain,
         symbol: 'ETH',
         decimals: 18,
         address: '0x0000000000000000000000000000000000000000',

--- a/src/adapters/looksrare/ethereum/balances.ts
+++ b/src/adapters/looksrare/ethereum/balances.ts
@@ -1,7 +1,6 @@
 import { BalancesContext, Contract } from '@lib/adapter'
 import { Balance } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { BigNumber } from 'ethers'
 
 const LOOKS: Contract = {
@@ -20,10 +19,10 @@ const WETH: Contract = {
   symbols: 'WETH',
 }
 
-export const getStakeBalances = async (ctx: BalancesContext, chain: Chain, stakingContract: Contract) => {
+export const getStakeBalances = async (ctx: BalancesContext, stakingContract: Contract) => {
   const [stakeBalanceOfRes, rewardsBalanceOfRes] = await Promise.all([
     call({
-      chain,
+      chain: ctx.chain,
       target: stakingContract.address,
       params: ctx.address,
       abi: {
@@ -36,7 +35,7 @@ export const getStakeBalances = async (ctx: BalancesContext, chain: Chain, staki
     }),
 
     call({
-      chain,
+      chain: ctx.chain,
       target: stakingContract.address,
       params: ctx.address,
       abi: {
@@ -53,7 +52,7 @@ export const getStakeBalances = async (ctx: BalancesContext, chain: Chain, staki
   const rewardsBalanceOf = BigNumber.from(rewardsBalanceOfRes.output)
 
   const stakebalance: Balance = {
-    chain,
+    chain: ctx.chain,
     address: LOOKS.address,
     decimals: LOOKS.decimals,
     symbol: LOOKS.symbols,
@@ -65,9 +64,9 @@ export const getStakeBalances = async (ctx: BalancesContext, chain: Chain, staki
   return stakebalance
 }
 
-export const getCompounderBalances = async (ctx: BalancesContext, chain: Chain, compounder: Contract) => {
+export const getCompounderBalances = async (ctx: BalancesContext, compounder: Contract) => {
   const sharesValue = await call({
-    chain,
+    chain: ctx.chain,
     target: compounder.address,
     params: [ctx.address],
     abi: {
@@ -80,7 +79,7 @@ export const getCompounderBalances = async (ctx: BalancesContext, chain: Chain, 
   })
 
   const compounderBalance: Balance = {
-    chain,
+    chain: ctx.chain,
     address: LOOKS.address,
     decimals: LOOKS.decimals,
     symbol: LOOKS.symbols,

--- a/src/adapters/looksrare/ethereum/index.ts
+++ b/src/adapters/looksrare/ethereum/index.ts
@@ -31,7 +31,7 @@ export const getContracts = () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     staking: getStakeBalances,
     compounder: getCompounderBalances,
   })

--- a/src/adapters/lusd-chickenbonds/ethereum/index.ts
+++ b/src/adapters/lusd-chickenbonds/ethereum/index.ts
@@ -14,7 +14,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts, props) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     chickenBondManager: (ctx) => getActiveBondsBalances(ctx, props.bondNFT),
   })
 

--- a/src/adapters/makerdao/ethereum/index.ts
+++ b/src/adapters/makerdao/ethereum/index.ts
@@ -59,8 +59,8 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const proxies = (
     await Promise.all(
       [
-        props.MakerProxyRegistry ? getMakerContracts(ctx, 'ethereum', MakerProxyRegistry) : null,
-        props.InstadAppProxyRegistry ? getInstaDappContracts(ctx, 'ethereum', InstadAppProxyRegistry) : null,
+        props.MakerProxyRegistry ? getMakerContracts(ctx, MakerProxyRegistry) : null,
+        props.InstadAppProxyRegistry ? getInstaDappContracts(ctx, InstadAppProxyRegistry) : null,
       ].filter(isNotNullish),
     )
   ).flat()

--- a/src/adapters/makerdao/ethereum/proxies.ts
+++ b/src/adapters/makerdao/ethereum/proxies.ts
@@ -1,6 +1,5 @@
 import { BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { multicall } from '@lib/multicall'
 import { ethers } from 'ethers'
 
@@ -47,13 +46,9 @@ const abi = {
   },
 }
 
-export async function getInstaDappContracts(
-  ctx: BalancesContext,
-  chain: Chain,
-  instaList: Contract,
-): Promise<Contract[]> {
+export async function getInstaDappContracts(ctx: BalancesContext, instaList: Contract): Promise<Contract[]> {
   const getUserLinkCountFromInstadApp = await call({
-    chain,
+    chain: ctx.chain,
     target: instaList.address,
     params: [ctx.address],
     abi: abi.userLink,
@@ -67,7 +62,7 @@ export async function getInstaDappContracts(
 
   for (let i = 1; i < userLinkCount; i++) {
     const userLinksRes = await call({
-      chain,
+      chain: ctx.chain,
       target: instaList.address,
       // Previous value gives access to the next one Id
       params: [ctx.address, ids[ids.length - 1]],
@@ -78,7 +73,7 @@ export async function getInstaDappContracts(
   }
 
   const getInstadAppAddressesProxiesFromId = await multicall({
-    chain,
+    chain: ctx.chain,
     calls: ids.map((id) => ({
       target: instaList.address,
       params: [id],
@@ -92,20 +87,16 @@ export async function getInstaDappContracts(
     .filter((res) => res !== ethers.constants.AddressZero)
 
   return instadAppAddressesProxiesFromId.map((address) => ({
-    chain,
+    chain: ctx.chain,
     address,
     proxy: 'InstaDapp',
   }))
 }
 
-export async function getMakerContracts(
-  ctx: BalancesContext,
-  chain: Chain,
-  proxyRegistry: Contract,
-): Promise<Contract[]> {
+export async function getMakerContracts(ctx: BalancesContext, proxyRegistry: Contract): Promise<Contract[]> {
   // Check if user's address uses Maker proxies
   const proxiesRes = await call({
-    chain,
+    chain: ctx.chain,
     target: proxyRegistry.address,
     params: [ctx.address],
     abi: abi.proxies,
@@ -114,7 +105,7 @@ export async function getMakerContracts(
   return [proxiesRes.output]
     .filter((res) => res !== ethers.constants.AddressZero)
     .map((address) => ({
-      chain,
+      chain: ctx.chain,
       address,
     }))
 }

--- a/src/adapters/maple/ethereum/farm.ts
+++ b/src/adapters/maple/ethereum/farm.ts
@@ -75,13 +75,13 @@ export async function getFarmContracts(chain: Chain, contract: Contract): Promis
   return contracts
 }
 
-export async function getFarmBalances(ctx: BalancesContext, chain: Chain, contracts: Contract[]): Promise<Balance[]> {
+export async function getFarmBalances(ctx: BalancesContext, contracts: Contract[]): Promise<Balance[]> {
   const farmBalances: Balance[] = []
 
-  const balances = await getERC20BalanceOf(ctx, chain, contracts as Token[])
+  const balances = await getERC20BalanceOf(ctx, contracts as Token[])
 
   const getRewards = await multicall({
-    chain,
+    chain: ctx.chain,
     calls: balances.map((balance) => ({
       target: balance.address,
       params: [ctx.address],

--- a/src/adapters/maple/ethereum/index.ts
+++ b/src/adapters/maple/ethereum/index.ts
@@ -18,7 +18,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: getFarmBalances,
   })
 

--- a/src/adapters/nemesis-dao/bsc/balances.ts
+++ b/src/adapters/nemesis-dao/bsc/balances.ts
@@ -1,6 +1,5 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
 import { BigNumber } from 'ethers'
 
@@ -12,11 +11,11 @@ const NMS: Contract = {
   symbol: 'NMS',
 }
 
-export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getStakeBalances(ctx: BalancesContext, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const balanceOfRes = await call({
-    chain,
+    chain: ctx.chain,
     target: contract.address,
     params: [ctx.address],
     abi: abi.balanceOf,
@@ -25,7 +24,7 @@ export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contr
   const balanceOf = BigNumber.from(balanceOfRes.output)
 
   balances.push({
-    chain,
+    chain: ctx.chain,
     address: contract.address,
     symbol: contract.symbol,
     decimals: 9,

--- a/src/adapters/nemesis-dao/bsc/index.ts
+++ b/src/adapters/nemesis-dao/bsc/index.ts
@@ -27,7 +27,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'bsc', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     sNMS: getStakeBalances,
   })
 

--- a/src/adapters/nexus-mutual/ethereum/index.ts
+++ b/src/adapters/nexus-mutual/ethereum/index.ts
@@ -32,7 +32,7 @@ export const getContracts = () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: BalancesContext, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     StakeNXM: getStakeBalances,
   })
 

--- a/src/adapters/nexus-mutual/ethereum/stake.ts
+++ b/src/adapters/nexus-mutual/ethereum/stake.ts
@@ -1,6 +1,5 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { Token } from '@lib/token'
 import { BigNumber } from 'ethers'
 
@@ -18,12 +17,12 @@ const wNXM: Token = {
   symbol: 'wNXM',
 }
 
-export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract) {
+export async function getStakeBalances(ctx: BalancesContext, contract: Contract) {
   const balances: Balance[] = []
 
   const [getStakeBalances, getRewardsBalances] = await Promise.all([
     call({
-      chain,
+      chain: ctx.chain,
       target: contract.address,
       params: [ctx.address],
       abi: {
@@ -38,7 +37,7 @@ export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contr
     }),
 
     call({
-      chain,
+      chain: ctx.chain,
       target: contract.address,
       params: [ctx.address],
       abi: {

--- a/src/adapters/olympus-dao/common/bond.ts
+++ b/src/adapters/olympus-dao/common/bond.ts
@@ -86,7 +86,7 @@ export async function getBondsContracts(chain: Chain, contract: Contract): Promi
   return await getPairsDetails(chain, bondContracts)
 }
 
-export async function getBondsBalances(ctx: BalancesContext, chain: Chain, contracts: Contract[]) {
+export async function getBondsBalances(ctx: BalancesContext, contracts: Contract[]) {
   const balances: Balance[] = []
 
   const calls = contracts.map((contract) => ({
@@ -96,15 +96,15 @@ export async function getBondsBalances(ctx: BalancesContext, chain: Chain, contr
 
   const [pendingPayoutForRes, underlyingsTokensReservesRes, totalPoolSuppliesRes] = await Promise.all([
     multicall({
-      chain,
+      chain: ctx.chain,
       calls: contracts.map((contract) => ({
         target: contract.bondAddress,
         params: [ctx.address],
       })),
       abi: abi.pendingPayoutFor,
     }),
-    multicall({ chain, calls, abi: abi.getReserves }),
-    multicall({ chain, calls, abi: abi.totalSupply }),
+    multicall({ chain: ctx.chain, calls, abi: abi.getReserves }),
+    multicall({ chain: ctx.chain, calls, abi: abi.totalSupply }),
   ])
 
   const pendingPayoutFor = pendingPayoutForRes.filter(isSuccess).map((res) => BigNumber.from(res.output))

--- a/src/adapters/olympus-dao/common/stake.ts
+++ b/src/adapters/olympus-dao/common/stake.ts
@@ -1,7 +1,6 @@
 import { Balance, Contract } from '@lib/adapter'
 import { BalancesContext } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
 import { BigNumber } from 'ethers/lib/ethers'
 
@@ -23,11 +22,11 @@ const OHM: Contract = {
   decimals: 9,
 }
 
-export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract) {
+export async function getStakeBalances(ctx: BalancesContext, contract: Contract) {
   const balances: Balance[] = []
 
   const balanceOfRes = await call({
-    chain,
+    chain: ctx.chain,
     target: contract.address,
     params: [ctx.address],
     abi: abi.balanceOf,
@@ -36,7 +35,7 @@ export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contr
   const amount = BigNumber.from(balanceOfRes.output)
 
   const balance: Balance = {
-    chain,
+    chain: ctx.chain,
     address: contract.address,
     decimals: contract.decimals,
     symbol: contract.symbol,
@@ -49,11 +48,11 @@ export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contr
   return balances
 }
 
-export async function getFormattedStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract) {
+export async function getFormattedStakeBalances(ctx: BalancesContext, contract: Contract) {
   const balances: Balance[] = []
 
   const balanceOfRes = await call({
-    chain,
+    chain: ctx.chain,
     target: contract.address,
     params: [ctx.address],
     abi: abi.balanceOf,
@@ -62,7 +61,7 @@ export async function getFormattedStakeBalances(ctx: BalancesContext, chain: Cha
   const balanceOf = balanceOfRes.output
 
   const formattedBalanceOfRes = await call({
-    chain,
+    chain: ctx.chain,
     target: contract.address,
     params: [balanceOf],
     abi: abiOlympus.balanceFrom,
@@ -71,7 +70,7 @@ export async function getFormattedStakeBalances(ctx: BalancesContext, chain: Cha
   const formattedBalanceOf = BigNumber.from(formattedBalanceOfRes.output)
 
   const balance: Balance = {
-    chain,
+    chain: ctx.chain,
     address: contract.address,
     symbol: contract.symbol,
     decimals: 9,

--- a/src/adapters/olympus-dao/ethereum/index.ts
+++ b/src/adapters/olympus-dao/ethereum/index.ts
@@ -35,7 +35,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     sOHM: getStakeBalances,
     gOHM: getFormattedStakeBalances,
     bonds: getBondsBalances,

--- a/src/adapters/pancakeswap/bsc/index.ts
+++ b/src/adapters/pancakeswap/bsc/index.ts
@@ -94,7 +94,7 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (
   ctx: BalancesContext,
   { pairs, masterChefPools, masterChefPools2 },
 ) => {
-  const pairsBalances = await getPairsBalances(ctx, 'bsc', pairs || [])
+  const pairsBalances = await getPairsBalances(ctx, pairs || [])
 
   //new masterchef
   let masterChefBalances = await getMasterChefBalances(ctx, {

--- a/src/adapters/pangolin/avax/index.ts
+++ b/src/adapters/pangolin/avax/index.ts
@@ -24,7 +24,7 @@ export const getContracts = async (props: any) => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'avax', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pairs: getPairsBalances,
   })
 

--- a/src/adapters/radiant/arbitrum/index.ts
+++ b/src/adapters/radiant/arbitrum/index.ts
@@ -1,7 +1,6 @@
 import { getLendingPoolHealthFactor } from '@lib/aave/v2/lending'
 import { BalancesContext, Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
-import { Chain } from '@lib/chains'
 import { getLendingPoolBalances, getLendingPoolContracts } from '@lib/geist/lending'
 import { getMultiFeeDistributionBalances } from '@lib/geist/stake'
 import { Token } from '@lib/token'
@@ -47,10 +46,10 @@ export const getContracts = async () => {
   }
 }
 
-function getLendingBalances(ctx: BalancesContext, chain: Chain, contracts: Contract[]) {
+function getLendingBalances(ctx: BalancesContext, contracts: Contract[]) {
   return Promise.all([
-    getLendingPoolBalances(ctx, chain, contracts, { chefIncentivesController: chefIncentivesControllerContract }),
-    getMultiFeeDistributionBalances(ctx, chain, contracts, {
+    getLendingPoolBalances(ctx, contracts, { chefIncentivesController: chefIncentivesControllerContract }),
+    getMultiFeeDistributionBalances(ctx, contracts, {
       multiFeeDistribution: multiFeeDistributionContract,
       lendingPool: lendingPoolContract,
       stakingToken: radiantToken,
@@ -60,10 +59,10 @@ function getLendingBalances(ctx: BalancesContext, chain: Chain, contracts: Contr
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
   const [balances, healthFactor] = await Promise.all([
-    resolveBalances<typeof getContracts>(ctx, 'arbitrum', contracts, {
+    resolveBalances<typeof getContracts>(ctx, contracts, {
       pools: getLendingBalances,
     }),
-    getLendingPoolHealthFactor(ctx, 'arbitrum', lendingPoolContract),
+    getLendingPoolHealthFactor(ctx, lendingPoolContract),
   ])
 
   return {

--- a/src/adapters/rocket-pool/ethereum/index.ts
+++ b/src/adapters/rocket-pool/ethereum/index.ts
@@ -1,6 +1,5 @@
 import { BalancesContext, Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
-import { Chain } from '@lib/chains'
 import { BN_TEN } from '@lib/math'
 import { getSingleStakeBalance } from '@lib/stake'
 import { ETH, Token } from '@lib/token'
@@ -49,14 +48,14 @@ const miniPoolManager: Contract = {
   underlyings: [ETH],
 }
 
-function getNodeStakingBalance(ctx: BalancesContext, chain: Chain, nodeStaking: Contract) {
-  return getSingleStakeBalance(ctx, chain, nodeStaking, {
+function getNodeStakingBalance(ctx: BalancesContext, nodeStaking: Contract) {
+  return getSingleStakeBalance(ctx, nodeStaking, {
     abi: abi.getNodeRPLStake,
   })
 }
 
-async function getMiniPoolManagerBalance(ctx: BalancesContext, chain: Chain, miniPoolManager: Contract) {
-  const balance = await getSingleStakeBalance(ctx, chain, miniPoolManager, {
+async function getMiniPoolManagerBalance(ctx: BalancesContext, miniPoolManager: Contract) {
+  const balance = await getSingleStakeBalance(ctx, miniPoolManager, {
     abi: abi.getNodeActiveMinipoolCount,
   })
 
@@ -76,7 +75,7 @@ export const getContracts = () => {
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
   console.log(contracts)
 
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     miniPoolManager: getMiniPoolManagerBalance,
     nodeStaking: getNodeStakingBalance,
   })

--- a/src/adapters/scream/fantom/index.ts
+++ b/src/adapters/scream/fantom/index.ts
@@ -19,7 +19,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'fantom', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     markets: getMarketsBalances,
   })
 

--- a/src/adapters/shibaswap/ethereum/balances.ts
+++ b/src/adapters/shibaswap/ethereum/balances.ts
@@ -1,5 +1,4 @@
 import { Balance, BalancesContext } from '@lib/adapter'
-import { Chain } from '@lib/chains'
 import { providers } from '@lib/providers'
 import { Token } from '@lib/token'
 import { BigNumber, ethers } from 'ethers'
@@ -14,8 +13,8 @@ const bone: Token = {
   address: '0x9813037ee2218799597d83d4a5b6f3b6778218d9',
 }
 
-export async function getStakerBalances(ctx: BalancesContext, chain: Chain, address: string): Promise<Balance[]> {
-  const provider = providers[chain]
+export async function getStakerBalances(ctx: BalancesContext, address: string): Promise<Balance[]> {
+  const provider = providers[ctx.chain]
   const Staker = new ethers.Contract(address, StakerAbi, provider)
 
   const stakedBone = await Staker.balanceOf(ctx.address)
@@ -29,8 +28,8 @@ export async function getStakerBalances(ctx: BalancesContext, chain: Chain, addr
   ]
 }
 
-export async function getLockerBalances(ctx: BalancesContext, chain: Chain, address: string): Promise<Balance[]> {
-  const provider = providers[chain]
+export async function getLockerBalances(ctx: BalancesContext, address: string): Promise<Balance[]> {
+  const provider = providers[ctx.chain]
   const Locker = new ethers.Contract(address, LockerAbi, provider)
 
   const remainingLocker = await Locker.unclaimedTokensByUser(ctx.address)

--- a/src/adapters/shibaswap/ethereum/index.ts
+++ b/src/adapters/shibaswap/ethereum/index.ts
@@ -87,15 +87,15 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (
 ) => {
   let balances: Balance[] = []
 
-  const stakerBalances = await getStakerBalances(ctx, 'ethereum', staker.address)
+  const stakerBalances = await getStakerBalances(ctx, staker.address)
 
   balances = balances.concat(stakerBalances)
 
-  const lockerBalances = await getLockerBalances(ctx, 'ethereum', locker.address)
+  const lockerBalances = await getLockerBalances(ctx, locker.address)
 
   balances = balances.concat(lockerBalances)
 
-  const pairsBalances = await getPairsBalances(ctx, 'ethereum', pairs || [])
+  const pairsBalances = await getPairsBalances(ctx, pairs || [])
 
   balances = balances.concat(pairsBalances)
 

--- a/src/adapters/spartacus/fantom/index.ts
+++ b/src/adapters/spartacus/fantom/index.ts
@@ -50,7 +50,7 @@ export const getContracts = () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'fantom', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     sSPA: getStakeBalances,
     bonds: getVestBalances,
   })

--- a/src/adapters/spartacus/fantom/stake.ts
+++ b/src/adapters/spartacus/fantom/stake.ts
@@ -1,6 +1,5 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
 import { BigNumber } from 'ethers'
 
@@ -13,11 +12,11 @@ const SPA: Contract = {
   symbol: 'SPA',
 }
 
-export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getStakeBalances(ctx: BalancesContext, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const balanceOfRes = await call({
-    chain,
+    chain: ctx.chain,
     target: contract.address,
     params: [ctx.address],
     abi: abi.balanceOf,
@@ -26,7 +25,7 @@ export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contr
   const amount = BigNumber.from(balanceOfRes.output)
 
   const balance: Balance = {
-    chain,
+    chain: ctx.chain,
     address: contract.address,
     symbol: contract.symbol,
     decimals: 9,

--- a/src/adapters/spartacus/fantom/vest.ts
+++ b/src/adapters/spartacus/fantom/vest.ts
@@ -1,5 +1,4 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
-import { Chain } from '@lib/chains'
 import { multicall } from '@lib/multicall'
 import { BigNumber } from 'ethers'
 
@@ -12,7 +11,7 @@ const SPA: Contract = {
   symbol: 'SPA',
 }
 
-export async function getVestBalances(ctx: BalancesContext, chain: Chain, contracts: Contract[]): Promise<Balance[]> {
+export async function getVestBalances(ctx: BalancesContext, contracts: Contract[]): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const calls = contracts.map((contract) => ({
@@ -21,7 +20,7 @@ export async function getVestBalances(ctx: BalancesContext, chain: Chain, contra
   }))
 
   const vestingBalanceOfRes = await multicall({
-    chain,
+    chain: ctx.chain,
     calls,
     abi: {
       inputs: [{ internalType: 'address', name: '_depositor', type: 'address' }],
@@ -39,7 +38,7 @@ export async function getVestBalances(ctx: BalancesContext, chain: Chain, contra
     const vestingBalance = vestingBalanceOf[i]
 
     balances.push({
-      chain,
+      chain: ctx.chain,
       address: contract.address,
       symbol: contract.symbol,
       decimals: 9,

--- a/src/adapters/spiritswap/fantom/index.ts
+++ b/src/adapters/spiritswap/fantom/index.ts
@@ -24,7 +24,7 @@ export const getContracts = async (props: any) => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: BalancesContext, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'fantom', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pairs: getPairsBalances,
   })
 

--- a/src/adapters/spookyswap/fantom/index.ts
+++ b/src/adapters/spookyswap/fantom/index.ts
@@ -24,7 +24,7 @@ export const getContracts = async (props: any) => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'fantom', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pairs: getPairsBalances,
   })
 

--- a/src/adapters/spool/ethereum/genesis.ts
+++ b/src/adapters/spool/ethereum/genesis.ts
@@ -1,5 +1,4 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
-import { Chain } from '@lib/chains'
 import { multicall } from '@lib/multicall'
 import { Token } from '@lib/token'
 import { BigNumber } from 'ethers'
@@ -11,12 +10,12 @@ const Spool: Token = {
   symbol: 'SPOOL',
 }
 
-export async function getYieldBalances(ctx: BalancesContext, chain: Chain, pools: Contract[]) {
+export async function getYieldBalances(ctx: BalancesContext, pools: Contract[]) {
   const balances: Balance[] = []
 
   const [getDeposit, getEarned] = await Promise.all([
     multicall({
-      chain,
+      chain: ctx.chain,
       calls: pools.map((pool) => ({
         target: pool.address,
         params: [ctx.address],
@@ -37,7 +36,7 @@ export async function getYieldBalances(ctx: BalancesContext, chain: Chain, pools
     }),
 
     multicall({
-      chain,
+      chain: ctx.chain,
       calls: pools.map((pool) => ({
         target: pool.address,
         params: [Spool.address, ctx.address],
@@ -68,7 +67,7 @@ export async function getYieldBalances(ctx: BalancesContext, chain: Chain, pools
     }
 
     balances.push({
-      chain,
+      chain: ctx.chain,
       name: pool.name,
       address: pool.address,
       symbol: underlying.symbol,

--- a/src/adapters/spool/ethereum/index.ts
+++ b/src/adapters/spool/ethereum/index.ts
@@ -66,7 +66,7 @@ export const getContracts = () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: BalancesContext, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     spoolStaking: getStakeBalances,
     genesisPools: getYieldBalances,
   })

--- a/src/adapters/spool/ethereum/stake.ts
+++ b/src/adapters/spool/ethereum/stake.ts
@@ -1,6 +1,5 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { Token } from '@lib/token'
 import { BigNumber } from 'ethers'
 
@@ -11,12 +10,12 @@ const Spool: Token = {
   symbol: 'SPOOL',
 }
 
-export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract) {
+export async function getStakeBalances(ctx: BalancesContext, contract: Contract) {
   const balances: Balance[] = []
 
   const [getBalances, getEarned] = await Promise.all([
     call({
-      chain,
+      chain: ctx.chain,
       target: contract.address,
       params: [ctx.address],
       abi: {
@@ -29,7 +28,7 @@ export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contr
     }),
 
     call({
-      chain,
+      chain: ctx.chain,
       target: contract.address,
       params: [Spool.address, ctx.address],
       abi: {
@@ -49,7 +48,7 @@ export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contr
   const earned = BigNumber.from(getEarned.output)
 
   balances.push({
-    chain,
+    chain: ctx.chain,
     address: Spool.address,
     decimals: Spool.decimals,
     symbol: Spool.symbol,

--- a/src/adapters/stakewise/ethereum/index.ts
+++ b/src/adapters/stakewise/ethereum/index.ts
@@ -37,7 +37,7 @@ export const getContracts = () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     stake: getERC20BalanceOf,
   })
 

--- a/src/adapters/stargate/arbitrum/index.ts
+++ b/src/adapters/stargate/arbitrum/index.ts
@@ -29,7 +29,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'arbitrum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: (...args) => getStakeBalances(...args, lpStaking),
   })
 

--- a/src/adapters/stargate/avax/index.ts
+++ b/src/adapters/stargate/avax/index.ts
@@ -28,7 +28,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'avax', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: (...args) => getStakeBalances(...args, lpStaking),
   })
 

--- a/src/adapters/stargate/bsc/index.ts
+++ b/src/adapters/stargate/bsc/index.ts
@@ -29,7 +29,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'bsc', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: (...args) => getStakeBalances(...args, lpStaking),
   })
 

--- a/src/adapters/stargate/common/stake.ts
+++ b/src/adapters/stargate/common/stake.ts
@@ -1,5 +1,4 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
-import { Chain } from '@lib/chains'
 import { BN_ZERO } from '@lib/math'
 import { multicall } from '@lib/multicall'
 import { BigNumber } from 'ethers'
@@ -33,7 +32,6 @@ const abi = {
 
 export async function getStakeBalances(
   ctx: BalancesContext,
-  chain: Chain,
   pools: Contract[],
   lpStaking: Contract,
 ): Promise<Balance[]> {
@@ -45,8 +43,8 @@ export async function getStakeBalances(
   }))
 
   const [userInfosRes, pendingRewardsRes] = await Promise.all([
-    multicall({ chain, calls, abi: abi.userInfos }),
-    multicall({ chain, calls, abi: abi.pendingReward }),
+    multicall({ chain: ctx.chain, calls, abi: abi.userInfos }),
+    multicall({ chain: ctx.chain, calls, abi: abi.pendingReward }),
   ])
 
   for (let i = 0; i < pools.length; i++) {

--- a/src/adapters/stargate/ethereum/index.ts
+++ b/src/adapters/stargate/ethereum/index.ts
@@ -29,7 +29,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: (...args) => getStakeBalances(...args, lpStaking),
   })
 

--- a/src/adapters/stargate/fantom/index.ts
+++ b/src/adapters/stargate/fantom/index.ts
@@ -28,7 +28,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'fantom', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: (...args) => getStakeBalances(...args, lpStaking),
   })
 

--- a/src/adapters/stargate/optimism/index.ts
+++ b/src/adapters/stargate/optimism/index.ts
@@ -29,7 +29,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'optimism', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: (...args) => getStakeBalances(...args, lpStaking),
   })
 

--- a/src/adapters/stargate/optimism/stake.ts
+++ b/src/adapters/stargate/optimism/stake.ts
@@ -1,6 +1,5 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { range } from '@lib/array'
-import { Chain } from '@lib/chains'
 import { multicall } from '@lib/multicall'
 import { BigNumber } from 'ethers'
 
@@ -33,7 +32,6 @@ const abi = {
 
 export async function getStakeBalances(
   ctx: BalancesContext,
-  chain: Chain,
   pools: Contract[],
   lpStaking: Contract,
 ): Promise<Balance[]> {
@@ -46,13 +44,13 @@ export async function getStakeBalances(
 
   const [getBalances, getPendingRewards] = await Promise.all([
     multicall({
-      chain,
+      chain: ctx.chain,
       calls,
       abi: abi.userInfos,
     }),
 
     multicall({
-      chain,
+      chain: ctx.chain,
       calls,
       abi: abi.pendingEmissionToken,
     }),
@@ -72,7 +70,7 @@ export async function getStakeBalances(
     }
 
     poolsBalances.push({
-      chain,
+      chain: ctx.chain,
       address: pool.address,
       decimals: pool.decimals,
       symbol: pool.symbol,

--- a/src/adapters/stargate/polygon/index.ts
+++ b/src/adapters/stargate/polygon/index.ts
@@ -29,7 +29,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'polygon', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: (...args) => getStakeBalances(...args, lpStaking),
   })
 

--- a/src/adapters/strike/ethereum/index.ts
+++ b/src/adapters/strike/ethereum/index.ts
@@ -23,7 +23,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: getMarketsBalances,
   })
 

--- a/src/adapters/sushiswap/ethereum/index.ts
+++ b/src/adapters/sushiswap/ethereum/index.ts
@@ -70,7 +70,7 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (
   ctx: BalancesContext,
   { pairs, masterChefPools },
 ) => {
-  const pairsBalances = await getPairsBalances(ctx, 'ethereum', pairs || [])
+  const pairsBalances = await getPairsBalances(ctx, pairs || [])
 
   let masterChefBalances = await getMasterChefBalances(ctx, {
     chain: 'ethereum',

--- a/src/adapters/synapse/arbitrum/index.ts
+++ b/src/adapters/synapse/arbitrum/index.ts
@@ -17,7 +17,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'arbitrum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: (...args) => getPoolsBalances(...args, MiniChef),
   })
 

--- a/src/adapters/synapse/avax/index.ts
+++ b/src/adapters/synapse/avax/index.ts
@@ -17,7 +17,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'avax', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: (...args) => getPoolsBalances(...args, MiniChef),
   })
 

--- a/src/adapters/synapse/bsc/index.ts
+++ b/src/adapters/synapse/bsc/index.ts
@@ -17,7 +17,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'bsc', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: (...args) => getPoolsBalances(...args, MiniChef),
   })
 

--- a/src/adapters/synapse/common/balance.ts
+++ b/src/adapters/synapse/common/balance.ts
@@ -102,7 +102,7 @@ export async function getPoolsContracts(chain: Chain, contract: Contract) {
   return getPairsDetails(chain, contracts)
 }
 
-export async function getPoolsBalances(ctx: BalancesContext, chain: Chain, pools: Contract[], MiniChef: Contract) {
+export async function getPoolsBalances(ctx: BalancesContext, pools: Contract[], MiniChef: Contract) {
   const balances: Balance[] = []
 
   const calls = pools.map((pool) => ({
@@ -111,8 +111,8 @@ export async function getPoolsBalances(ctx: BalancesContext, chain: Chain, pools
   }))
 
   const [userInfosRes, pendingSynapsesRes] = await Promise.all([
-    multicall({ chain, calls, abi: abi.userInfo }),
-    multicall({ chain, calls, abi: abi.pendingSynapse }),
+    multicall({ chain: ctx.chain, calls, abi: abi.userInfo }),
+    multicall({ chain: ctx.chain, calls, abi: abi.pendingSynapse }),
   ])
 
   for (let poolIdx = 0; poolIdx < pools.length; poolIdx++) {
@@ -136,5 +136,5 @@ export async function getPoolsBalances(ctx: BalancesContext, chain: Chain, pools
     balances.push(balance)
   }
 
-  return getUnderlyingBalances(chain, balances)
+  return getUnderlyingBalances(ctx.chain, balances)
 }

--- a/src/adapters/synapse/ethereum/index.ts
+++ b/src/adapters/synapse/ethereum/index.ts
@@ -17,7 +17,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: (...args) => getPoolsBalances(...args, MiniChef),
   })
 

--- a/src/adapters/synapse/fantom/index.ts
+++ b/src/adapters/synapse/fantom/index.ts
@@ -17,7 +17,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'fantom', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: (...args) => getPoolsBalances(...args, MiniChef),
   })
 

--- a/src/adapters/synapse/optimism/index.ts
+++ b/src/adapters/synapse/optimism/index.ts
@@ -17,7 +17,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'optimism', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: (...args) => getPoolsBalances(...args, MiniChef),
   })
 

--- a/src/adapters/synapse/polygon/index.ts
+++ b/src/adapters/synapse/polygon/index.ts
@@ -17,7 +17,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'polygon', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: (...args) => getPoolsBalances(...args, MiniChef),
   })
 

--- a/src/adapters/synthetix/common/lend.ts
+++ b/src/adapters/synthetix/common/lend.ts
@@ -1,6 +1,5 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { BigNumber } from 'ethers'
 
 const abi = {
@@ -46,7 +45,6 @@ const abi = {
 
 export async function getLendBorrowBalances(
   ctx: BalancesContext,
-  chain: Chain,
   synthetixContract: Contract,
   feePoolContract: Contract,
   sUSDContract: Contract,
@@ -56,21 +54,21 @@ export async function getLendBorrowBalances(
 
   const [suppliedRes, borrowedRes, feesAvailableRes] = await Promise.all([
     call({
-      chain,
+      chain: ctx.chain,
       target: synthetixContract.address,
       params: [ctx.address],
       abi: abi.collateral,
     }),
 
     call({
-      chain,
+      chain: ctx.chain,
       target: synthetixContract.address,
       params: [ctx.address],
       abi: abi.remainingIssuableSynths,
     }),
 
     call({
-      chain,
+      chain: ctx.chain,
       target: feePoolContract.address,
       params: [ctx.address],
       abi: abi.feesAvailable,
@@ -84,7 +82,7 @@ export async function getLendBorrowBalances(
 
   if (SNX) {
     balances.push({
-      chain,
+      chain: ctx.chain,
       address: synthetixContract.address,
       decimals: synthetixContract.decimals,
       symbol: synthetixContract.symbol,
@@ -94,7 +92,7 @@ export async function getLendBorrowBalances(
     })
 
     balances.push({
-      chain,
+      chain: ctx.chain,
       address: sUSDContract.address,
       decimals: sUSDContract.decimals,
       symbol: sUSDContract.symbol,
@@ -103,7 +101,7 @@ export async function getLendBorrowBalances(
     })
 
     balances.push({
-      chain,
+      chain: ctx.chain,
       address: sUSDContract.address,
       decimals: sUSDContract.decimals,
       symbol: sUSDContract.symbol,
@@ -112,7 +110,7 @@ export async function getLendBorrowBalances(
     })
 
     balances.push({
-      chain,
+      chain: ctx.chain,
       address: SNX.address,
       decimals: SNX.decimals,
       symbol: SNX.symbol,

--- a/src/adapters/synthetix/common/vest.ts
+++ b/src/adapters/synthetix/common/vest.ts
@@ -1,6 +1,5 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
 import { BigNumber } from 'ethers'
 
@@ -18,7 +17,6 @@ const abiSNX = {
 
 export async function getVestBalances(
   ctx: BalancesContext,
-  chain: Chain,
   escrow: Contract,
   liquidator: Contract,
 ): Promise<Balance[]> {
@@ -26,14 +24,14 @@ export async function getVestBalances(
 
   const [balanceOf, earnedRes] = await Promise.all([
     call({
-      chain,
+      chain: ctx.chain,
       target: escrow.address,
       params: [ctx.address],
       abi: abi.balanceOf,
     }),
 
     call({
-      chain,
+      chain: ctx.chain,
       target: liquidator.address,
       params: [ctx.address],
       abi: abiSNX.earned,
@@ -46,7 +44,7 @@ export async function getVestBalances(
 
   if (SNX) {
     balances.push({
-      chain,
+      chain: ctx.chain,
       address: SNX.address,
       decimals: SNX.decimals,
       symbol: SNX.symbol,

--- a/src/adapters/synthetix/ethereum/index.ts
+++ b/src/adapters/synthetix/ethereum/index.ts
@@ -55,7 +55,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     synthetix: (...args) => getLendBorrowBalances(...args, feePool, sUSD),
     rewardEscrow: (...args) => getVestBalances(...args, liquidatorReward),
   })

--- a/src/adapters/synthetix/optimism/index.ts
+++ b/src/adapters/synthetix/optimism/index.ts
@@ -55,7 +55,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'optimism', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     synthetix: (...args) => getLendBorrowBalances(...args, feePool, sUSD),
     rewardEscrow: (...args) => getVestBalances(...args, liquidatorReward),
   })

--- a/src/adapters/templedao/ethereum/balances.ts
+++ b/src/adapters/templedao/ethereum/balances.ts
@@ -1,6 +1,5 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
 import { multicall } from '@lib/multicall'
 import { isNotNullish } from '@lib/type'
@@ -17,14 +16,13 @@ const TEMPLE: Contract = {
 
 export async function getStakeBalances(
   ctx: BalancesContext,
-  chain: Chain,
   contract: Contract,
   templeStaking: Contract,
 ): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const balanceOfRes = await call({
-    chain,
+    chain: ctx.chain,
     target: contract.address,
     params: [ctx.address],
     abi: abi.balanceOf,
@@ -33,7 +31,7 @@ export async function getStakeBalances(
   const balanceOf = balanceOfRes.output
 
   const formattedBalanceRes = await call({
-    chain,
+    chain: ctx.chain,
     target: templeStaking.address,
     params: [balanceOf],
     abi: {
@@ -48,7 +46,7 @@ export async function getStakeBalances(
   const formattedBalance = BigNumber.from(formattedBalanceRes.output)
 
   const balance: Balance = {
-    chain,
+    chain: ctx.chain,
     address: contract.address,
     symbol: contract.symbol,
     decimals: contract.decimals,
@@ -62,7 +60,7 @@ export async function getStakeBalances(
   return balances
 }
 
-export async function getLockedBalances(ctx: BalancesContext, chain: Chain, contracts: Contract[]): Promise<Balance[]> {
+export async function getLockedBalances(ctx: BalancesContext, contracts: Contract[]): Promise<Balance[]> {
   const calls = contracts.map((contract) => ({
     target: contract.address,
     params: [],
@@ -70,7 +68,7 @@ export async function getLockedBalances(ctx: BalancesContext, chain: Chain, cont
 
   const [balancesLockedRes, periodStartTimestampRes, periodDurationRes] = await Promise.all([
     multicall({
-      chain,
+      chain: ctx.chain,
       calls: contracts.map((contract) => ({
         target: contract.address,
         params: [ctx.address],
@@ -79,7 +77,7 @@ export async function getLockedBalances(ctx: BalancesContext, chain: Chain, cont
     }),
 
     multicall({
-      chain,
+      chain: ctx.chain,
       calls,
       abi: {
         inputs: [],
@@ -91,7 +89,7 @@ export async function getLockedBalances(ctx: BalancesContext, chain: Chain, cont
     }),
 
     multicall({
-      chain,
+      chain: ctx.chain,
       calls,
       abi: {
         inputs: [],
@@ -112,7 +110,7 @@ export async function getLockedBalances(ctx: BalancesContext, chain: Chain, cont
       const amountLocked = BigNumber.from(balancesLockedRes[i].output)
 
       const balance: Balance = {
-        chain,
+        chain: ctx.chain,
         decimals: contract.decimals,
         symbol: contract.symbol,
         address: contract.address,

--- a/src/adapters/templedao/ethereum/index.ts
+++ b/src/adapters/templedao/ethereum/index.ts
@@ -72,7 +72,7 @@ export const getContracts = () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     OG_TEMPLE: (...args) => getStakeBalances(...args, templeStaking),
     vaults: getLockedBalances,
   })

--- a/src/adapters/traderjoe/avax/balances.ts
+++ b/src/adapters/traderjoe/avax/balances.ts
@@ -1,7 +1,6 @@
 import { BalancesContext } from '@lib/adapter'
 import { Balance, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { BigNumber } from 'ethers'
 
 interface Token extends Contract {
@@ -126,26 +125,26 @@ const JOE: Token = {
   coingeckoId: 'joe',
 }
 
-export async function getStakeBalance(ctx: BalancesContext, chain: Chain) {
+export async function getStakeBalance(ctx: BalancesContext) {
   const balances: Balance[] = []
 
   const [sJOEbalanceOfRes, veJOEbalanceOfRes, rJOEbalanceOfRes] = await Promise.all([
     call({
-      chain,
+      chain: ctx.chain,
       target: pools[0],
       params: [ctx.address, USDC.address],
       abi: abi.getUserInfo,
     }),
 
     call({
-      chain,
+      chain: ctx.chain,
       target: pools[1],
       params: [ctx.address],
       abi: abi.veJoeUserInfos,
     }),
 
     call({
-      chain,
+      chain: ctx.chain,
       target: pools[2],
       params: [ctx.address],
       abi: abi.rJoeUserInfo,
@@ -160,21 +159,21 @@ export async function getStakeBalance(ctx: BalancesContext, chain: Chain) {
 
   const [sJOErewardsRes, veJOErewardsRes, rJOErewardsRes] = await Promise.all([
     call({
-      chain,
+      chain: ctx.chain,
       target: pools[0],
       params: [ctx.address, USDC.address],
       abi: abi.pendingReward,
     }),
 
     call({
-      chain,
+      chain: ctx.chain,
       target: pools[1],
       params: [ctx.address],
       abi: abi.getPendingVeJoe,
     }),
 
     call({
-      chain,
+      chain: ctx.chain,
       target: pools[2],
       params: [ctx.address],
       abi: abi.pendingRJoe,

--- a/src/adapters/traderjoe/avax/index.ts
+++ b/src/adapters/traderjoe/avax/index.ts
@@ -60,11 +60,11 @@ export const getContracts = async (props: any) => {
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
   const [balances, stakeBalances] = await Promise.all([
-    resolveBalances<typeof getContracts>(ctx, 'avax', contracts, {
+    resolveBalances<typeof getContracts>(ctx, contracts, {
       markets: getMarketsBalances,
       pools: getPairsBalances,
     }),
-    getStakeBalance(ctx, 'avax'),
+    getStakeBalance(ctx),
   ])
 
   return {

--- a/src/adapters/truefi/ethereum/farm.ts
+++ b/src/adapters/truefi/ethereum/farm.ts
@@ -1,5 +1,4 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
-import { Chain } from '@lib/chains'
 import { multicall } from '@lib/multicall'
 import { Token } from '@lib/token'
 import { isSuccess } from '@lib/type'
@@ -43,7 +42,7 @@ const TRU: Token = {
   decimals: 8,
 }
 
-export async function getFarmBalances(ctx: BalancesContext, chain: Chain, pools: Contract[], multifarm: Contract) {
+export async function getFarmBalances(ctx: BalancesContext, pools: Contract[], multifarm: Contract) {
   const balances: Balance[] = []
 
   const calls = pools.map((pool) => ({
@@ -52,8 +51,8 @@ export async function getFarmBalances(ctx: BalancesContext, chain: Chain, pools:
   }))
 
   const [stakeds, claimables] = await Promise.all([
-    multicall({ chain, calls, abi: abi.staked }),
-    multicall({ chain, calls, abi: abi.claimable }),
+    multicall({ chain: ctx.chain, calls, abi: abi.staked }),
+    multicall({ chain: ctx.chain, calls, abi: abi.claimable }),
   ])
 
   for (let i = 0; i < pools.length; i++) {

--- a/src/adapters/truefi/ethereum/index.ts
+++ b/src/adapters/truefi/ethereum/index.ts
@@ -1,6 +1,5 @@
 import { BalancesContext, Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
-import { Chain } from '@lib/chains'
 import { Token } from '@lib/token'
 
 import { getFarmBalances } from './farm'
@@ -52,13 +51,13 @@ export const getContracts = async () => {
   }
 }
 
-async function getAllBalances(ctx: BalancesContext, chain: Chain, pools: Contract[]) {
-  const poolsSupplies = await getPoolsSupplies(chain, pools)
-  return getFarmBalances(ctx, chain, poolsSupplies, trueMultiFarm)
+async function getAllBalances(ctx: BalancesContext, pools: Contract[]) {
+  const poolsSupplies = await getPoolsSupplies(ctx.chain, pools)
+  return getFarmBalances(ctx, poolsSupplies, trueMultiFarm)
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: getAllBalances,
     stkTRU: getTRUStakeBalances,
     TUSD: getTUSDStakeBalances,

--- a/src/adapters/truefi/ethereum/stake.ts
+++ b/src/adapters/truefi/ethereum/stake.ts
@@ -1,6 +1,5 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
 import { Token } from '@lib/token'
 import { BigNumber } from 'ethers'
@@ -50,19 +49,19 @@ const TrueUSD: Token = {
   decimals: 18,
 }
 
-export async function getTRUStakeBalances(ctx: BalancesContext, chain: Chain, stkTRU: Contract) {
+export async function getTRUStakeBalances(ctx: BalancesContext, stkTRU: Contract) {
   const balances: Balance[] = []
 
   const [balanceOfRes, claimableRes] = await Promise.all([
     call({
-      chain,
+      chain: ctx.chain,
       target: stkTRU.address,
       params: [ctx.address],
       abi: abi.balanceOf,
     }),
 
     call({
-      chain,
+      chain: ctx.chain,
       target: stkTRU.address,
       params: [ctx.address, TRU.address],
       abi: abiTRU.claimable,
@@ -73,7 +72,7 @@ export async function getTRUStakeBalances(ctx: BalancesContext, chain: Chain, st
   const claimable = BigNumber.from(claimableRes.output)
 
   balances.push({
-    chain,
+    chain: ctx.chain,
     address: stkTRU.address,
     decimals: stkTRU.decimals,
     symbol: stkTRU.symbol,
@@ -86,26 +85,26 @@ export async function getTRUStakeBalances(ctx: BalancesContext, chain: Chain, st
   return balances
 }
 
-export async function getTUSDStakeBalances(ctx: BalancesContext, chain: Chain, TUSD: Contract) {
+export async function getTUSDStakeBalances(ctx: BalancesContext, TUSD: Contract) {
   const balances: Balance[] = []
 
   const [balanceOfRes, poolValueRes, totalSupplyRes] = await Promise.all([
     call({
-      chain,
+      chain: ctx.chain,
       target: TUSD.address,
       params: [ctx.address],
       abi: abi.balanceOf,
     }),
 
     call({
-      chain,
+      chain: ctx.chain,
       target: TUSD.address,
       params: [],
       abi: abiTRU.poolValue,
     }),
 
     call({
-      chain,
+      chain: ctx.chain,
       target: TUSD.address,
       params: [],
       abi: abiTRU.totalSupply,
@@ -117,7 +116,7 @@ export async function getTUSDStakeBalances(ctx: BalancesContext, chain: Chain, T
   const totalSupply = BigNumber.from(totalSupplyRes.output)
 
   balances.push({
-    chain,
+    chain: ctx.chain,
     address: TUSD.address,
     decimals: TUSD.decimals,
     symbol: TUSD.symbol,

--- a/src/adapters/uniswap/ethereum/index.ts
+++ b/src/adapters/uniswap/ethereum/index.ts
@@ -68,7 +68,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: BalancesContext, { pairs }) => {
-  const lpBalances = await getPairsBalances(ctx, 'ethereum', pairs || [])
+  const lpBalances = await getPairsBalances(ctx, pairs || [])
 
   return {
     balances: lpBalances.map((balance) => ({ ...balance, category: 'farm' })),

--- a/src/adapters/uwu-lend/ethereum/index.ts
+++ b/src/adapters/uwu-lend/ethereum/index.ts
@@ -1,7 +1,6 @@
 import { getLendingPoolHealthFactor } from '@lib/aave/v2/lending'
 import { BalancesContext, Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
-import { Chain } from '@lib/chains'
 import { getLendingPoolBalances, getLendingPoolContracts } from '@lib/geist/lending'
 import { Token } from '@lib/token'
 
@@ -48,12 +47,12 @@ export const getContracts = async () => {
   }
 }
 
-function getLendingBalances(ctx: BalancesContext, chain: Chain, contracts: Contract[]) {
+function getLendingBalances(ctx: BalancesContext, contracts: Contract[]) {
   return Promise.all([
-    getLendingPoolBalances(ctx, chain, contracts, {
+    getLendingPoolBalances(ctx, contracts, {
       chefIncentivesController: chefIncentivesControllerContract,
     }),
-    getMultiFeeDistributionBalances(ctx, chain, contracts, {
+    getMultiFeeDistributionBalances(ctx, contracts, {
       multiFeeDistributionAddress: multiFeeDistributionContract.address,
     }),
   ])
@@ -61,10 +60,10 @@ function getLendingBalances(ctx: BalancesContext, chain: Chain, contracts: Contr
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
   const [balances, healthFactor] = await Promise.all([
-    resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+    resolveBalances<typeof getContracts>(ctx, contracts, {
       pools: getLendingBalances,
     }),
-    getLendingPoolHealthFactor(ctx, 'ethereum', lendingPoolContract),
+    getLendingPoolHealthFactor(ctx, lendingPoolContract),
   ])
 
   return {

--- a/src/adapters/uwu-lend/ethereum/lock.ts
+++ b/src/adapters/uwu-lend/ethereum/lock.ts
@@ -1,5 +1,4 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
-import { Chain } from '@lib/chains'
 import { getERC20Details } from '@lib/erc20'
 import { providers } from '@lib/providers'
 import { Token } from '@lib/token'
@@ -14,12 +13,11 @@ export interface GetMultiFeeDistributionBalancesParams {
 
 export async function getMultiFeeDistributionBalances(
   ctx: BalancesContext,
-  chain: Chain,
   lendingPoolContracts: Contract[],
   { multiFeeDistributionAddress }: GetMultiFeeDistributionBalancesParams,
 ) {
   const balances: Balance[] = []
-  const provider = providers[chain]
+  const provider = providers[ctx.chain]
 
   const lendingPoolContractByAddress: { [key: string]: Contract } = {}
   for (const contract of lendingPoolContracts) {
@@ -40,14 +38,14 @@ export async function getMultiFeeDistributionBalances(
   const [stakingToken, rewardToken] = await getERC20Details('ethereum', [stakingTokenAddress, rewardTokenAddress])
 
   const tokens = claimableRewards.map((res: any) => res.token)
-  const tokenDetails = await getERC20Details(chain, tokens)
+  const tokenDetails = await getERC20Details(ctx.chain, tokens)
   const tokenByAddress: { [key: string]: Token } = {}
   for (const token of tokenDetails) {
     tokenByAddress[token.address] = token
   }
 
   // get balances of Sushi staking LP token
-  const [lockedBalance] = await getUnderlyingBalances(chain, [
+  const [lockedBalance] = await getUnderlyingBalances(ctx.chain, [
     { ...stakingToken, amount: lockedBalances.total, rewards: [] } as Balance,
   ])
 
@@ -60,7 +58,7 @@ export async function getMultiFeeDistributionBalances(
         continue
       }
       const reward: Balance = {
-        chain,
+        chain: ctx.chain,
         address: rewardData.token,
         amount: rewardData.amount,
         decimals: token.decimals,

--- a/src/adapters/valas/bsc/index.ts
+++ b/src/adapters/valas/bsc/index.ts
@@ -1,7 +1,6 @@
 import { getLendingPoolHealthFactor } from '@adapters/aave/v3/common/lending'
 import { BalancesContext, Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
-import { Chain } from '@lib/chains'
 import { getLendingPoolBalances, getLendingPoolContracts } from '@lib/geist/lending'
 import { getMultiFeeDistributionBalances } from '@lib/geist/stake'
 import { Token } from '@lib/token'
@@ -47,10 +46,10 @@ export const getContracts = async () => {
   }
 }
 
-function getLendingBalances(ctx: BalancesContext, chain: Chain, contracts: Contract[]) {
+function getLendingBalances(ctx: BalancesContext, contracts: Contract[]) {
   return Promise.all([
-    getLendingPoolBalances(ctx, chain, contracts, { chefIncentivesController: chefIncentivesControllerContract }),
-    getMultiFeeDistributionBalances(ctx, chain, contracts, {
+    getLendingPoolBalances(ctx, contracts, { chefIncentivesController: chefIncentivesControllerContract }),
+    getMultiFeeDistributionBalances(ctx, contracts, {
       multiFeeDistribution: multiFeeDistributionContract,
       lendingPool: lendingPoolContract,
       stakingToken: valasToken,
@@ -60,10 +59,10 @@ function getLendingBalances(ctx: BalancesContext, chain: Chain, contracts: Contr
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
   const [balances, healthFactor] = await Promise.all([
-    resolveBalances<typeof getContracts>(ctx, 'bsc', contracts, {
+    resolveBalances<typeof getContracts>(ctx, contracts, {
       pools: getLendingBalances,
     }),
-    getLendingPoolHealthFactor(ctx, 'bsc', lendingPoolContract),
+    getLendingPoolHealthFactor(ctx, lendingPoolContract),
   ])
 
   return {

--- a/src/adapters/vector/avax/farm.ts
+++ b/src/adapters/vector/avax/farm.ts
@@ -188,7 +188,6 @@ export async function getFarmContracts(chain: Chain, masterChef: Contract) {
 
 export async function getFarmBalances(
   ctx: BalancesContext,
-  chain: Chain,
   pools: FarmContract[],
   masterChef: Contract,
 ): Promise<Balance[]> {
@@ -196,7 +195,7 @@ export async function getFarmBalances(
 
   const [userDepositBalancesRes, pendingBaseRewardsRes, pendingRewardsRes] = await Promise.all([
     multicall({
-      chain,
+      chain: ctx.chain,
       calls: pools.map((pool) => ({
         target: masterChef.address,
         params: [pool.address, ctx.address],
@@ -205,7 +204,7 @@ export async function getFarmBalances(
     }),
 
     multicall({
-      chain,
+      chain: ctx.chain,
       calls: pools.map((pool) => ({
         target: masterChef.address,
         params: [pool.address, ctx.address, pool.address],
@@ -214,7 +213,7 @@ export async function getFarmBalances(
     }),
 
     multicall({
-      chain,
+      chain: ctx.chain,
       calls: pools.flatMap(
         (pool) =>
           pool.rewards?.map((rewardToken) => ({
@@ -238,7 +237,7 @@ export async function getFarmBalances(
     }
 
     const balance: FarmBalance = {
-      chain,
+      chain: ctx.chain,
       address: pool.address,
       symbol: pool.symbol,
       decimals: pool.decimals,
@@ -269,7 +268,7 @@ export async function getFarmBalances(
     // resolve LP underlyings
     if (balance.amount.gt(0)) {
       if (balance.symbol === 'JLP') {
-        const underlyings = await getPoolsUnderlyings(chain, balance)
+        const underlyings = await getPoolsUnderlyings(ctx.chain, balance)
         balance.underlyings = [...underlyings]
       }
     }

--- a/src/adapters/vector/avax/index.ts
+++ b/src/adapters/vector/avax/index.ts
@@ -28,7 +28,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'avax', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     farmContracts: (...args) => getFarmBalances(...args, masterChef),
     vtxLocker: getLockerBalances,
   })

--- a/src/adapters/vector/avax/locker.ts
+++ b/src/adapters/vector/avax/locker.ts
@@ -1,7 +1,6 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { range } from '@lib/array'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { abi } from '@lib/erc20'
 import { getERC20Details } from '@lib/erc20'
 import { multicall } from '@lib/multicall'
@@ -15,18 +14,18 @@ const VTX: Token = {
   symbol: 'VTX',
 }
 
-export async function getLockerBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getLockerBalances(ctx: BalancesContext, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
   const [userTotalDepositRes, rewarderAddressRes, userExtraLockedSlots] = await Promise.all([
     call({
-      chain,
+      chain: ctx.chain,
       target: contract.address,
       params: [ctx.address],
       abi: abi.balanceOf,
     }),
 
     call({
-      chain,
+      chain: ctx.chain,
       target: contract.address,
       params: [],
       abi: {
@@ -39,7 +38,7 @@ export async function getLockerBalances(ctx: BalancesContext, chain: Chain, cont
     }),
 
     call({
-      chain,
+      chain: ctx.chain,
       target: contract.address,
       params: [ctx.address],
       abi: {
@@ -55,10 +54,10 @@ export async function getLockerBalances(ctx: BalancesContext, chain: Chain, cont
   const userTotalDeposit = BigNumber.from(userTotalDepositRes.output)
   const rewarderAddress = rewarderAddressRes.output
 
-  const rewards = await lockedRewardsBalances(ctx, chain, rewarderAddress)
+  const rewards = await lockedRewardsBalances(ctx, rewarderAddress)
 
   balances.push({
-    chain,
+    chain: ctx.chain,
     address: contract.address,
     decimals: contract.decimals,
     symbol: contract.symbol,
@@ -69,7 +68,7 @@ export async function getLockerBalances(ctx: BalancesContext, chain: Chain, cont
   })
 
   const extraUserLockedBySlotsRes = await multicall({
-    chain,
+    chain: ctx.chain,
     calls: range(0, userExtraLockedSlots.output).map((i) => ({
       target: contract.address,
       params: [ctx.address, i],
@@ -100,7 +99,7 @@ export async function getLockerBalances(ctx: BalancesContext, chain: Chain, cont
 
   for (const extraUserLockedBySlot of extraUserLockedBySlots) {
     balances.push({
-      chain,
+      chain: ctx.chain,
       address: contract.address,
       decimals: contract.decimals,
       symbol: contract.symbol,
@@ -114,9 +113,9 @@ export async function getLockerBalances(ctx: BalancesContext, chain: Chain, cont
   return balances
 }
 
-const lockedRewardsBalances = async (ctx: BalancesContext, chain: Chain, rewarder: string): Promise<Balance[]> => {
+const lockedRewardsBalances = async (ctx: BalancesContext, rewarder: string): Promise<Balance[]> => {
   const pendingRewardsTokensRes = await multicall({
-    chain,
+    chain: ctx.chain,
     // There is no logic in the contracts to know the number of tokens in advance. Among all the contracts checked, 7 seems to be the maximum number of extra tokens used.
     calls: range(0, 7).map((i) => ({
       target: rewarder,
@@ -132,10 +131,10 @@ const lockedRewardsBalances = async (ctx: BalancesContext, chain: Chain, rewarde
   })
 
   const pendingRewardsTokens = pendingRewardsTokensRes.filter((res) => res.success).map((res) => res.output)
-  const rewardsTokens = await getERC20Details(chain, pendingRewardsTokens)
+  const rewardsTokens = await getERC20Details(ctx.chain, pendingRewardsTokens)
 
   const pendingRewardsBalancesRes = await multicall({
-    chain,
+    chain: ctx.chain,
     calls: pendingRewardsTokens.map((token) => ({
       target: rewarder,
       params: [ctx.address, token],

--- a/src/adapters/venus/bsc/index.ts
+++ b/src/adapters/venus/bsc/index.ts
@@ -58,7 +58,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'bsc', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     VenusVault: getStakeBalances,
     markets: (...args) => getLendBorrowBalances(...args, Comptroller),
     Comptroller: (...args) => getRewardsBalances(...args, VenusLens),

--- a/src/adapters/venus/bsc/lend.ts
+++ b/src/adapters/venus/bsc/lend.ts
@@ -1,6 +1,5 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { getMarketsBalances } from '@lib/compound/v2/lending'
 import { Token } from '@lib/token'
 import { BigNumber } from 'ethers'
@@ -26,16 +25,15 @@ const VAI: Token = {
 
 export async function getLendBorrowBalances(
   ctx: BalancesContext,
-  chain: Chain,
   contracts: Contract[],
   comptroller: Contract,
 ): Promise<Balance[]> {
   const VAIMinted: Balance[] = []
 
-  const marketsBalances = await getMarketsBalances(ctx, 'bsc', contracts)
+  const marketsBalances = await getMarketsBalances(ctx, contracts)
 
   const VAIBalancesRes = await call({
-    chain,
+    chain: ctx.chain,
     target: comptroller.address,
     params: [ctx.address],
     abi: abi.mintedVAIs,
@@ -44,7 +42,7 @@ export async function getLendBorrowBalances(
   const VAIBalances = BigNumber.from(VAIBalancesRes.output)
 
   VAIMinted.push({
-    chain,
+    chain: ctx.chain,
     decimals: VAI.decimals,
     symbol: VAI.symbol,
     address: VAI.address,

--- a/src/adapters/venus/bsc/rewards.ts
+++ b/src/adapters/venus/bsc/rewards.ts
@@ -1,6 +1,5 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { Token } from '@lib/token'
 import { BigNumber } from 'ethers'
 
@@ -41,14 +40,13 @@ const XVS: Token = {
 
 export async function getRewardsBalances(
   ctx: BalancesContext,
-  chain: Chain,
   comptroller: Contract,
   lens: Contract,
 ): Promise<Balance[]> {
   const rewards: Balance[] = []
 
   const XVSAllocatedRewardsRes = await call({
-    chain,
+    chain: ctx.chain,
     target: lens.address,
     params: [XVS.address, comptroller.address, ctx.address],
     abi: abi.getXVSBalanceMetadataExt,
@@ -57,7 +55,7 @@ export async function getRewardsBalances(
   const XVSAllocatedRewards = BigNumber.from(XVSAllocatedRewardsRes.output.allocated)
 
   rewards.push({
-    chain,
+    chain: ctx.chain,
     address: XVS.address,
     decimals: XVS.decimals,
     symbol: XVS.symbol,

--- a/src/adapters/venus/bsc/stake.ts
+++ b/src/adapters/venus/bsc/stake.ts
@@ -1,6 +1,5 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { Token } from '@lib/token'
 import { BigNumber } from 'ethers'
 
@@ -42,19 +41,19 @@ const VAI: Token = {
   address: '0x4BD17003473389A42DAF6a0a729f6Fdb328BbBd7',
 }
 
-export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contract: Contract): Promise<Balance[]> {
+export async function getStakeBalances(ctx: BalancesContext, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const [stakeBalanceRes, pendingXVSRes] = await Promise.all([
     call({
-      chain,
+      chain: ctx.chain,
       target: contract.address,
       params: [ctx.address],
       abi: abi.userInfo,
     }),
 
     call({
-      chain,
+      chain: ctx.chain,
       target: contract.address,
       params: [ctx.address],
       abi: abi.pendingXVS,
@@ -65,7 +64,7 @@ export async function getStakeBalances(ctx: BalancesContext, chain: Chain, contr
   const pendingXVS = BigNumber.from(pendingXVSRes.output)
 
   balances.push({
-    chain,
+    chain: ctx.chain,
     address: VAI.address,
     decimals: VAI.decimals,
     symbol: VAI.symbol,

--- a/src/adapters/wallet/index.ts
+++ b/src/adapters/wallet/index.ts
@@ -7,13 +7,13 @@ import { Token } from '@lib/token'
 import { chains as tokensByChain } from '@llamafolio/tokens'
 import { ethers } from 'ethers'
 
-async function getCoinBalance(ctx: BalancesContext, chain: Chain, token?: Token) {
+async function getCoinBalance(ctx: BalancesContext, token?: Token) {
   if (!token) {
     return null
   }
 
-  const provider = providers[chain]
-  const amount = await provider.getBalance(ctx.address, ctx.blockHeight?.[chain])
+  const provider = providers[ctx.chain]
+  const amount = await provider.getBalance(ctx.address, ctx.blockHeight)
   return { ...token, amount } as Balance
 }
 
@@ -40,7 +40,7 @@ const getChainHandlers = (chain: Chain) => {
   }
 
   const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-    const balances = await resolveBalances<typeof getContracts>(ctx, chain, contracts, {
+    const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
       coin: getCoinBalance,
       erc20: getERC20BalanceOf,
     })

--- a/src/adapters/wepiggy/arbitrum/index.ts
+++ b/src/adapters/wepiggy/arbitrum/index.ts
@@ -51,7 +51,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'arbitrum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     poolsMarkets: getMarketsBalances,
     piggyDistribution: getMarketsRewards,
   })

--- a/src/adapters/wepiggy/bsc/index.ts
+++ b/src/adapters/wepiggy/bsc/index.ts
@@ -49,7 +49,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'bsc', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     poolsMarkets: getMarketsBalances,
     piggyDistribution: getMarketsRewards,
   })

--- a/src/adapters/wepiggy/common/rewards.ts
+++ b/src/adapters/wepiggy/common/rewards.ts
@@ -1,6 +1,5 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
-import { Chain } from '@lib/chains'
 import { Token } from '@lib/token'
 import { BigNumber } from 'ethers'
 
@@ -12,13 +11,9 @@ const WPC: Token = {
   symbol: 'WPC',
 }
 
-export async function getMarketsRewards(
-  ctx: BalancesContext,
-  chain: Chain,
-  piggyDistribution: Contract,
-): Promise<Balance> {
+export async function getMarketsRewards(ctx: BalancesContext, piggyDistribution: Contract): Promise<Balance> {
   const pendingWPCRewardsRes = await call({
-    chain,
+    chain: ctx.chain,
     target: piggyDistribution.address,
     params: [ctx.address, 'true', 'true'],
     abi: {
@@ -34,13 +29,10 @@ export async function getMarketsRewards(
     },
   })
 
-  // It looks like Debank is using a 1e3 factor
-  // Unfortunately Piggy's documentation is in Chinese, so it's complicated to find the mathematical logic
-  // At first it seems judicious to render the same as Debank
   const pendingWPCRewards = BigNumber.from(pendingWPCRewardsRes.output).mul(Math.pow(10, 3))
 
   const reward: Balance = {
-    chain,
+    chain: ctx.chain,
     address: WPC.address,
     decimals: WPC.decimals,
     symbol: WPC.symbol,

--- a/src/adapters/wepiggy/ethereum/index.ts
+++ b/src/adapters/wepiggy/ethereum/index.ts
@@ -49,7 +49,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'ethereum', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     poolsMarkets: getMarketsBalances,
     piggyDistribution: getMarketsRewards,
   })

--- a/src/adapters/wepiggy/optimism/index.ts
+++ b/src/adapters/wepiggy/optimism/index.ts
@@ -49,7 +49,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'optimism', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     poolsMarkets: getMarketsBalances,
     piggyDistribution: getMarketsRewards,
   })

--- a/src/adapters/wepiggy/polygon/index.ts
+++ b/src/adapters/wepiggy/polygon/index.ts
@@ -44,7 +44,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'polygon', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     poolsMarkets: getMarketsBalances,
     piggyDistribution: getMarketsRewards,
   })

--- a/src/adapters/wonderland/avax/index.ts
+++ b/src/adapters/wonderland/avax/index.ts
@@ -29,7 +29,7 @@ export const getContracts = async () => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, 'avax', contracts, {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     wMEMO: getFormattedStakeBalance,
     stake: (...args) => getStakeBalance(...args, wMemoFarm),
   })

--- a/src/lib/aave/v2/lending.ts
+++ b/src/lib/aave/v2/lending.ts
@@ -173,9 +173,9 @@ export async function getLendingPoolContracts(chain: Chain, lendingPool: Contrac
   return contracts
 }
 
-export async function getLendingPoolBalances(ctx: BalancesContext, chain: Chain, contracts: Contract[]) {
+export async function getLendingPoolBalances(ctx: BalancesContext, contracts: Contract[]) {
   try {
-    const balances: Balance[] = await getERC20BalanceOf(ctx, chain, contracts as Token[])
+    const balances: Balance[] = await getERC20BalanceOf(ctx, contracts as Token[])
 
     // use the same amount for underlyings
     for (const balance of balances) {
@@ -193,10 +193,10 @@ export async function getLendingPoolBalances(ctx: BalancesContext, chain: Chain,
   }
 }
 
-export async function getLendingPoolHealthFactor(ctx: BalancesContext, chain: Chain, lendingPool: Contract) {
+export async function getLendingPoolHealthFactor(ctx: BalancesContext, lendingPool: Contract) {
   try {
     const userAccountDataRes = await call({
-      chain,
+      chain: ctx.chain,
       target: lendingPool.address,
       params: [ctx.address],
       abi: abi.getUserAccountData,

--- a/src/lib/balance.ts
+++ b/src/lib/balance.ts
@@ -44,9 +44,7 @@ export async function getBalances(ctx: BalancesContext, contracts: BaseContract[
   ).filter(isNotNullish)
 
   const tokensBalances: Token[] = (
-    await Promise.all(
-      Object.keys(tokensByChain).map((chain) => getERC20BalanceOf(ctx, chain as Chain, tokensByChain[chain])),
-    )
+    await Promise.all(Object.keys(tokensByChain).map((chain) => getERC20BalanceOf(ctx, tokensByChain[chain])))
   ).flat() as Token[]
 
   return coinsBalances.concat(tokensBalances)
@@ -159,12 +157,10 @@ export function sanitizeBalances(balances: Balance[]) {
 
 export async function resolveBalances<C extends GetContractsHandler>(
   ctx: BalancesContext,
-  chain: Chain,
   contracts: Partial<Awaited<ReturnType<C>>['contracts']>,
   resolvers: {
     [key in keyof Partial<Awaited<ReturnType<C>>['contracts']>]: (
       ctx: BalancesContext,
-      chain: Chain,
       contracts: Awaited<ReturnType<C>>['contracts'][key],
     ) =>
       | Promise<Balance | Balance[] | Balance[][] | null | undefined>
@@ -182,7 +178,7 @@ export async function resolveBalances<C extends GetContractsHandler>(
       .map(async (contractKey) => {
         try {
           const resolver = resolvers[contractKey]
-          const balances = await resolver(ctx, chain, contracts[contractKey]!)
+          const balances = await resolver(ctx, contracts[contractKey]!)
           return balances
         } catch (error) {
           console.error(`Resolver ${contractKey} failed`, error)

--- a/src/lib/compound/v2/lending.ts
+++ b/src/lib/compound/v2/lending.ts
@@ -109,21 +109,17 @@ export async function getMarketsContracts(
   return contracts
 }
 
-export async function getMarketsBalances(
-  ctx: BalancesContext,
-  chain: Chain,
-  contracts: Contract[],
-): Promise<Balance[]> {
+export async function getMarketsBalances(ctx: BalancesContext, contracts: Contract[]): Promise<Balance[]> {
   const cTokenByAddress: { [key: string]: Contract } = {}
   for (const contract of contracts) {
     cTokenByAddress[contract.address] = contract
   }
 
   const [cTokensBalances, cTokensBorrowBalanceCurrentRes, cTokensExchangeRateCurrentRes] = await Promise.all([
-    getERC20BalanceOf(ctx, chain, contracts as Token[]),
+    getERC20BalanceOf(ctx, contracts as Token[]),
 
     multicall({
-      chain,
+      chain: ctx.chain,
       calls: contracts.map((token) => ({
         target: token.address,
         params: [ctx.address],
@@ -140,7 +136,7 @@ export async function getMarketsBalances(
     }),
 
     multicall({
-      chain,
+      chain: ctx.chain,
       calls: contracts.map((token) => ({
         target: token.address,
         params: [],

--- a/src/lib/erc20.ts
+++ b/src/lib/erc20.ts
@@ -59,9 +59,9 @@ export const abi = {
   },
 }
 
-export async function getERC20BalanceOf(ctx: BalancesContext, chain: Chain, tokens: Token[]): Promise<Balance[]> {
+export async function getERC20BalanceOf(ctx: BalancesContext, tokens: Token[]): Promise<Balance[]> {
   const balances = await multicall({
-    chain,
+    chain: ctx.chain,
     calls: tokens.map((token) => ({
       target: token.address,
       params: [ctx.address],
@@ -72,7 +72,7 @@ export async function getERC20BalanceOf(ctx: BalancesContext, chain: Chain, toke
   return tokens
     .map((token, i) => {
       if (!balances[i].success || balances[i].output == null) {
-        console.error(`Could not get balanceOf for token ${chain}:${token.address}`)
+        console.error(`Could not get balanceOf for token ${ctx.chain}:${token.address}`)
         return null
       }
 

--- a/src/lib/geist/lending.ts
+++ b/src/lib/geist/lending.ts
@@ -79,13 +79,12 @@ export interface GetLendingPoolBalancesParams {
 
 export async function getLendingPoolBalances(
   ctx: BalancesContext,
-  chain: Chain,
   contracts: Contract[],
   { chefIncentivesController }: GetLendingPoolBalancesParams,
 ) {
-  const provider = providers[chain]
+  const provider = providers[ctx.chain]
 
-  const balances = await getAaveLendingPoolBalances(ctx, chain, contracts)
+  const balances = await getAaveLendingPoolBalances(ctx, contracts)
 
   const balanceByAddress: { [key: string]: Balance } = {}
   for (const balance of balances) {

--- a/src/lib/pools.ts
+++ b/src/lib/pools.ts
@@ -19,15 +19,10 @@ export interface GetPoolsBalancesParams {
  * @param pools address: LP token address
  * @param params
  */
-export async function getPoolsBalances(
-  ctx: BalancesContext,
-  chain: Chain,
-  pools: Contract[],
-  params: GetPoolsBalancesParams,
-) {
-  const poolsBalances = await getERC20BalanceOf(ctx, chain, pools as Token[])
+export async function getPoolsBalances(ctx: BalancesContext, pools: Contract[], params: GetPoolsBalancesParams) {
+  const poolsBalances = await getERC20BalanceOf(ctx, pools as Token[])
 
-  return getPoolsUnderlyingBalances(chain, poolsBalances, params)
+  return getPoolsUnderlyingBalances(ctx.chain, poolsBalances, params)
 }
 
 export async function getPoolsUnderlyingBalances(chain: Chain, pools: Balance[], params: GetPoolsBalancesParams) {
@@ -122,18 +117,17 @@ export interface GetStakingPoolsBalancesParams extends GetPoolsBalancesParams {
  */
 export async function getStakingPoolsBalances(
   ctx: BalancesContext,
-  chain: Chain,
   pools: Contract[],
   params: GetStakingPoolsBalancesParams,
 ) {
   const { getLPTokenAddress } = params
   const stakingPoolsBalances: Balance[] = []
 
-  const poolsBalances = await getPoolsBalances(ctx, chain, pools, params)
+  const poolsBalances = await getPoolsBalances(ctx, pools, params)
 
   const [totalSuppliesRes, stakingTokenBalancesRes] = await Promise.all([
     multicall({
-      chain,
+      chain: ctx.chain,
       calls: poolsBalances.map((pool) => ({
         params: [],
         target: getLPTokenAddress(pool),
@@ -142,7 +136,7 @@ export async function getStakingPoolsBalances(
     }),
 
     multicallBalances({
-      chain,
+      chain: ctx.chain,
       calls: poolsBalances.map((pool) => ({
         params: [pool.address],
         target: getLPTokenAddress(pool),

--- a/src/lib/stake.ts
+++ b/src/lib/stake.ts
@@ -1,19 +1,13 @@
 import { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call, TCall } from '@lib/call'
 import { Category } from '@lib/category'
-import { Chain } from '@lib/chains'
 import { abi as erc20ABI, getERC20BalanceOf } from '@lib/erc20'
 import { Token } from '@lib/token'
 import { BigNumber } from 'ethers'
 
-export async function getSingleStakeBalance(
-  ctx: BalancesContext,
-  chain: Chain,
-  contract: Contract,
-  callOptions?: Partial<TCall>,
-) {
+export async function getSingleStakeBalance(ctx: BalancesContext, contract: Contract, callOptions?: Partial<TCall>) {
   const amountRes = await call({
-    chain,
+    chain: ctx.chain,
     abi: erc20ABI.balanceOf,
     target: contract.address,
     params: [ctx.address],
@@ -31,7 +25,7 @@ export async function getSingleStakeBalance(
   return balance
 }
 
-export async function getSingleStakeBalances(ctx: BalancesContext, chain: Chain, contracts: Contract[]) {
-  const balances = await getERC20BalanceOf(ctx, chain, contracts as Token[])
+export async function getSingleStakeBalances(ctx: BalancesContext, contracts: Contract[]) {
+  const balances = await getERC20BalanceOf(ctx, contracts as Token[])
   return balances.map((bal) => ({ ...bal, category: 'stake' as Category }))
 }

--- a/src/lib/uniswap/v2/pair.ts
+++ b/src/lib/uniswap/v2/pair.ts
@@ -44,10 +44,10 @@ export const abi = {
  * Retrieves pairs balances (with underlyings) of Uniswap V2 like Pair.
  * `amount`, `underlyings[0]` (token0) and `underlyings[1]` (token1) must be defined.
  */
-export async function getPairsBalances(ctx: BalancesContext, chain: Chain, contracts: Contract[]): Promise<Balance[]> {
-  const balances = await getERC20BalanceOf(ctx, chain, contracts as Token[])
+export async function getPairsBalances(ctx: BalancesContext, contracts: Contract[]): Promise<Balance[]> {
+  const balances = await getERC20BalanceOf(ctx, contracts as Token[])
 
-  return getUnderlyingBalances(chain, balances)
+  return getUnderlyingBalances(ctx.chain, balances)
 }
 
 /**


### PR DESCRIPTION
<!-- 🦙🦙 Thanks for contributing ! 🦙🦙 -->

<!-- Please specify the adapter id in the title -->

<!-- If you're creating a new adapter, please make sure the `links` field is well specified: this info will help us review it -->

## Summary

<!-- Which issues will be closed? (if applicable) -->

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

See: https://github.com/llamafolio/llamafolio-api/issues/239

remove extra `chain` arg in `resolveBalances` functions and helpers. `chain` is stored in the context, which contains more info like the current block

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
