### PR TITLE
fix: filter zero balances

### DIFF
--- a/src/handlers/getBalances.ts
+++ b/src/handlers/getBalances.ts
@@ -6,7 +6,7 @@ import { selectYieldsByKeys } from '@db/yields'
 import { badRequest, serverError, success } from '@handlers/response'
 import { Balance, ContractStandard, Lock } from '@lib/adapter'
 import { groupBy } from '@lib/array'
-import { areBalancesStale } from '@lib/balance'
+import { areBalancesStale, isBalanceUSDGtZero } from '@lib/balance'
 import { isHex } from '@lib/buf'
 import { Category } from '@lib/category'
 import { Chain } from '@lib/chains'
@@ -176,7 +176,9 @@ export const handler: APIGatewayProxyHandler = async (event, context) => {
       selectLastBalancesSnapshotsByFromAddress(client, address),
     ])
 
-    const pricedBalancesWithYields = await getBalancesYields(redisClient, pricedBalances)
+    const nonZeroPricedBalances = pricedBalances.filter(isBalanceUSDGtZero)
+
+    const pricedBalancesWithYields = await getBalancesYields(redisClient, nonZeroPricedBalances)
 
     const protocols: BalancesProtocolResponse[] = []
     const balancesByAdapterId = groupBy(pricedBalancesWithYields, 'adapterId')

--- a/src/handlers/getBalancesTokens.ts
+++ b/src/handlers/getBalancesTokens.ts
@@ -4,7 +4,7 @@ import pool from '@db/pool'
 import { badRequest, serverError, success } from '@handlers/response'
 import { BalancesContext, PricedBalance } from '@lib/adapter'
 import { groupBy } from '@lib/array'
-import { sanitizeBalances, sortBalances, sumBalances } from '@lib/balance'
+import { isBalanceUSDGtZero, sanitizeBalances, sortBalances, sumBalances } from '@lib/balance'
 import { isHex } from '@lib/buf'
 import { Chain, chainById } from '@lib/chains'
 import { getPricedBalances } from '@lib/price'
@@ -109,15 +109,17 @@ export const handler: APIGatewayProxyHandler = async (event, context) => {
 
     const pricedBalances = await getPricedBalances(sanitizedBalances)
 
+    const nonZeroPricedBalances = pricedBalances.filter(isBalanceUSDGtZero)
+
     const hrend = process.hrtime(hrstart)
 
     console.log(
-      `getPricedBalances ${sanitizedBalances.length} balances, found ${pricedBalances.length} balances in %ds %dms`,
+      `getPricedBalances ${sanitizedBalances.length} balances, found ${nonZeroPricedBalances.length} balances in %ds %dms`,
       hrend[0],
       hrend[1] / 1000000,
     )
 
-    const pricedBalancesByChain = groupBy(pricedBalances, 'chain')
+    const pricedBalancesByChain = groupBy(nonZeroPricedBalances, 'chain')
 
     const now = new Date()
 


### PR DESCRIPTION
<!-- 🦙🦙 Thanks for contributing ! 🦙🦙 -->

<!-- Please specify the adapter id in the title -->

<!-- If you're creating a new adapter, please make sure the `links` field is well specified: this info will help us review it -->

## Summary

<!-- Which issues will be closed? (if applicable) -->

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

fix: https://github.com/llamafolio/llamafolio-api/issues/389

Filter out balances where we successfully fetched the price and amount but the total USD is 0

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
