### PR TITLE
Feat, Reduce max-age from 15 to 5

### DIFF
--- a/src/handlers/getBalances.ts
+++ b/src/handlers/getBalances.ts
@@ -209,8 +209,7 @@ export const handler: APIGatewayProxyHandler = async (event, context) => {
       protocols,
     }
 
-    // max-age 15sec as it's the average time to refresh balances
-    return success(balancesResponse, { maxAge: 15 })
+    return success(balancesResponse, { maxAge: status === 'success' ? 15 : 5 })
   } catch (error) {
     console.error('Failed to retrieve balances', { error, address })
     return serverError('Failed to retrieve balances')


### PR DESCRIPTION
## Summary
Now we have the problem that the browser caches requests to /balance for 15 seconds because of the max-age=15 set.

We should lower this value to 5 for new ('empty') addresses. Otherwise, when a user tries to request data from a new address, and it does not have time to be processed in 15 seconds, the user will have to wait an extra 15 seconds, i.e., at least 30 seconds. This is too long.

<img width="852" alt="CleanShot 2023-01-18 at 10 54 40@2x" src="https://user-images.githubusercontent.com/37555845/213079605-99ad11f0-dfff-4ae9-bc11-ab7585d4207e.png">

## Checklist

- [x] I checked my changes for obvious issues, debug statements, and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
