### PR TITLE
feat: protocols storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,6 @@
         "@defillama/sdk": "^3.0.8",
         "@llamafolio/tokens": "file:./llamafolio-tokens",
         "aws-sdk": "^2.1189.0",
-        "canvas": "^2.11.0",
-        "color-thief-node": "^1.0.4",
         "dotenv": "^16.0.1",
         "ethers": "^5.6.9",
         "graphql": "^16.6.0",
@@ -2297,24 +2295,6 @@
       "resolved": "llamafolio-tokens",
       "link": true
     },
-    "node_modules/@mapbox/node-pre-gyp": {
-      "version": "1.0.10",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "make-dir": "^3.1.0",
-        "node-fetch": "^2.6.7",
-        "nopt": "^5.0.0",
-        "npmlog": "^5.0.1",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "tar": "^6.1.11"
-      },
-      "bin": {
-        "node-pre-gyp": "bin/node-pre-gyp"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -2951,10 +2931,6 @@
         "es5-ext": "^0.10.47"
       }
     },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "license": "ISC"
-    },
     "node_modules/acorn": {
       "version": "8.8.0",
       "dev": true,
@@ -2996,6 +2972,7 @@
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -3071,6 +3048,7 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3101,10 +3079,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/aproba": {
-      "version": "2.0.0",
-      "license": "ISC"
     },
     "node_modules/archive-type": {
       "version": "4.0.0",
@@ -3187,17 +3161,6 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "2.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/arg": {
@@ -3378,6 +3341,7 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -3613,6 +3577,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3838,49 +3803,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/canvas": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.0.tgz",
-      "integrity": "sha512-bdTjFexjKJEwtIo0oRx8eD4G2yWoUOXP9lj279jmQ2zMnTQhT8C3512OKz3s+ZOaQlLbE7TuVvRDYDB3Llyy5g==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@mapbox/node-pre-gyp": "^1.0.0",
-        "nan": "^2.17.0",
-        "simple-get": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/canvas/node_modules/decompress-response": {
-      "version": "4.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/canvas/node_modules/mimic-response": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/canvas/node_modules/simple-get": {
-      "version": "3.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^4.2.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "dev": true,
@@ -3960,6 +3882,7 @@
     },
     "node_modules/chownr": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -4173,20 +4096,6 @@
         "simple-swizzle": "^0.2.2"
       }
     },
-    "node_modules/color-support": {
-      "version": "1.1.3",
-      "license": "ISC",
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
-    "node_modules/color-thief-node": {
-      "version": "1.0.4",
-      "license": "ISC",
-      "dependencies": {
-        "canvas": "^2.5.0"
-      }
-    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "license": "MIT",
@@ -4238,11 +4147,8 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "license": "ISC"
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -4698,10 +4604,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
     "node_modules/denque": {
       "version": "2.1.0",
       "license": "Apache-2.0",
@@ -4711,6 +4613,7 @@
     },
     "node_modules/detect-libc": {
       "version": "2.0.1",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -4840,6 +4743,7 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/end-of-stream": {
@@ -6042,6 +5946,7 @@
     },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
@@ -6052,6 +5957,7 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/fs2": {
@@ -6108,24 +6014,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/gauge": {
-      "version": "3.0.2",
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.2",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.1",
-        "object-assign": "^4.1.1",
-        "signal-exit": "^3.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/gensync": {
@@ -6207,6 +6095,7 @@
     },
     "node_modules/glob": {
       "version": "7.2.3",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -6381,10 +6270,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-unicode": {
-      "version": "2.0.1",
-      "license": "ISC"
-    },
     "node_modules/hash.js": {
       "version": "1.1.7",
       "license": "MIT",
@@ -6434,6 +6319,7 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -6538,6 +6424,7 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -6724,6 +6611,7 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8089,6 +7977,7 @@
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -8115,6 +8004,7 @@
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^6.0.0"
@@ -8128,6 +8018,7 @@
     },
     "node_modules/make-dir/node_modules/semver": {
       "version": "6.3.0",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8297,6 +8188,7 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -8312,6 +8204,7 @@
     },
     "node_modules/minipass": {
       "version": "3.3.3",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -8322,6 +8215,7 @@
     },
     "node_modules/minizlib": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^3.0.0",
@@ -8333,6 +8227,7 @@
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -8354,10 +8249,6 @@
       "version": "0.0.8",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/nan": {
-      "version": "2.17.0",
-      "license": "MIT"
     },
     "node_modules/napi-build-utils": {
       "version": "1.0.2",
@@ -8535,19 +8426,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/nopt": {
-      "version": "5.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "dev": true,
@@ -8603,18 +8481,9 @@
         "node": ">=8"
       }
     },
