### PR TITLE
feat: balances groups adapters partial support

### DIFF
--- a/scripts/run-adapter-balances.ts
+++ b/scripts/run-adapter-balances.ts
@@ -58,7 +58,8 @@ async function main() {
       groupContracts(contracts) || [],
       adapterProps?.contractsProps || {},
     )
-    const sanitizedBalances = sanitizeBalances(balancesRes?.balances || [])
+    // TODO: add full support for groups of balances
+    const sanitizedBalances = sanitizeBalances(balancesRes?.groups?.[0]?.balances || [])
 
     const pricedBalances = await getPricedBalances(sanitizedBalances)
 

--- a/scripts/run-adapter.ts
+++ b/scripts/run-adapter.ts
@@ -61,7 +61,8 @@ async function main() {
     ])
 
     const balancesRes = await adapter[chain]?.getBalances(ctx, contracts, props)
-    const sanitizedBalances = sanitizeBalances(balancesRes?.balances || [])
+    // TODO: add full support for groups of balances
+    const sanitizedBalances = sanitizeBalances(balancesRes?.groups?.[0]?.balances || [])
 
     const yieldsRes = await fetch('https://yields.llama.fi/poolsOld')
     const yieldsData = (await yieldsRes.json()).data

--- a/scripts/update-balances.ts
+++ b/scripts/update-balances.ts
@@ -98,15 +98,16 @@ async function main() {
           const hrend = process.hrtime(hrstart)
 
           console.log(
-            `[${adapterId}][${chain}] getBalances ${contractsByAdapterIdChain[adapterId][chain].length} contracts, found ${balancesConfig.balances.length} balances in %ds %dms`,
+            `[${adapterId}][${chain}] getBalances ${contractsByAdapterIdChain[adapterId][chain].length} contracts, found ${balancesConfig.groups[0].balances.length} balances in %ds %dms`,
             hrend[0],
             hrend[1] / 1000000,
           )
 
+          // TODO: add full support for groups of balances
           const extendedBalancesConfig: ExtendedBalancesConfig = {
             ...balancesConfig,
             // Tag balances with adapterId
-            balances: balancesConfig.balances.map((balance) => ({ ...balance, adapterId })),
+            balances: balancesConfig.groups[0].balances.map((balance) => ({ ...balance, adapterId })),
             adapterId,
             chain,
           }

--- a/src/adapters/0vix/polygon/index.ts
+++ b/src/adapters/0vix/polygon/index.ts
@@ -36,7 +36,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor: healthFactor! * Math.pow(10, 18),
+    groups: [{ balances, healthFactor: healthFactor! * Math.pow(10, 18) }],
   }
 }

--- a/src/adapters/aave-v2/avax/index.ts
+++ b/src/adapters/aave-v2/avax/index.ts
@@ -45,7 +45,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getLendingPoolHealthFactor(ctx, lendingPool)
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/aave-v2/ethereum/index.ts
+++ b/src/adapters/aave-v2/ethereum/index.ts
@@ -76,7 +76,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getLendingPoolHealthFactor(ctx, lendingPool)
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/aave-v2/polygon/index.ts
+++ b/src/adapters/aave-v2/polygon/index.ts
@@ -45,7 +45,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getLendingPoolHealthFactor(ctx, lendingPool)
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/aave-v3/arbitrum/index.ts
+++ b/src/adapters/aave-v3/arbitrum/index.ts
@@ -49,7 +49,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getLendingPoolHealthFactor(ctx, lendingPool)
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/aave-v3/avax/index.ts
+++ b/src/adapters/aave-v3/avax/index.ts
@@ -48,8 +48,10 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
 
   const healthFactor = await getLendingPoolHealthFactor(ctx, lendingPool)
 
-  return {
-    balances,
-    healthFactor,
-  }
+  return [
+    {
+      balances,
+      healthFactor,
+    },
+  ]
 }

