### PR TITLE
Feat: Adapter, Sideshift

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -155,6 +155,7 @@
         "set-protocol",
         "sharedstake",
         "shibaswap",
+        "sideshift",
         "snowbank",
         "solidlizard",
         "solidly-v2",

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -106,6 +106,7 @@ import scream from '@adapters/scream'
 import setProtocol from '@adapters/set-protocol'
 import sharedstake from '@adapters/sharedstake'
 import shibaswap from '@adapters/shibaswap'
+import sideshift from '@adapters/sideshift'
 import snowbank from '@adapters/snowbank'
 import solidlizard from '@adapters/solidlizard'
 import solidlyV2 from '@adapters/solidly-v2'
@@ -253,6 +254,7 @@ export const adapters: Adapter[] = [
   setProtocol,
   sharedstake,
   shibaswap,
+  sideshift,
   snowbank,
   solidlizard,
   solidlyV2,

--- a/src/adapters/sideshift/ethereum/balance.ts
+++ b/src/adapters/sideshift/ethereum/balance.ts
@@ -1,0 +1,46 @@
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { call } from '@lib/call'
+import { abi as erc20Abi } from '@lib/erc20'
+import { Token } from '@lib/token'
+import { BigNumber } from 'ethers'
+
+const abi = {
+  convertToAssets: {
+    inputs: [{ internalType: 'uint256', name: 'shares', type: 'uint256' }],
+    name: 'convertToAssets',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+}
+
+const XAI: Token = {
+  chain: 'ethereum',
+  address: '0x35e78b3982E87ecfD5b3f3265B601c046cDBe232',
+  symbol: 'XAI',
+  decimals: 18,
+}
+
+export async function getsvXAIBalances(ctx: BalancesContext, contract: Contract): Promise<Balance> {
+  const { output: balanceOf } = await call({
+    ctx,
+    target: contract.address,
+    params: [ctx.address],
+    abi: erc20Abi.balanceOf,
+  })
+
+  const { output: fmtBalanceOf } = await call({
+    ctx,
+    target: contract.address,
+    params: [balanceOf],
+    abi: abi.convertToAssets,
+  })
+
+  return {
+    ...contract,
+    amount: BigNumber.from(fmtBalanceOf),
+    underlyings: [XAI],
+    rewards: undefined,
+    category: 'farm',
+  }
+}

--- a/src/adapters/sideshift/ethereum/index.ts
+++ b/src/adapters/sideshift/ethereum/index.ts
@@ -1,0 +1,28 @@
+import { Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+import { getsvXAIBalances } from './balance'
+
+const svXAI: Contract = {
+  chain: 'ethereum',
+  address: '0x3808708e761b988d23ae011ed0e12674fb66bd62',
+  underlyings: ['0x35e78b3982E87ecfD5b3f3265B601c046cDBe232'],
+  symbol: 'svXAI',
+  decimals: 18,
+}
+
+export const getContracts = () => {
+  return {
+    contracts: { svXAI },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    svXAI: getsvXAIBalances,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/sideshift/index.ts
+++ b/src/adapters/sideshift/index.ts
@@ -1,0 +1,10 @@
+import { Adapter } from '@lib/adapter'
+
+import * as ethereum from './ethereum'
+
+const adapter: Adapter = {
+  id: 'sideshift',
+  ethereum,
+}
+
+export default adapter

--- a/src/lib/lock.ts
+++ b/src/lib/lock.ts
@@ -5,7 +5,7 @@ import { BigNumber } from 'ethers'
 
 import { range } from './array'
 import { abi as erc20Abi } from './erc20'
-import { BN_ZERO, sumBN } from './math'
+import { BN_ZERO, isZero, sumBN } from './math'
 import { multicall } from './multicall'
 import { isSuccess } from './type'
 
@@ -182,7 +182,7 @@ export async function getMultipleLockerBalances(
     category: 'lock',
   }
 
-  if (rewards) {
+  if (rewards && !isZero(totalLocked)) {
     rewards.map((reward, idx: number) => {
       claimableBalance.rewards?.push({
         ...reward,
@@ -205,7 +205,7 @@ export async function getMultipleLockerBalances(
       category: 'lock',
     }
 
-    if (rewards) {
+    if (rewards && !isZero(totalLocked)) {
       rewards.map((reward, idx: number) => {
         balance.rewards?.push({
           ...reward,


### PR DESCRIPTION
### Overview
- Added handling error to prevent `'division by zero'` that sometimes appeared during update balances for `Convex`
- Added Sideshift adapter

### Tasks

- [x] Store contracts
- [x] Farm

### Farm

`npm run adapter-balances sideshift ethereum 0xdab4b5cea2dceb46588d0f8c91cdf068e41c4c51`

![sideshift-0xdab4b5cea2dceb46588d0f8c91cdf068e41c4c51](https://user-images.githubusercontent.com/110820448/231694285-370681aa-f0d3-49b2-93f0-1fe6685516e5.png)