-    "node_modules/npmlog": {
-      "version": "5.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "are-we-there-yet": "^2.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^3.0.0",
-        "set-blocking": "^2.0.0"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8672,6 +8541,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -8941,6 +8811,7 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9397,6 +9268,7 @@
     },
     "node_modules/readable-stream": {
       "version": "3.6.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -9587,6 +9459,7 @@
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -9708,6 +9581,7 @@
     },
     "node_modules/semver": {
       "version": "7.3.8",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -10095,10 +9969,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "license": "ISC"
-    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "dev": true,
@@ -10159,10 +10029,12 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10343,6 +10215,7 @@
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -10362,6 +10235,7 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -10416,6 +10290,7 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -10570,6 +10445,7 @@
     },
     "node_modules/tar": {
       "version": "6.1.11",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "chownr": "^2.0.0",
@@ -11079,6 +10955,7 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {
@@ -11217,13 +11094,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/wide-align": {
-      "version": "1.1.5",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
-    },
     "node_modules/widest-line": {
       "version": "4.0.1",
       "dev": true,
@@ -11310,6 +11180,7 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -11375,6 +11246,7 @@
     },
     "node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml-ast-parser": {
@@ -13019,20 +12891,6 @@
         "typescript": "^4.8.3"
       }
     },
-    "@mapbox/node-pre-gyp": {
-      "version": "1.0.10",
-      "requires": {
-        "detect-libc": "^2.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "make-dir": "^3.1.0",
-        "node-fetch": "^2.6.7",
-        "nopt": "^5.0.0",
-        "npmlog": "^5.0.1",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "tar": "^6.1.11"
-      }
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -13479,9 +13337,6 @@
         "es5-ext": "^0.10.47"
       }
     },
-    "abbrev": {
-      "version": "1.1.1"
-    },
     "acorn": {
       "version": "8.8.0",
       "dev": true
@@ -13504,6 +13359,7 @@
     },
     "agent-base": {
       "version": "6.0.2",
+      "dev": true,
       "requires": {
         "debug": "4"
       }
@@ -13548,7 +13404,8 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.1"
+      "version": "5.0.1",
+      "dev": true
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -13564,9 +13421,6 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
-    },
-    "aproba": {
-      "version": "2.0.0"
     },
     "archive-type": {
       "version": "4.0.0",
@@ -13634,13 +13488,6 @@
             "safe-buffer": "~5.1.0"
           }
         }
-      }
-    },
-    "are-we-there-yet": {
-      "version": "2.0.0",
-      "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
       }
     },
     "arg": {
@@ -13764,7 +13611,8 @@
       }
     },
     "balanced-match": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "base64-js": {
       "version": "1.5.1"
@@ -13889,6 +13737,7 @@
     },
     "brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -14024,35 +13873,6 @@
       "version": "1.0.30001374",
       "dev": true
     },