--- a/src/adapters/aave-v3/fantom/index.ts
+++ b/src/adapters/aave-v3/fantom/index.ts
@@ -49,7 +49,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getLendingPoolHealthFactor(ctx, lendingPool)
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/aave-v3/polygon/index.ts
+++ b/src/adapters/aave-v3/polygon/index.ts
@@ -49,7 +49,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getLendingPoolHealthFactor(ctx, lendingPool)
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/abracadabra/arbitrum/index.ts
+++ b/src/adapters/abracadabra/arbitrum/index.ts
@@ -47,6 +47,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/abracadabra/avax/index.ts
+++ b/src/adapters/abracadabra/avax/index.ts
@@ -51,6 +51,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/abracadabra/ethereum/index.ts
+++ b/src/adapters/abracadabra/ethereum/index.ts
@@ -98,6 +98,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/abracadabra/fantom/index.ts
+++ b/src/adapters/abracadabra/fantom/index.ts
@@ -53,6 +53,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/alchemix/ethereum/index.ts
+++ b/src/adapters/alchemix/ethereum/index.ts
@@ -68,6 +68,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/alpaca-finance/bsc/index.ts
+++ b/src/adapters/alpaca-finance/bsc/index.ts
@@ -40,6 +40,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/alpaca-finance/fantom/index.ts
+++ b/src/adapters/alpaca-finance/fantom/index.ts
@@ -31,6 +31,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/angle/arbitrum/index.ts
+++ b/src/adapters/angle/arbitrum/index.ts
@@ -11,6 +11,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {})
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/angle/avax/index.ts
+++ b/src/adapters/angle/avax/index.ts
@@ -11,6 +11,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {})
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/angle/ethereum/index.ts
+++ b/src/adapters/angle/ethereum/index.ts
@@ -44,6 +44,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/angle/optimism/index.ts
+++ b/src/adapters/angle/optimism/index.ts
@@ -11,6 +11,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {})
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/angle/polygon/index.ts
+++ b/src/adapters/angle/polygon/index.ts
@@ -11,6 +11,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {})
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/apeswap-amm/bsc/index.ts
+++ b/src/adapters/apeswap-amm/bsc/index.ts
@@ -57,6 +57,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/apeswap-amm/ethereum/index.ts
+++ b/src/adapters/apeswap-amm/ethereum/index.ts
@@ -29,6 +29,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/apeswap-amm/polygon/index.ts
+++ b/src/adapters/apeswap-amm/polygon/index.ts
@@ -57,6 +57,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/apeswap-lending/bsc/index.ts
+++ b/src/adapters/apeswap-lending/bsc/index.ts
@@ -31,7 +31,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/api3/ethereum/index.ts
+++ b/src/adapters/api3/ethereum/index.ts
@@ -29,6 +29,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/arrakis/ethereum/index.ts
+++ b/src/adapters/arrakis/ethereum/index.ts
@@ -26,6 +26,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/arrakis/optimism/index.ts
+++ b/src/adapters/arrakis/optimism/index.ts
@@ -26,6 +26,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/arrakis/polygon/index.ts
+++ b/src/adapters/arrakis/polygon/index.ts
@@ -26,6 +26,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/atlantis-loans/avax/index.ts
+++ b/src/adapters/atlantis-loans/avax/index.ts
@@ -34,7 +34,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/atlantis-loans/bsc/index.ts
+++ b/src/adapters/atlantis-loans/bsc/index.ts
@@ -65,7 +65,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/atlantis-loans/polygon/index.ts
+++ b/src/adapters/atlantis-loans/polygon/index.ts
@@ -65,7 +65,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/atlas-usv/avax/index.ts
+++ b/src/adapters/atlas-usv/avax/index.ts
@@ -32,6 +32,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/atlas-usv/bsc/index.ts
+++ b/src/adapters/atlas-usv/bsc/index.ts
@@ -32,6 +32,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/atlas-usv/ethereum/index.ts
+++ b/src/adapters/atlas-usv/ethereum/index.ts
@@ -32,6 +32,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/atlas-usv/polygon/index.ts
+++ b/src/adapters/atlas-usv/polygon/index.ts
@@ -32,6 +32,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/aura/ethereum/index.ts
+++ b/src/adapters/aura/ethereum/index.ts
@@ -61,6 +61,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/badger-dao/ethereum/index.ts
+++ b/src/adapters/badger-dao/ethereum/index.ts
@@ -17,6 +17,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/balancer/arbitrum/index.ts
+++ b/src/adapters/balancer/arbitrum/index.ts
@@ -34,6 +34,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/balancer/ethereum/index.ts
+++ b/src/adapters/balancer/ethereum/index.ts
@@ -73,6 +73,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/balancer/polygon/index.ts
+++ b/src/adapters/balancer/polygon/index.ts
@@ -34,6 +34,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/bancor-v3/ethereum/index.ts
+++ b/src/adapters/bancor-v3/ethereum/index.ts
@@ -24,6 +24,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/beefy/arbitrum/index.ts
+++ b/src/adapters/beefy/arbitrum/index.ts
@@ -18,6 +18,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/beefy/avax/index.ts
+++ b/src/adapters/beefy/avax/index.ts
@@ -15,6 +15,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {})
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/beefy/bsc/index.ts
+++ b/src/adapters/beefy/bsc/index.ts
@@ -15,6 +15,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {})
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/beefy/ethereum/index.ts
+++ b/src/adapters/beefy/ethereum/index.ts
@@ -18,6 +18,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/beefy/fantom/index.ts
+++ b/src/adapters/beefy/fantom/index.ts
@@ -18,6 +18,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/beefy/optimism/index.ts
+++ b/src/adapters/beefy/optimism/index.ts
@@ -15,6 +15,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {})
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/beefy/polygon/index.ts
+++ b/src/adapters/beefy/polygon/index.ts
@@ -15,6 +15,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {})
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/benddao/ethereum/index.ts
+++ b/src/adapters/benddao/ethereum/index.ts
@@ -57,7 +57,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   // const healthFactor = await getNFTHealthFactor((sortedBalances.nfts as NFTBorrowBalance[]) || [])
 
   return {
-    balances,
-    // healthFactor,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/benqi-lending/avax/index.ts
+++ b/src/adapters/benqi-lending/avax/index.ts
@@ -30,7 +30,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/benqi-staked-avax/avax/index.ts
+++ b/src/adapters/benqi-staked-avax/avax/index.ts
@@ -34,6 +34,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/biswap/bsc/index.ts
+++ b/src/adapters/biswap/bsc/index.ts
@@ -81,6 +81,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/blur/ethereum/index.ts
+++ b/src/adapters/blur/ethereum/index.ts
@@ -29,6 +29,10 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances: balances.map((balance) => ({ ...balance, symbol: weth.symbol, category: 'stake' })),
+    groups: [
+      {
+        balances: balances.map((balance) => ({ ...balance, symbol: weth.symbol, category: 'stake' })),
+      },
+    ],
   }
 }

