### PR TITLE
feat: add endpoint latest snapshot

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -150,6 +150,14 @@ functions:
           method: get
           path: /protocols/latest
 
+  getLatestSnapshot:
+    handler: src/handlers/getLatestSnapshot.handler
+    description: Get latest snapshot
+    events:
+      - httpApi:
+          method: get
+          path: /snapshots/{address}/latest
+
   getSyncStatus:
     handler: src/handlers/getSyncStatus.handler
     description: Get sync status

--- a/src/handlers/getLatestSnapshot.ts
+++ b/src/handlers/getLatestSnapshot.ts
@@ -1,0 +1,49 @@
+import { selectLastBalancesSnapshotsByFromAddress } from '@db/balances-snapshots'
+import pool from '@db/pool'
+import { badRequest, serverError, success } from '@handlers/response'
+import { sumBalances } from '@lib/balance'
+import { isHex } from '@lib/buf'
+import { TUnixTimestamp } from '@lib/type'
+import { APIGatewayProxyHandler } from 'aws-lambda'
+
+interface LatestSnapshotResponse {
+  balanceUSD: number
+  updatedAt: TUnixTimestamp
+}
+
+export const handler: APIGatewayProxyHandler = async (event, context) => {
+  context.callbackWaitsForEmptyEventLoop = false
+
+  const address = event.pathParameters?.address
+  if (!address) {
+    return badRequest('Missing address parameter')
+  }
+  if (!isHex(address)) {
+    return badRequest('Invalid address parameter, expected hex')
+  }
+
+  const client = await pool.connect()
+
+  try {
+    const lastBalancesSnapshots = await selectLastBalancesSnapshotsByFromAddress(client, address)
+
+    if (lastBalancesSnapshots.length === 0) {
+      // balances updates minimum interval is 2 minutes
+      return success({}, { maxAge: 2 * 60 })
+    }
+
+    const timestamp = lastBalancesSnapshots[0].timestamp
+
+    const response: LatestSnapshotResponse = {
+      updatedAt: Math.floor(new Date(timestamp).getTime()),
+      balanceUSD: sumBalances(lastBalancesSnapshots),
+    }
+
+    return success(response, { maxAge: 2 * 60 })
+  } catch (e) {
+    console.error('Failed to retrieve latest snapshot', e)
+    return serverError('Failed to retrieve latest snapshot')
+  } finally {
+    client.release(true)
+  }
+}

--- a/src/lib/type.ts
+++ b/src/lib/type.ts
@@ -7,3 +7,5 @@ export function isNotNullish<T>(param: T | undefined | null): param is T {
 export function isSuccess<T, P, O>(param: MultiCallResult<T, P, O>): param is MultiCallResult<T, P, NonNullable<O>> {
   return param.success
 }
+
+export type TUnixTimestamp = number


### PR DESCRIPTION
<!-- 🦙🦙 Thanks for contributing ! 🦙🦙 -->

<!-- Please specify the adapter id in the title -->

<!-- If you're creating a new adapter, please make sure the `links` field is well specified: this info will help us review it -->

## Summary

<!-- Which issues will be closed? (if applicable) -->

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

Fix: https://github.com/llamafolio/llamafolio-api/issues/286

Retrieve latest balance snapshot from an account

Endpoint available at: `/snapshots/{address}/latest`

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
