### PR TITLE
Feat: Adapter, Honeyswap

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -106,6 +106,7 @@
         "hector-network",
         "hex",
         "homora-v2",
+        "honeyswap",
         "hundred-finance",
         "illuvium",
         "inverse-finance",

--- a/src/adapters/honeyswap/index.ts
+++ b/src/adapters/honeyswap/index.ts
@@ -1,0 +1,12 @@
+import { Adapter } from '@lib/adapter'
+
+import * as polygon from './polygon'
+import * as xdai from './xdai'
+
+const adapter: Adapter = {
+  id: 'honeyswap',
+  polygon,
+  xdai,
+}
+
+export default adapter

--- a/src/adapters/honeyswap/polygon/index.ts
+++ b/src/adapters/honeyswap/polygon/index.ts
@@ -1,0 +1,36 @@
+import { BaseContext, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+import { getPairsContracts } from '@lib/uniswap/v2/factory'
+import { getPairsBalances } from '@lib/uniswap/v2/pair'
+
+export const getContracts = async (ctx: BaseContext, props: any) => {
+  const offset = props.pairOffset || 0
+  const limit = 100
+
+  const { pairs, allPairsLength } = await getPairsContracts({
+    ctx,
+    factoryAddress: '0x03daa61d8007443a6584e3d8f85105096543c19c',
+    offset,
+    limit,
+  })
+
+  return {
+    contracts: {
+      pairs,
+    },
+    revalidate: 60 * 60,
+    revalidateProps: {
+      pairOffset: Math.min(offset + limit, allPairsLength),
+    },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    pairs: getPairsBalances,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/honeyswap/xdai/index.ts
+++ b/src/adapters/honeyswap/xdai/index.ts
@@ -1,0 +1,36 @@
+import { BaseContext, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+import { getPairsContracts } from '@lib/uniswap/v2/factory'
+import { getPairsBalances } from '@lib/uniswap/v2/pair'
+
+export const getContracts = async (ctx: BaseContext, props: any) => {
+  const offset = props.pairOffset || 0
+  const limit = 100
+
+  const { pairs, allPairsLength } = await getPairsContracts({
+    ctx,
+    factoryAddress: '0xa818b4f111ccac7aa31d0bcc0806d64f2e0737d7',
+    offset,
+    limit,
+  })
+
+  return {
+    contracts: {
+      pairs,
+    },
+    revalidate: 60 * 60,
+    revalidateProps: {
+      pairOffset: Math.min(offset + limit, allPairsLength),
+    },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    pairs: getPairsBalances,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -57,6 +57,7 @@ import gyro from '@adapters/gyro'
 import hectorNetwork from '@adapters/hector-network'
 import hex from '@adapters/hex'
 import homoraV2 from '@adapters/homora-v2'
+import honeyswap from '@adapters/honeyswap'
 import hundredFinance from '@adapters/hundred-finance'
 import illuvium from '@adapters/illuvium'
 import inverseFinance from '@adapters/inverse-finance'
@@ -209,6 +210,7 @@ export const adapters: Adapter[] = [
   hectorNetwork,
   hex,
   homoraV2,
+  honeyswap,
   hundredFinance,
   illuvium,
   inverseFinance,


### PR DESCRIPTION
Add Honeyswap adapter on both gnosis (xdai) and polygon chains

@0xsign As you can see on the Gnosis screenshot, Gnosis adapters seem to update, but do not display correctly on the website, id problem? I've used xdai as chain id

- [x] store contracts

### Polygon

npm run adapter-balances honeyswap polygon 0x62d7e2484fcfc6752b9473260efe1b86cabac34e

![honey-poly-0x62d7e2484fcfc6752b9473260efe1b86cabac34e](https://user-images.githubusercontent.com/110820448/232782871-0a4647b4-77cc-4627-8e3f-55e1310e40ab.png)

### Gnosis

npm run adapter-balances honeyswap xdai 0xb44825cf0d8d4dd552f2434056c41582415aaaa1

![honey-gnosis-0xb44825cf0d8d4dd552f2434056c41582415aaaa1](https://user-images.githubusercontent.com/110820448/232782963-511d51ee-571c-4d1f-a19b-879e4ad6856c.png)