--- a/src/adapters/cap-finance/arbitrum/index.ts
+++ b/src/adapters/cap-finance/arbitrum/index.ts
@@ -34,6 +34,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/compound-v3/ethereum/index.ts
+++ b/src/adapters/compound-v3/ethereum/index.ts
@@ -43,7 +43,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/compound/ethereum/index.ts
+++ b/src/adapters/compound/ethereum/index.ts
@@ -53,7 +53,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/concentrator/ethereum/index.ts
+++ b/src/adapters/concentrator/ethereum/index.ts
@@ -146,5 +146,7 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
     veCTR: getLockerBalances,
   })
 
-  return { balances }
+  return {
+    groups: [{ balances }],
+  }
 }

--- a/src/adapters/convex-finance/ethereum/index.ts
+++ b/src/adapters/convex-finance/ethereum/index.ts
@@ -85,6 +85,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances: balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/curve/arbitrum/index.ts
+++ b/src/adapters/curve/arbitrum/index.ts
@@ -39,6 +39,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/curve/avax/index.ts
+++ b/src/adapters/curve/avax/index.ts
@@ -39,6 +39,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/curve/ethereum/index.ts
+++ b/src/adapters/curve/ethereum/index.ts
@@ -49,6 +49,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/curve/fantom/index.ts
+++ b/src/adapters/curve/fantom/index.ts
@@ -39,6 +39,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/curve/optimism/index.ts
+++ b/src/adapters/curve/optimism/index.ts
@@ -39,6 +39,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/curve/polygon/index.ts
+++ b/src/adapters/curve/polygon/index.ts
@@ -39,6 +39,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/dydx/ethereum/index.ts
+++ b/src/adapters/dydx/ethereum/index.ts
@@ -35,6 +35,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/euler/ethereum/index.ts
+++ b/src/adapters/euler/ethereum/index.ts
@@ -109,7 +109,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: 
   ])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/floor-dao/ethereum/index.ts
