### PR TITLE
Feat: Adapter Yoshi-exchange

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -196,6 +196,7 @@
         "wonderland",
         "x2y2",
         "yearn-finance",
+        "yoshi-exchange",
         "zyberswap"
       ],
       "default": "curve"

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -147,6 +147,7 @@ import wepiggy from '@adapters/wepiggy'
 import wonderland from '@adapters/wonderland'
 import x2y2 from '@adapters/x2y2'
 import yearnFinance from '@adapters/yearn-finance'
+import yoshiExchange from '@adapters/yoshi-exchange'
 import zyberswap from '@adapters/zyberswap'
 import { Adapter } from '@lib/adapter'
 
@@ -300,6 +301,7 @@ export const adapters: Adapter[] = [
   wonderland,
   x2y2,
   yearnFinance,
+  yoshiExchange,
   zyberswap,
 ]
 

--- a/src/adapters/yoshi-exchange/bsc/index.ts
+++ b/src/adapters/yoshi-exchange/bsc/index.ts
@@ -1,0 +1,36 @@
+import { BaseContext, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+import { getPairsContracts } from '@lib/uniswap/v2/factory'
+import { getPairsBalances } from '@lib/uniswap/v2/pair'
+
+export const getContracts = async (ctx: BaseContext, props: any) => {
+  const offset = props.pairOffset || 0
+  const limit = 100
+
+  const { pairs, allPairsLength } = await getPairsContracts({
+    ctx,
+    factoryAddress: '0x542b6524abf0bd47dc191504e38400ec14d0290c',
+    offset,
+    limit,
+  })
+
+  return {
+    contracts: {
+      pairs,
+    },
+    revalidate: 60 * 60,
+    revalidateProps: {
+      pairOffset: Math.min(offset + limit, allPairsLength),
+    },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    pairs: getPairsBalances,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/yoshi-exchange/fantom/index.ts
+++ b/src/adapters/yoshi-exchange/fantom/index.ts
@@ -1,0 +1,36 @@
+import { BaseContext, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+import { getPairsContracts } from '@lib/uniswap/v2/factory'
+import { getPairsBalances } from '@lib/uniswap/v2/pair'
+
+export const getContracts = async (ctx: BaseContext, props: any) => {
+  const offset = props.pairOffset || 0
+  const limit = 300
+
+  const { pairs, allPairsLength } = await getPairsContracts({
+    ctx,
+    factoryAddress: '0xc5bc174cb6382fbab17771d05e6a918441deceea',
+    offset,
+    limit,
+  })
+
+  return {
+    contracts: {
+      pairs,
+    },
+    revalidate: 60 * 60,
+    revalidateProps: {
+      pairOffset: Math.min(offset + limit, allPairsLength),
+    },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    pairs: getPairsBalances,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/yoshi-exchange/index.ts
+++ b/src/adapters/yoshi-exchange/index.ts
@@ -1,0 +1,12 @@
+import { Adapter } from '@lib/adapter'
+
+import * as bsc from './bsc'
+import * as fantom from './fantom'
+
+const adapter: Adapter = {
+  id: 'yoshi-exchange',
+  fantom,
+  bsc,
+}
+
+export default adapter


### PR DESCRIPTION
Add Yoshi-Exchange (uni-v2 Forked)

- [x] Store contracts
- [x] LP on both BSC + FTM

### BSC
`npm run adapter yoshi-exchange bsc 0x4f77435fb06c589db87acb9a30de44134c269a6f`

![yoshi-bsc-lp-0x4f77435fb06c589db87acb9a30de44134c269a6f](https://user-images.githubusercontent.com/110820448/233036060-d06cc4ce-1900-4d32-b076-8e37b4026848.png)

### FTM
`npm run adapter yoshi-exchange fantom 0x4f77435fb06c589db87acb9a30de44134c269a6f`

![yoshi-ftm-lp-0x4f77435fb06c589db87acb9a30de44134c269a6f](https://user-images.githubusercontent.com/110820448/233036053-c38ba40b-f6a1-4928-bf44-af511ee01264.png)
