### PR TITLE
Feat: Adapter, Gnosis-protocol-v1

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -87,6 +87,7 @@
         "gearbox",
         "geist",
         "gmx",
+        "gnosis-protocol-v1",
         "granary-finance",
         "gro",
         "hector-network",

--- a/src/adapters/gnosis-protocol-v1/ethereum/index.ts
+++ b/src/adapters/gnosis-protocol-v1/ethereum/index.ts
@@ -1,0 +1,29 @@
+import { Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+import { getERC20BalanceOf } from '@lib/erc20'
+import { Token } from '@lib/token'
+
+const lockerGnosis: Contract = {
+  chain: 'ethereum',
+  address: '0x4f8ad938eba0cd19155a835f617317a6e788c868',
+  decimals: 18,
+  symbol: 'LGNO',
+  underlyings: ['0x6810e776880C02933D47DB1b9fc05908e5386b96'],
+}
+
+export const getContracts = () => {
+  return {
+    contracts: { lockerGnosis },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    lockerGnosis: (ctx, lockerGnosis) => getERC20BalanceOf(ctx, [lockerGnosis] as Token[]),
+  })
+
+  return {
+    // Lock:end is an universal timestamp for all users who have lock on gnosis-protocol-v1, and which corresponds to the deposit deadline (1644944444) + 1 year of lock duration (31536000)
+    groups: [{ balances: balances.map((balance) => ({ ...balance, category: 'lock', lock: { end: 1676480444 } })) }],
+  }
+}

--- a/src/adapters/gnosis-protocol-v1/index.ts
+++ b/src/adapters/gnosis-protocol-v1/index.ts
@@ -1,0 +1,10 @@
+import { Adapter } from '@lib/adapter'
+
+import * as ethereum from './ethereum'
+
+const adapter: Adapter = {
+  id: 'gnosis-protocol-v1',
+  ethereum,
+}
+
+export default adapter

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -38,6 +38,7 @@ import fraxlend from '@adapters/fraxlend'
 import gearbox from '@adapters/gearbox'
 import geist from '@adapters/geist'
 import gmx from '@adapters/gmx'
+import gnosisProtocolV1 from '@adapters/gnosis-protocol-v1'
 import granaryFinance from '@adapters/granary-finance'
 import gro from '@adapters/gro'
 import hectorNetwork from '@adapters/hector-network'
@@ -149,6 +150,7 @@ export const adapters: Adapter[] = [
   gearbox,
   geist,
   gmx,
+  gnosisProtocolV1,
   granaryFinance,
   gro,
   hectorNetwork,


### PR DESCRIPTION
### Feat: Adapter, Gnosis-protocol-v1

- [x] stake

`npm run adapter-balances gnosis-protocol-v1 ethereum 0xbdfa4f4492dd7b7cf211209c4791af8d52bf5c50`


![gnosis_0xbdfa4f4492dd7b7cf211209c4791af8d52bf5c50](https://user-images.githubusercontent.com/110820448/225336372-05d7cd1a-4bd5-4692-b216-47e4fd9cb425.png)