+++ b/src/adapters/floor-dao/ethereum/index.ts
@@ -42,6 +42,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/flux-finance/ethereum/index.ts
+++ b/src/adapters/flux-finance/ethereum/index.ts
@@ -30,7 +30,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/fortress-loans/bsc/index.ts
+++ b/src/adapters/fortress-loans/bsc/index.ts
@@ -34,7 +34,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/frax-finance/ethereum/index.ts
+++ b/src/adapters/frax-finance/ethereum/index.ts
@@ -72,6 +72,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/fraxlend/ethereum/index.ts
+++ b/src/adapters/fraxlend/ethereum/index.ts
@@ -29,6 +29,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/gearbox/ethereum/index.ts
+++ b/src/adapters/gearbox/ethereum/index.ts
@@ -23,6 +23,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/geist/fantom/index.ts
+++ b/src/adapters/geist/fantom/index.ts
@@ -67,7 +67,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   ])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/gmx/arbitrum/index.ts
+++ b/src/adapters/gmx/arbitrum/index.ts
@@ -33,6 +33,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances: balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/gmx/avax/index.ts
+++ b/src/adapters/gmx/avax/index.ts
@@ -33,6 +33,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances: balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/granary-finance/avax/index.ts
+++ b/src/adapters/granary-finance/avax/index.ts
@@ -27,7 +27,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   ])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/granary-finance/ethereum/index.ts
+++ b/src/adapters/granary-finance/ethereum/index.ts
@@ -27,7 +27,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   ])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/granary-finance/fantom/index.ts
+++ b/src/adapters/granary-finance/fantom/index.ts
@@ -27,7 +27,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   ])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/granary-finance/optimism/index.ts
+++ b/src/adapters/granary-finance/optimism/index.ts
@@ -27,7 +27,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   ])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/hector-network/fantom/index.ts
+++ b/src/adapters/hector-network/fantom/index.ts
@@ -90,6 +90,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/hex/ethereum/index.ts
+++ b/src/adapters/hex/ethereum/index.ts
@@ -23,6 +23,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/homora-v2/avax/index.ts
+++ b/src/adapters/homora-v2/avax/index.ts
@@ -34,6 +34,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/homora-v2/ethereum/index.ts
+++ b/src/adapters/homora-v2/ethereum/index.ts
@@ -33,6 +33,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/homora-v2/fantom/index.ts
+++ b/src/adapters/homora-v2/fantom/index.ts
@@ -29,6 +29,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/homora-v2/optimism/index.ts
+++ b/src/adapters/homora-v2/optimism/index.ts
@@ -25,6 +25,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/hundred-finance/arbitrum/index.ts
+++ b/src/adapters/hundred-finance/arbitrum/index.ts
@@ -34,7 +34,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/hundred-finance/ethereum/index.ts
+++ b/src/adapters/hundred-finance/ethereum/index.ts
@@ -34,7 +34,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/hundred-finance/fantom/index.ts
+++ b/src/adapters/hundred-finance/fantom/index.ts
@@ -34,7 +34,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/hundred-finance/optimism/index.ts
+++ b/src/adapters/hundred-finance/optimism/index.ts
@@ -34,7 +34,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/hundred-finance/polygon/index.ts
+++ b/src/adapters/hundred-finance/polygon/index.ts
@@ -34,7 +34,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/inverse-finance/ethereum/index.ts
+++ b/src/adapters/inverse-finance/ethereum/index.ts
@@ -30,7 +30,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/iron-bank/avax/index.ts
+++ b/src/adapters/iron-bank/avax/index.ts
@@ -26,7 +26,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/iron-bank/ethereum/index.ts
+++ b/src/adapters/iron-bank/ethereum/index.ts
@@ -26,7 +26,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/iron-bank/fantom/index.ts
+++ b/src/adapters/iron-bank/fantom/index.ts
@@ -26,7 +26,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/iron-bank/optimism/index.ts
+++ b/src/adapters/iron-bank/optimism/index.ts
@@ -26,7 +26,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/klima-dao/polygon/index.ts
+++ b/src/adapters/klima-dao/polygon/index.ts
@@ -42,6 +42,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/leonicornswap/bsc/index.ts
+++ b/src/adapters/leonicornswap/bsc/index.ts
@@ -60,6 +60,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/lido/ethereum/index.ts
+++ b/src/adapters/lido/ethereum/index.ts
@@ -50,6 +50,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/life-dao/avax/index.ts
+++ b/src/adapters/life-dao/avax/index.ts
@@ -32,6 +32,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/liqee/bsc/index.ts
+++ b/src/adapters/liqee/bsc/index.ts
@@ -28,7 +28,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/liqee/ethereum/index.ts
+++ b/src/adapters/liqee/ethereum/index.ts
@@ -32,7 +32,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/liquity/ethereum/index.ts
+++ b/src/adapters/liquity/ethereum/index.ts
@@ -66,7 +66,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(ctx, balances)
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/llamapay/arbitrum/index.ts
+++ b/src/adapters/llamapay/arbitrum/index.ts
@@ -13,6 +13,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx) 
   const streams = await getPayeeStreams(ctx)
 
   return {
-    balances: streams,
+    groups: [{ balances: streams }],
   }
 }

--- a/src/adapters/llamapay/avax/index.ts
+++ b/src/adapters/llamapay/avax/index.ts
@@ -13,6 +13,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx) 
   const streams = await getPayeeStreams(ctx)
 
   return {
-    balances: streams,
+    groups: [{ balances: streams }],
   }
 }

