### PR TITLE
LIDO return staked tokens instead of underlyings

### DIFF
--- a/src/adapters/lido/arbitrum/index.ts
+++ b/src/adapters/lido/arbitrum/index.ts
@@ -2,15 +2,7 @@ import { getWStEthStakeBalances } from '@adapters/lido/common/stake'
 import { Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
 
-const WETHArbitrum: Contract = {
-  address: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
-  chain: 'arbitrum',
-  symbol: 'WETH',
-  decimals: 18,
-  coingeckoId: 'weth',
-}
-
-const wstETHArbitrum: Contract = {
+const wstETH: Contract = {
   name: 'wstETH',
   displayName: 'Wrapped liquid staked Ether 2.0',
   chain: 'arbitrum',
@@ -18,20 +10,19 @@ const wstETHArbitrum: Contract = {
   symbol: 'wstETH',
   decimals: 18,
   coingeckoId: 'wrapped-steth',
-  underlyings: [WETHArbitrum],
 }
 
 export const getContracts = () => {
   return {
     contracts: {
-      wstETHArbitrum,
+      wstETH,
     },
   }
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
   const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
-    wstETHArbitrum: getWStEthStakeBalances,
+    wstETH: getWStEthStakeBalances,
   })
 
   return {

--- a/src/adapters/lido/common/stake.ts
+++ b/src/adapters/lido/common/stake.ts
@@ -27,19 +27,15 @@ export async function getWStEthStakeBalances(ctx: BalancesContext, contract: Con
   })
 
   const formattedBalanceOf = BigNumber.from(converterWStEthToStEthRes.output)
-  const underlying = contract.underlyings?.[0]
 
-  if (underlying) {
-    balances.push({
-      chain: ctx.chain,
-      decimals: contract.decimals,
-      symbol: contract.symbol,
-      address: contract.address,
-      amount: formattedBalanceOf,
-      underlyings: [{ ...underlying, symbol: contract.symbol }],
-      category: 'stake',
-    })
-  }
+  balances.push({
+    chain: ctx.chain,
+    decimals: contract.decimals,
+    symbol: contract.symbol,
+    address: contract.address,
+    amount: formattedBalanceOf,
+    category: 'stake',
+  })
 
   return balances
 }
@@ -55,19 +51,15 @@ export async function getStEthStakeBalances(ctx: BalancesContext, contract: Cont
   })
 
   const balanceOf = BigNumber.from(balanceOfRes.output)
-  const underlying = contract.underlyings?.[0]
 
-  if (underlying) {
-    balances.push({
-      chain: ctx.chain,
-      decimals: contract.decimals,
-      symbol: contract.symbol,
-      address: contract.address,
-      amount: balanceOf,
-      underlyings: [{ ...underlying, symbol: contract.symbol }],
-      category: 'stake',
-    })
-  }
+  balances.push({
+    chain: ctx.chain,
+    decimals: contract.decimals,
+    symbol: contract.symbol,
+    address: contract.address,
+    amount: balanceOf,
+    category: 'stake',
+  })
 
   return balances
 }
@@ -100,19 +92,15 @@ export async function getStMaticBalances(ctx: BalancesContext, contract: Contrac
   })
 
   const formattedBalanceOf = BigNumber.from(converterWStEthToStEthRes.output[0])
-  const underlying = contract.underlyings?.[0]
 
-  if (underlying) {
-    balances.push({
-      chain: ctx.chain,
-      decimals: contract.decimals,
-      symbol: contract.symbol,
-      address: contract.address,
-      amount: formattedBalanceOf,
-      underlyings: [{ ...underlying, symbol: contract.symbol }],
-      category: 'stake',
-    })
-  }
+  balances.push({
+    chain: ctx.chain,
+    decimals: contract.decimals,
+    symbol: contract.symbol,
+    address: contract.address,
+    amount: formattedBalanceOf,
+    category: 'stake',
+  })
 
   return balances
 }

