### PR TITLE
Fix, Frax

### DIFF
--- a/src/adapters/frax-finance/providers/uniswapNFT.ts
+++ b/src/adapters/frax-finance/providers/uniswapNFT.ts
@@ -1,3 +1,4 @@
+import { getTokenIdsBalances } from '@adapters/uniswap-v3/common/pools'
 import { factory, nonFungiblePositionManager } from '@adapters/uniswap-v3/ethereum'
 import { BalancesContext, BaseContext, Contract } from '@lib/adapter'
 import { Call, multicall } from '@lib/multicall'


### PR DESCRIPTION
Small fix on frax.

uniswapNFTProvider was not working since `getTokenIdsBalances`  function was not import