--- a/src/adapters/llamapay/bsc/index.ts
+++ b/src/adapters/llamapay/bsc/index.ts
@@ -13,6 +13,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx) 
   const streams = await getPayeeStreams(ctx)
 
   return {
-    balances: streams,
+    groups: [{ balances: streams }],
   }
 }

--- a/src/adapters/llamapay/ethereum/index.ts
+++ b/src/adapters/llamapay/ethereum/index.ts
@@ -13,6 +13,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx) 
   const streams = await getPayeeStreams(ctx)
 
   return {
-    balances: streams,
+    groups: [{ balances: streams }],
   }
 }

--- a/src/adapters/llamapay/fantom/index.ts
+++ b/src/adapters/llamapay/fantom/index.ts
@@ -13,6 +13,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx) 
   const streams = await getPayeeStreams(ctx)
 
   return {
-    balances: streams,
+    groups: [{ balances: streams }],
   }
 }

--- a/src/adapters/llamapay/optimism/index.ts
+++ b/src/adapters/llamapay/optimism/index.ts
@@ -13,6 +13,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx) 
   const streams = await getPayeeStreams(ctx)
 
   return {
-    balances: streams,
+    groups: [{ balances: streams }],
   }
 }

--- a/src/adapters/llamapay/polygon/index.ts
+++ b/src/adapters/llamapay/polygon/index.ts
@@ -13,6 +13,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx) 
   const streams = await getPayeeStreams(ctx)
 
   return {
-    balances: streams,
+    groups: [{ balances: streams }],
   }
 }

--- a/src/adapters/llamapay/xdai/index.ts
+++ b/src/adapters/llamapay/xdai/index.ts
@@ -13,6 +13,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx) 
   const streams = await getPayeeStreams(ctx)
 
   return {
-    balances: streams,
+    groups: [{ balances: streams }],
   }
 }

--- a/src/adapters/looksrare/ethereum/index.ts
+++ b/src/adapters/looksrare/ethereum/index.ts
@@ -37,6 +37,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/lusd-chickenbonds/ethereum/index.ts
+++ b/src/adapters/lusd-chickenbonds/ethereum/index.ts
@@ -19,6 +19,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/makerdao/ethereum/index.ts
+++ b/src/adapters/makerdao/ethereum/index.ts
@@ -72,7 +72,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   // const healthFactor = getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    // healthFactor,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/maple/ethereum/index.ts
+++ b/src/adapters/maple/ethereum/index.ts
@@ -23,6 +23,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/mdex/bsc/index.ts
+++ b/src/adapters/mdex/bsc/index.ts
@@ -57,6 +57,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/merit-circle/ethereum/index.ts
+++ b/src/adapters/merit-circle/ethereum/index.ts
@@ -64,6 +64,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/morpho-aave/ethereum/index.ts
+++ b/src/adapters/morpho-aave/ethereum/index.ts
@@ -25,7 +25,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   ])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/morpho-compound/ethereum/index.ts
+++ b/src/adapters/morpho-compound/ethereum/index.ts
@@ -25,7 +25,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   ])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/nemesis-dao/bsc/index.ts
+++ b/src/adapters/nemesis-dao/bsc/index.ts
@@ -32,6 +32,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/nexus-mutual/ethereum/index.ts
+++ b/src/adapters/nexus-mutual/ethereum/index.ts
@@ -37,6 +37,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/olympus-dao/ethereum/index.ts
+++ b/src/adapters/olympus-dao/ethereum/index.ts
@@ -50,6 +50,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/opyn-squeeth/ethereum/index.ts
+++ b/src/adapters/opyn-squeeth/ethereum/index.ts
@@ -33,6 +33,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/pancakeswap/bsc/index.ts
+++ b/src/adapters/pancakeswap/bsc/index.ts
@@ -171,6 +171,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/pandora/bsc/index.ts
+++ b/src/adapters/pandora/bsc/index.ts
@@ -86,6 +86,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/pangolin/avax/index.ts
+++ b/src/adapters/pangolin/avax/index.ts
@@ -68,6 +68,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/pika-protocol/optimism/index.ts
+++ b/src/adapters/pika-protocol/optimism/index.ts
@@ -47,6 +47,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/platypus-finance/avax/index.ts
+++ b/src/adapters/platypus-finance/avax/index.ts
@@ -54,6 +54,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/quickswap-dex/polygon/index.ts
+++ b/src/adapters/quickswap-dex/polygon/index.ts
@@ -29,6 +29,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/radiant/arbitrum/index.ts
+++ b/src/adapters/radiant/arbitrum/index.ts
@@ -66,7 +66,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   ])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/rage-trade/arbitrum/index.ts
+++ b/src/adapters/rage-trade/arbitrum/index.ts
@@ -62,6 +62,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/ribbon-finance/ethereum/index.ts
+++ b/src/adapters/ribbon-finance/ethereum/index.ts
@@ -49,6 +49,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/rocket-pool/ethereum/index.ts
+++ b/src/adapters/rocket-pool/ethereum/index.ts
@@ -81,6 +81,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/scream/fantom/index.ts
+++ b/src/adapters/scream/fantom/index.ts
@@ -26,7 +26,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/set-protocol/ethereum/index.ts
+++ b/src/adapters/set-protocol/ethereum/index.ts
@@ -23,6 +23,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/shibaswap/ethereum/index.ts
+++ b/src/adapters/shibaswap/ethereum/index.ts
@@ -118,7 +118,8 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: 
     shibaStaker: getStakerBalances,
     locker: getLockerBalances,
   })