-    "canvas": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.0.tgz",
-      "integrity": "sha512-bdTjFexjKJEwtIo0oRx8eD4G2yWoUOXP9lj279jmQ2zMnTQhT8C3512OKz3s+ZOaQlLbE7TuVvRDYDB3Llyy5g==",
-      "requires": {
-        "@mapbox/node-pre-gyp": "^1.0.0",
-        "nan": "^2.17.0",
-        "simple-get": "^3.0.3"
-      },
-      "dependencies": {
-        "decompress-response": {
-          "version": "4.2.1",
-          "requires": {
-            "mimic-response": "^2.0.0"
-          }
-        },
-        "mimic-response": {
-          "version": "2.1.0"
-        },
-        "simple-get": {
-          "version": "3.1.1",
-          "requires": {
-            "decompress-response": "^4.2.0",
-            "once": "^1.3.1",
-            "simple-concat": "^1.0.0"
-          }
-        }
-      }
-    },
     "chalk": {
       "version": "4.1.2",
       "dev": true,
@@ -14104,7 +13924,8 @@
       }
     },
     "chownr": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "ci-info": {
       "version": "3.3.2",
@@ -14242,15 +14063,6 @@
         "simple-swizzle": "^0.2.2"
       }
     },
-    "color-support": {
-      "version": "1.1.3"
-    },
-    "color-thief-node": {
-      "version": "1.0.4",
-      "requires": {
-        "canvas": "^2.5.0"
-      }
-    },
     "combined-stream": {
       "version": "1.0.8",
       "requires": {
@@ -14284,10 +14096,8 @@
       }
     },
     "concat-map": {
-      "version": "0.0.1"
-    },
-    "console-control-strings": {
-      "version": "1.1.0"
+      "version": "0.0.1",
+      "dev": true
     },
     "content-disposition": {
       "version": "0.5.4",
@@ -14608,14 +14418,12 @@
     "delayed-stream": {
       "version": "1.0.0"
     },
-    "delegates": {
-      "version": "1.0.0"
-    },
     "denque": {
       "version": "2.1.0"
     },
     "detect-libc": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "dev": true
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -14703,7 +14511,8 @@
       "dev": true
     },
     "emoji-regex": {
-      "version": "8.0.0"
+      "version": "8.0.0",
+      "dev": true
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -15467,12 +15276,14 @@
     },
     "fs-minipass": {
       "version": "2.1.0",
+      "dev": true,
       "requires": {
         "minipass": "^3.0.0"
       }
     },
     "fs.realpath": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "fs2": {
       "version": "0.3.9",
@@ -15506,20 +15317,6 @@
     },
     "functions-have-names": {
       "version": "1.2.3"
-    },
-    "gauge": {
-      "version": "3.0.2",
-      "requires": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.2",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.1",
-        "object-assign": "^4.1.1",
-        "signal-exit": "^3.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.2"
-      }
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -15562,6 +15359,7 @@
     },
     "glob": {
       "version": "7.2.3",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -15666,9 +15464,6 @@
         "has-symbols": "^1.0.2"
       }
     },
-    "has-unicode": {
-      "version": "2.0.1"
-    },
     "hash.js": {
       "version": "1.1.7",
       "requires": {
@@ -15706,6 +15501,7 @@
     },
     "https-proxy-agent": {
       "version": "5.0.1",
+      "dev": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"
@@ -15765,6 +15561,7 @@
     },
     "inflight": {
       "version": "1.0.6",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -15876,7 +15673,8 @@
       "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
     },
     "is-generator-fn": {
       "version": "2.1.0",
@@ -16811,6 +16609,7 @@
     },
     "lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -16828,12 +16627,14 @@
     },
     "make-dir": {
       "version": "3.1.0",
+      "dev": true,
       "requires": {
         "semver": "^6.0.0"
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0"
+          "version": "6.3.0",
+          "dev": true
         }
       }
     },