--- a/src/adapters/lido/ethereum/index.ts
+++ b/src/adapters/lido/ethereum/index.ts
@@ -3,14 +3,6 @@ import { getStMaticBalances } from '@adapters/lido/common/stake'
 import { Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
 
-const WETH: Contract = {
-  address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-  chain: 'ethereum',
-  symbol: 'WETH',
-  decimals: 18,
-  coingeckoId: 'weth',
-}
-
 const stETH: Contract = {
   name: 'stETH',
   displayName: 'Liquid staked Ether 2.0',
@@ -19,7 +11,6 @@ const stETH: Contract = {
   symbol: 'stETH',
   decimals: 18,
   coingeckoId: 'staked-ether',
-  underlyings: [WETH],
 }
 
 const wstETH: Contract = {
@@ -30,26 +21,15 @@ const wstETH: Contract = {
   symbol: 'wstETH',
   decimals: 18,
   coingeckoId: 'wrapped-steth',
-  underlyings: [WETH],
 }
 
-const MATICEthereum: Contract = {
-  chain: 'ethereum',
-  address: '0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0',
-  name: 'MATIC',
-  symbol: 'MATIC',
-  decimals: 18,
-  coingeckoId: 'matic-network',
-}
-
-const stMATICEthereum: Contract = {
+const stMATIC: Contract = {
   chain: 'ethereum',
   address: '0x9ee91f9f426fa633d227f7a9b000e28b9dfd8599',
   name: 'Staked MATIC',
   symbol: 'stMATIC',
   decimals: 18,
   coingeckoId: 'lido-staked-matic',
-  underlyings: [MATICEthereum],
 }
 
 export const getContracts = () => {
@@ -57,7 +37,7 @@ export const getContracts = () => {
     contracts: {
       stETH,
       wstETH,
-      stMATICEthereum,
+      stMATIC,
     },
   }
 }
@@ -66,7 +46,7 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     stETH: getStEthStakeBalances,
     wstETH: getWStEthStakeBalances,
-    stMATICEthereum: getStMaticBalances,
+    stMATIC: getStMaticBalances,
   })
 
   return {

--- a/src/adapters/lido/optimism/index.ts
+++ b/src/adapters/lido/optimism/index.ts
@@ -2,15 +2,7 @@ import { getWStEthStakeBalances } from '@adapters/lido/common/stake'
 import { Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
 
-const WETHOptimism: Contract = {
-  address: '0x4200000000000000000000000000000000000006',
-  chain: 'optimism',
-  symbol: 'WETH',
-  decimals: 18,
-  coingeckoId: 'weth',
-}
-
-const wstETHOptimism: Contract = {
+const wstETH: Contract = {
   name: 'wstETH',
   displayName: 'Wrapped liquid staked Ether 2.0',
   chain: 'optimism',
@@ -18,20 +10,19 @@ const wstETHOptimism: Contract = {
   symbol: 'wstETH',
   decimals: 18,
   coingeckoId: 'wrapped-steth',
-  underlyings: [WETHOptimism],
 }
 
 export const getContracts = () => {
   return {
     contracts: {
-      wstETHOptimism,
+      wstETH,
     },
   }
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
   const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
-    wstETHOptimism: getWStEthStakeBalances,
+    wstETH: getWStEthStakeBalances,
   })
 
   return {


### PR DESCRIPTION
<!-- 🦙🦙 Thanks for contributing ! 🦙🦙 -->

<!-- Please specify the adapter id in the title -->

<!-- If you're creating a new adapter, please make sure the `links` field is well specified: this info will help us review it -->

## Summary

<!-- Which issues will be closed? (if applicable) -->

<!-- What changes are being made? -->
- Small change of symbol returned to Lido adapter in order to clearly distinguish wstETH | stETH | WETH
<!-- Why are these changes necessary? -->
![lido_symbol](https://user-images.githubusercontent.com/110820448/210324110-5ee8438a-bc81-4851-b727-cc39009a84f1.png)

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
