### PR TITLE
Adapter, Liquity, Fix

### DIFF
--- a/src/adapters/liquity/ethereum/index.ts
+++ b/src/adapters/liquity/ethereum/index.ts
@@ -2,7 +2,7 @@ import { Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
 
 import { getFarmBalance } from './farm'
-import { getLendBalances } from './lend'
+import { getHealthFactor, getLendBalances } from './lend'
 import { getStakeBalances } from './stake'
 
 const stabilityPool: Contract = {
@@ -63,10 +63,10 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
     lqtyStaking: getStakeBalances,
   })
 
-  // const healthFactor = await getHealthFactor(ctx, balances)
+  const healthFactor = await getHealthFactor(ctx, balances)
 
   return {
     balances,
-    // healthFactor,
+    healthFactor,
   }
 }

--- a/src/adapters/liquity/ethereum/lend.ts
+++ b/src/adapters/liquity/ethereum/lend.ts
@@ -90,8 +90,7 @@ export async function getLendBalances(ctx: BalancesContext, troveManager: Contra
   return balances
 }
 
-export const getHealthFactor = async (ctx: BalancesContext, balances: Balance[]): Promise<number[] | undefined> => {
-  const healthFactor: number[] = []
+export const getHealthFactor = async (ctx: BalancesContext, balances: Balance[]): Promise<number | undefined> => {
   const priceFeedRes = await call({ ctx, target: priceFeed.address, abi: abi.Price })
 
   const lendAmounts = balances
@@ -102,16 +101,7 @@ export const getHealthFactor = async (ctx: BalancesContext, balances: Balance[])
     .filter((balance) => balance.category === 'borrow')
     .map((balance) => balance.amount.mul(MCR).div(utils.parseEther('1.0')))
 
-  for (let idx = 0; idx < lendAmounts.length; idx++) {
-    const lendAmount = lendAmounts[idx]
-    const borrowAmount = borrowAmounts[idx]
-
-    if (!borrowAmount) {
-      return
-    }
-
-    healthFactor.push(+lendAmount.mul(1e3).div(borrowAmount) / 1e3)
-  }
+  const healthFactor = Number(lendAmounts[0].mul(1e3).div(borrowAmounts[0])) / 1e3
 
   return healthFactor
 }


### PR DESCRIPTION
### Adapter, Liquity, Fix

Add healthfactor to liquity adapter, but still 'comment' to prevent llamafolio crash when clicking on drawerPanel until we find a way to show healthfactor as an array

`npm run adapter-balances liquity ethereum 0xbdfa4f4492dd7b7cf211209c4791af8d52bf5c50`

![health_liquity](https://user-images.githubusercontent.com/110820448/223974544-4774dded-61e2-4258-bc0a-76757b93c3fa.png)