@@ -16946,6 +16747,7 @@
     },
     "minimatch": {
       "version": "3.1.2",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -16956,19 +16758,22 @@
     },
     "minipass": {
       "version": "3.3.3",
+      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
     },
     "minizlib": {
       "version": "2.1.2",
+      "dev": true,
       "requires": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
       }
     },
     "mkdirp": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "dev": true
     },
     "mkdirp-classic": {
       "version": "0.5.3",
@@ -16980,9 +16785,6 @@
     "mute-stream": {
       "version": "0.0.8",
       "dev": true
-    },
-    "nan": {
-      "version": "2.17.0"
     },
     "napi-build-utils": {
       "version": "1.0.2",
@@ -17096,12 +16898,6 @@
         "sorted-array-functions": "^1.3.0"
       }
     },
-    "nopt": {
-      "version": "5.0.0",
-      "requires": {
-        "abbrev": "1"
-      }
-    },
     "normalize-path": {
       "version": "3.0.0",
       "dev": true
@@ -17136,17 +16932,9 @@
         }
       }
     },
-    "npmlog": {
-      "version": "5.0.1",
-      "requires": {
-        "are-we-there-yet": "^2.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^3.0.0",
-        "set-blocking": "^2.0.0"
-      }
-    },
     "object-assign": {
-      "version": "4.1.1"
+      "version": "4.1.1",
+      "dev": true
     },
     "object-hash": {
       "version": "2.2.0",
@@ -17177,6 +16965,7 @@
     },
     "once": {
       "version": "1.4.0",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -17333,7 +17122,8 @@
       "dev": true
     },
     "path-is-absolute": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "path-key": {
       "version": "2.0.1",
@@ -17597,6 +17387,7 @@
     },
     "readable-stream": {
       "version": "3.6.0",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -17706,6 +17497,7 @@
     },
     "rimraf": {
       "version": "3.0.2",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -17763,6 +17555,7 @@
     },
     "semver": {
       "version": "7.3.8",
+      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -18006,9 +17799,6 @@
         "bluebird": "^3.7.2"
       }
     },
-    "set-blocking": {
-      "version": "2.0.0"
-    },
     "setimmediate": {
       "version": "1.0.5",
       "dev": true
@@ -18047,10 +17837,12 @@
       }
     },
     "signal-exit": {
-      "version": "3.0.7"
+      "version": "3.0.7",
+      "dev": true
     },
     "simple-concat": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "simple-get": {
       "version": "4.0.1",
@@ -18166,6 +17958,7 @@
     },
     "string_decoder": {
       "version": "1.3.0",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       }
@@ -18180,6 +17973,7 @@
     },
     "string-width": {
       "version": "4.2.3",
+      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -18218,6 +18012,7 @@
     },
     "strip-ansi": {
       "version": "6.0.1",
+      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -18314,6 +18109,7 @@
     },
     "tar": {
       "version": "6.1.11",
+      "dev": true,
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -18620,7 +18416,8 @@
       }
     },
     "util-deprecate": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "uuid": {
       "version": "8.3.2",
@@ -18719,12 +18516,6 @@
         "is-typed-array": "^1.1.9"
       }
     },