+
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/sonne-finance/optimism/index.ts
+++ b/src/adapters/sonne-finance/optimism/index.ts
@@ -34,7 +34,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/spartacus/fantom/index.ts
+++ b/src/adapters/spartacus/fantom/index.ts
@@ -56,6 +56,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/spiritswap/fantom/index.ts
+++ b/src/adapters/spiritswap/fantom/index.ts
@@ -78,6 +78,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/spookyswap/fantom/index.ts
+++ b/src/adapters/spookyswap/fantom/index.ts
@@ -74,6 +74,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/spool/ethereum/index.ts
+++ b/src/adapters/spool/ethereum/index.ts
@@ -72,6 +72,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/stakewise/ethereum/index.ts
+++ b/src/adapters/stakewise/ethereum/index.ts
@@ -42,6 +42,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/stargate/arbitrum/index.ts
+++ b/src/adapters/stargate/arbitrum/index.ts
@@ -34,6 +34,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/stargate/avax/index.ts
+++ b/src/adapters/stargate/avax/index.ts
@@ -33,6 +33,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/stargate/bsc/index.ts
+++ b/src/adapters/stargate/bsc/index.ts
@@ -34,6 +34,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/stargate/ethereum/index.ts
+++ b/src/adapters/stargate/ethereum/index.ts
@@ -34,6 +34,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/stargate/fantom/index.ts
+++ b/src/adapters/stargate/fantom/index.ts
@@ -33,6 +33,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/stargate/optimism/index.ts
+++ b/src/adapters/stargate/optimism/index.ts
@@ -34,6 +34,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/stargate/polygon/index.ts
+++ b/src/adapters/stargate/polygon/index.ts
@@ -34,6 +34,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/strike/ethereum/index.ts
+++ b/src/adapters/strike/ethereum/index.ts
@@ -30,7 +30,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/sturdy/ethereum/index.ts
+++ b/src/adapters/sturdy/ethereum/index.ts
@@ -49,7 +49,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getLendingPoolHealthFactor(ctx, lendingPool)
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/sturdy/fantom/index.ts
+++ b/src/adapters/sturdy/fantom/index.ts
@@ -22,6 +22,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/sushiswap/arbitrum/index.ts
+++ b/src/adapters/sushiswap/arbitrum/index.ts
@@ -62,6 +62,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/sushiswap/avax/index.ts
+++ b/src/adapters/sushiswap/avax/index.ts
@@ -31,6 +31,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/sushiswap/bsc/index.ts
+++ b/src/adapters/sushiswap/bsc/index.ts
@@ -31,6 +31,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/sushiswap/ethereum/index.ts
+++ b/src/adapters/sushiswap/ethereum/index.ts
@@ -92,6 +92,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/sushiswap/fantom/index.ts
+++ b/src/adapters/sushiswap/fantom/index.ts
@@ -62,6 +62,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/sushiswap/polygon/index.ts
+++ b/src/adapters/sushiswap/polygon/index.ts
@@ -62,6 +62,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/synapse/arbitrum/index.ts
+++ b/src/adapters/synapse/arbitrum/index.ts
@@ -38,6 +38,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/synapse/avax/index.ts
+++ b/src/adapters/synapse/avax/index.ts
@@ -37,6 +37,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/synapse/bsc/index.ts
+++ b/src/adapters/synapse/bsc/index.ts
@@ -33,6 +33,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/synapse/ethereum/index.ts
+++ b/src/adapters/synapse/ethereum/index.ts
@@ -33,6 +33,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/synapse/fantom/index.ts
+++ b/src/adapters/synapse/fantom/index.ts
@@ -33,6 +33,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/synapse/optimism/index.ts
+++ b/src/adapters/synapse/optimism/index.ts
@@ -33,6 +33,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/synapse/polygon/index.ts
+++ b/src/adapters/synapse/polygon/index.ts
@@ -33,6 +33,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/synthetix/ethereum/index.ts
+++ b/src/adapters/synthetix/ethereum/index.ts
@@ -61,6 +61,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/synthetix/optimism/index.ts
+++ b/src/adapters/synthetix/optimism/index.ts
@@ -61,6 +61,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/templedao/ethereum/index.ts
+++ b/src/adapters/templedao/ethereum/index.ts
@@ -78,6 +78,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/traderjoe/avax/index.ts
+++ b/src/adapters/traderjoe/avax/index.ts
@@ -98,6 +98,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   ])
 
   return {
-    balances: [...balances, ...stakeBalances],
+    groups: [{ balances: [...balances, ...stakeBalances] }],
   }
 }

--- a/src/adapters/truefi/ethereum/index.ts
+++ b/src/adapters/truefi/ethereum/index.ts
@@ -64,6 +64,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/uniswap-v2/ethereum/index.ts
+++ b/src/adapters/uniswap-v2/ethereum/index.ts
@@ -87,6 +87,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances: balances.map((balance) => ({ ...balance, category: 'farm' })),
+    groups: [{ balances: balances.map((balance) => ({ ...balance, category: 'farm' })) }],
   }
 }

--- a/src/adapters/uniswap-v3/arbitrum/index.ts
+++ b/src/adapters/uniswap-v3/arbitrum/index.ts
@@ -27,6 +27,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/uniswap-v3/celo/index.ts
+++ b/src/adapters/uniswap-v3/celo/index.ts
@@ -27,6 +27,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/uniswap-v3/ethereum/index.ts
+++ b/src/adapters/uniswap-v3/ethereum/index.ts
@@ -27,6 +27,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/uniswap-v3/optimism/index.ts
+++ b/src/adapters/uniswap-v3/optimism/index.ts
@@ -27,6 +27,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/uniswap-v3/polygon/index.ts
+++ b/src/adapters/uniswap-v3/polygon/index.ts
@@ -27,6 +27,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/uwu-lend/ethereum/index.ts
+++ b/src/adapters/uwu-lend/ethereum/index.ts
@@ -67,7 +67,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   ])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/valas-finance/bsc/index.ts
+++ b/src/adapters/valas-finance/bsc/index.ts
@@ -67,7 +67,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   ])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/vector/avax/index.ts
+++ b/src/adapters/vector/avax/index.ts
@@ -34,6 +34,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/venus/bsc/index.ts
+++ b/src/adapters/venus/bsc/index.ts
@@ -67,7 +67,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/wallet/index.ts
+++ b/src/adapters/wallet/index.ts
@@ -46,7 +46,7 @@ const getChainHandlers = (chain: Chain) => {
     })
 
     return {
-      balances,
+      groups: [{ balances }],
     }
   }
 

--- a/src/adapters/wepiggy/arbitrum/index.ts
+++ b/src/adapters/wepiggy/arbitrum/index.ts
@@ -59,7 +59,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/wepiggy/bsc/index.ts
+++ b/src/adapters/wepiggy/bsc/index.ts
@@ -57,7 +57,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/wepiggy/ethereum/index.ts
+++ b/src/adapters/wepiggy/ethereum/index.ts
@@ -57,7 +57,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/wepiggy/optimism/index.ts
+++ b/src/adapters/wepiggy/optimism/index.ts
@@ -57,7 +57,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
 
   return {
-    balances,
-    healthFactor,
+    groups: [{ balances, healthFactor }],
   }
 }

--- a/src/adapters/wepiggy/polygon/index.ts
+++ b/src/adapters/wepiggy/polygon/index.ts
@@ -50,6 +50,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/wonderland/avax/index.ts
+++ b/src/adapters/wonderland/avax/index.ts
@@ -35,6 +35,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/yearn-finance/arbitrum/index.ts
+++ b/src/adapters/yearn-finance/arbitrum/index.ts
@@ -23,6 +23,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/yearn-finance/ethereum/index.ts
+++ b/src/adapters/yearn-finance/ethereum/index.ts
@@ -23,6 +23,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/yearn-finance/fantom/index.ts
+++ b/src/adapters/yearn-finance/fantom/index.ts
@@ -23,6 +23,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/yearn-finance/optimism/index.ts
+++ b/src/adapters/yearn-finance/optimism/index.ts
@@ -23,6 +23,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/adapters/zyberswap/arbitrum/index.ts
+++ b/src/adapters/zyberswap/arbitrum/index.ts
@@ -82,6 +82,6 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   })
 
   return {
-    balances,
+    groups: [{ balances }],
   }
 }

--- a/src/handlers/getBalancesTokens.ts
+++ b/src/handlers/getBalancesTokens.ts
@@ -65,7 +65,7 @@ export const handler: APIGatewayProxyHandler = async (event, context) => {
 
     const chains = Object.keys(tokensByChain)
 
-    const chainsBalancesConfig = await Promise.all(
+    const chainsBalances = await Promise.all(
       chains
         .filter((chain) => walletAdapter[chain as Chain])
         .map(async (chain) => {
@@ -85,12 +85,12 @@ export const handler: APIGatewayProxyHandler = async (event, context) => {
             const hrend = process.hrtime(hrstart)
 
             console.log(
-              `[${walletAdapter.id}][${chain}] found ${balancesConfig.balances.length} balances in %ds %dms`,
+              `[${walletAdapter.id}][${chain}] found ${balancesConfig.groups[0].balances.length} balances in %ds %dms`,
               hrend[0],
               hrend[1] / 1000000,
             )
 
-            return balancesConfig
+            return balancesConfig.groups[0].balances
           } catch (error) {
             console.error(`[${walletAdapter.id}][${chain}]: Failed to getBalances`, error)
             return
@@ -98,10 +98,10 @@ export const handler: APIGatewayProxyHandler = async (event, context) => {
         }),
     )
 
-    const walletBalancesConfigs = chainsBalancesConfig.filter(isNotNullish)
+    const walletBalances = chainsBalances.filter(isNotNullish)
 
     // Ungroup balances to make only 1 call to the price API
-    const balances = walletBalancesConfigs.flatMap((balanceConfig) => balanceConfig?.balances).filter(isNotNullish)
+    const balances = walletBalances.flat().filter(isNotNullish)
 
     const sanitizedBalances = sanitizeBalances(balances)
 

--- a/src/handlers/updateBalances.ts
+++ b/src/handlers/updateBalances.ts
@@ -104,15 +104,16 @@ export const handler: APIGatewayProxyHandler = async (event, context) => {
           const hrend = process.hrtime(hrstart)
 
           console.log(
-            `[${adapterId}][${chain}] getBalances ${contractsByAdapterIdChain[adapterId][chain].length} contracts, found ${balancesConfig.balances.length} balances in %ds %dms`,
+            `[${adapterId}][${chain}] getBalances ${contractsByAdapterIdChain[adapterId][chain].length} contracts, found ${balancesConfig.groups[0].balances.length} balances in %ds %dms`,
             hrend[0],
             hrend[1] / 1000000,
           )
 
+          // TODO: add full support for groups of balances
           const extendedBalancesConfig: ExtendedBalancesConfig = {
             ...balancesConfig,
             // Tag balances with adapterId
-            balances: balancesConfig.balances.map((balance) => ({ ...balance, adapterId })),
+            balances: balancesConfig.groups[0].balances.map((balance) => ({ ...balance, adapterId })),
             adapterId,
             chain,
           }

--- a/src/lib/adapter.ts
+++ b/src/lib/adapter.ts
@@ -86,10 +86,14 @@ export interface Lock {
   end?: number
 }
 
-export interface BalancesConfig {
+export interface BalancesGroup {
   balances: Balance[]
   // Metadata
   healthFactor?: number
+}
+
+export interface BalancesConfig {
+  groups: BalancesGroup[]
 }
 
 export interface ContractsMap {

--- a/src/lib/lambda.ts
+++ b/src/lib/lambda.ts
@@ -3,13 +3,17 @@ import aws from 'aws-sdk'
 
 type InvocationType = 'RequestResponse' | 'Event' | 'DryRun'
 
-export function invokeLambda(functioName: string, event: any, invocationType?: InvocationType) {
+export function invokeLambda(functionName: string, event: any, invocationType?: InvocationType) {
+  if (process.env.IS_OFFLINE) {
+    return
+  }
+
   return new Promise((resolve) => {
     new aws.Lambda({
       endpoint: process.env.IS_OFFLINE ? 'http://localhost:3002' : undefined,
     }).invoke(
       {
-        FunctionName: functioName,
+        FunctionName: functionName,
         InvocationType: invocationType || 'Event',
         Payload: JSON.stringify(event, null, 2), // pass params
       },


### PR DESCRIPTION
<!-- 🦙🦙 Thanks for contributing ! 🦙🦙 -->

<!-- Please specify the adapter id in the title -->

<!-- If you're creating a new adapter, please make sure the `links` field is well specified: this info will help us review it -->

## Summary

<!-- Which issues will be closed? (if applicable) -->

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

Adds partial support for groups of balances (only support 1 group at the moment, the default group we've been using so far).

Next step is to store and return multiple groups of balances (example: Maker)

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