-    "wide-align": {
-      "version": "1.1.5",
-      "requires": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
-    },
     "widest-line": {
       "version": "4.0.1",
       "dev": true,
@@ -18772,7 +18563,8 @@
       }
     },
     "wrappy": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "write-file-atomic": {
       "version": "4.0.1",
@@ -18804,7 +18596,8 @@
       "dev": true
     },
     "yallist": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "dev": true
     },
     "yaml-ast-parser": {
       "version": "0.0.43",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "LlamaFolio API",
   "scripts": {
     "adapter": "ts-node -T scripts/run-adapter.ts",
-    "build": "ts-node -T scripts/build-adapters.ts",
+    "build-adapters": "ts-node -T scripts/build-adapters.ts",
+    "build": "npm run build-adapters",
     "dev": "sls offline",
     "deploy:dev": "npm run postinstall && npm run build && NODE_ENV=dev sls deploy --stage dev",
     "deploy:prod": "npm run postinstall && npm run build && NODE_ENV=prod sls deploy --stage prod",
@@ -33,8 +34,6 @@
     "@defillama/sdk": "^3.0.8",
     "@llamafolio/tokens": "file:./llamafolio-tokens",
     "aws-sdk": "^2.1189.0",
-    "canvas": "^2.11.0",
-    "color-thief-node": "^1.0.4",
     "dotenv": "^16.0.1",
     "ethers": "^5.6.9",
     "graphql": "^16.6.0",

--- a/scripts/create-adapter.ts
+++ b/scripts/create-adapter.ts
@@ -2,7 +2,6 @@ import { execSync } from 'child_process'
 import fs from 'fs'
 import path from 'path'
 
-import { keyBy } from '../src/lib/array'
 import { chainIdResolver } from '../src/lib/chains'
 import { fetchProtocolsLite } from '../src/lib/protocols'
 
@@ -71,9 +70,8 @@ async function main() {
     return
   }
 
-  const protocols = await fetchProtocolsLite()
-  const protocolBySlug = keyBy(protocols, 'slug')
-  const protocol = protocolBySlug[slug]
+  const protocols = await fetchProtocolsLite([slug])
+  const protocol = protocols[0]
 
   if (!protocol) {
     console.error(`Failed to create adapter: ${slug} doesn't exist on DefiLlama`)

--- a/serverless.yml
+++ b/serverless.yml
@@ -204,6 +204,13 @@ functions:
     events:
       - schedule: rate(10 minutes)
 
+  scheduledUpdateProtocols:
+    handler: src/handlers/updateProtocols.scheduledUpdateProtocols
+    description: Scheduled update protocols
+    events:
+      # every new hour
+      - schedule: cron(0 * * * ? *)
+
   scheduledUpdateYields:
     handler: src/handlers/updateYields.scheduledUpdateYields
     description: Scheduled update yields

--- a/src/adapters/adapter-smoke.test.ts
+++ b/src/adapters/adapter-smoke.test.ts
@@ -1,13 +1,13 @@
 import { adapters } from '@adapters/index'
 import { groupBy } from '@lib/array'
-import { fetchProtocolsLite, IProtocolLite } from '@lib/protocols'
+import { fetchProtocolsLite, IProtocol } from '@lib/protocols'
 
 describe('metadata basic validations', () => {
   let protocolById: { [key: string]: any } = {}
-  let protocols: IProtocolLite[] = []
+  let protocols: IProtocol[] = []
 
   beforeAll(async () => {
-    protocols = await fetchProtocolsLite()
+    protocols = await fetchProtocolsLite(adapters.map((adapter) => adapter.id))
     protocolById = groupBy(protocols, 'slug')
   })
 

--- a/src/db/adapters.ts
+++ b/src/db/adapters.ts
@@ -112,8 +112,8 @@ export async function selectAdapter(client: PoolClient, chain: Chain, adapterId:
   return adaptersRes.rows.length === 1 ? fromStorage(adaptersRes.rows)[0] : null
 }
 
-export async function selectDistinctIdAdapters(client: PoolClient) {
-  const adaptersRes = await client.query(`select distinct(id), * from adapters;`, [])
+export async function selectDistinctAdaptersIds(client: PoolClient) {
+  const adaptersRes = await client.query(`select distinct(id) from adapters;`, [])
 
   return fromStorage(adaptersRes.rows)
 }

--- a/src/handlers/getAdapters.ts
+++ b/src/handlers/getAdapters.ts
@@ -1,4 +1,4 @@
-import { selectDistinctIdAdapters } from '@db/adapters'
+import { selectDistinctAdaptersIds } from '@db/adapters'
 import pool from '@db/pool'
 import { serverError, success } from '@handlers/response'
 import { APIGatewayProxyHandler } from 'aws-lambda'
@@ -9,7 +9,7 @@ export const handler: APIGatewayProxyHandler = async (_event, context) => {
   const client = await pool.connect()
 
   try {
-    const adapters = await selectDistinctIdAdapters(client)
+    const adapters = await selectDistinctAdaptersIds(client)
 
     return success(
       {

--- a/src/handlers/getProtocols.ts
+++ b/src/handlers/getProtocols.ts
@@ -3,17 +3,10 @@ import { selectProtocols } from '@db/protocols'
 import { success } from '@handlers/response'
 import { APIGatewayProxyHandler } from 'aws-lambda'
 
-export const handler: APIGatewayProxyHandler = async (event) => {
-  const ids = event.queryStringParameters?.ids?.split(',') ?? []
-
+export const handler: APIGatewayProxyHandler = async () => {
   const client = await pool.connect()
 
-  const protocols = await selectProtocols(client, ids)
+  const protocols = await selectProtocols(client)
 
-  return success(
-    {
-      protocols,
-    },
-    { maxAge: 60 * 60 },
-  )
+  return success({ protocols }, { maxAge: 60 * 60 })
 }

--- a/src/handlers/revalidateAdapters.ts
+++ b/src/handlers/revalidateAdapters.ts
@@ -3,7 +3,7 @@ import {
   Adapter as DBAdapter,
   selectAdapter,
   selectAdaptersContractsExpired,
-  selectDistinctIdAdapters,
+  selectDistinctAdaptersIds,
   upsertAdapters,
 } from '@db/adapters'
 import { deleteContractsByAdapter, insertContracts } from '@db/contracts'
@@ -23,7 +23,7 @@ const revalidateAdaptersContracts: APIGatewayProxyHandler = async (_event, conte
   try {
     const [expiredAdaptersRes, adapterIdsRes] = await Promise.all([
       selectAdaptersContractsExpired(client),
-      selectDistinctIdAdapters(client),
+      selectDistinctAdaptersIds(client),
     ])
 
     const adapterIds = new Set(adapterIdsRes.map((adapter) => adapter.id))

--- a/src/handlers/updateProtocols.ts
+++ b/src/handlers/updateProtocols.ts
@@ -1,0 +1,45 @@
+import { selectDistinctAdaptersIds } from '@db/adapters'
+import pool from '@db/pool'
+import { deleteAllProtocols, insertProtocols } from '@db/protocols'
+import { STAGE } from '@env'
+import { serverError, success } from '@handlers/response'
+import { invokeLambda, wrapScheduledLambda } from '@lib/lambda'
+import { fetchProtocols } from '@lib/protocols'
+import { APIGatewayProxyHandler } from 'aws-lambda'
+
+const updateProtocols: APIGatewayProxyHandler = async () => {
+  await invokeLambda(`llamafolio-api-${STAGE}-updateProtocols`, {}, 'Event')
+
+  return success({})
+}
+
+export const scheduledUpdateProtocols = wrapScheduledLambda(updateProtocols)
+
+export const handler: APIGatewayProxyHandler = async (_event, context) => {
+  context.callbackWaitsForEmptyEventLoop = false
+
+  const client = await pool.connect()
+
+  try {
+    const adapters = await selectDistinctAdaptersIds(client)
+
+    const adaptersIds = adapters.map((adapter) => adapter.id)
+
+    const protocols = await fetchProtocols(adaptersIds)
+
+    await client.query('BEGIN')
+
+    await deleteAllProtocols(client)
+
+    await insertProtocols(client, protocols)
+
+    await client.query('COMMIT')
+
+    console.log(`Inserted ${protocols.length} protocols`)
+
+    return success({})
+  } catch (e) {
+    console.log('Failed to update protocols', e)
+    return serverError('Failed to update protocols')
+  }
+}


### PR DESCRIPTION
## Summary

This PR aggregates all the requests for protocol information into a script and stores it for easy fetch.

The protocol information is separated into 3 requests:
1. Fetch the protocol lite data.
2. Fetch the protocol config data.
3. Fetch the protocol palette from the logo.

To work, the `colorThief` package is replaced with `color-thief-node`, which needs the usage of `canvas`. 

This modification doesn't work "out of the box" it requires some packages (`librsvg`, `pixman`, `pango` and `cairo`)

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI