### PR TITLE
Feat: Adapter, Timewarp

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -181,6 +181,7 @@
         "templedao",
         "the-open-dao-sos",
         "thena",
+        "timewarp",
         "tokemak",
         "tokenlon",
         "traderjoe",

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -132,6 +132,7 @@ import synthetix from '@adapters/synthetix'
 import templedao from '@adapters/templedao'
 import theOpenDaoSos from '@adapters/the-open-dao-sos'
 import thena from '@adapters/thena'
+import timewarp from '@adapters/timewarp'
 import tokemak from '@adapters/tokemak'
 import tokenlon from '@adapters/tokenlon'
 import traderjoe from '@adapters/traderjoe'
@@ -291,6 +292,7 @@ export const adapters: Adapter[] = [
   templedao,
   theOpenDaoSos,
   thena,
+  timewarp,
   tokemak,
   tokenlon,
   traderjoe,

--- a/src/adapters/timewarp/bsc/index.ts
+++ b/src/adapters/timewarp/bsc/index.ts
@@ -1,0 +1,36 @@
+import { Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+import { getTimeWarpStakeBalances } from '../common/stake'
+
+const stakers: Contract[] = [
+  {
+    chain: 'bsc',
+    address: '0xc48467ba55cf0b777978f19701329c87949efd3c',
+    token: '0xa5ebd19961cf4b8af06a9d9d2b91d73b48744867',
+    underlyings: ['0x3b198e26e473b8fab2085b37978e36c9de5d7f68', '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c'],
+    rewards: ['0x3b198e26e473b8fab2085b37978e36c9de5d7f68'],
+  },
+  {
+    chain: 'bsc',
+    address: '0x59f2757ae3a1baa21e4f397a28985ceb431c676b',
+    token: '0x3b198e26e473b8fab2085b37978e36c9de5d7f68',
+    rewards: ['0x3b198e26e473b8fab2085b37978e36c9de5d7f68'],
+  },
+]
+
+export const getContracts = () => {
+  return {
+    contracts: { stakers },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    stakers: getTimeWarpStakeBalances,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/timewarp/common/stake.ts
+++ b/src/adapters/timewarp/common/stake.ts
@@ -1,0 +1,86 @@
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { BN_ZERO } from '@lib/math'
+import { Call, multicall } from '@lib/multicall'
+import { isSuccess } from '@lib/type'
+import { getUnderlyingBalances } from '@lib/uniswap/v2/pair'
+import { BigNumber } from 'ethers'
+
+const abi = {
+  userStacked: {
+    inputs: [{ internalType: 'address', name: '', type: 'address' }],
+    name: 'userStacked',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  userLastReward: {
+    inputs: [{ internalType: 'address', name: '', type: 'address' }],
+    name: 'userLastReward',
+    outputs: [{ internalType: 'uint32', name: '', type: 'uint32' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  getReward: {
+    inputs: [
+      { internalType: 'address', name: '_user', type: 'address' },
+      { internalType: 'uint32', name: '_lastRewardIndex', type: 'uint32' },
+    ],
+    name: 'getReward',
+    outputs: [
+      { internalType: 'uint256', name: 'amount', type: 'uint256' },
+      { internalType: 'uint32', name: 'lastRewardIndex', type: 'uint32' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+}
+
+export async function getTimeWarpStakeBalances(ctx: BalancesContext, stakers: Contract[]): Promise<Balance[]> {
+  const balances: Balance[] = []
+  const fmtBalances: Balance[] = []
+
+  const calls: Call[] = stakers.map((staker) => ({ target: staker.address, params: [ctx.address] }))
+
+  const [userBalances, userLastRewardsIdxRes] = await Promise.all([
+    multicall({ ctx, calls, abi: abi.userStacked }),
+    multicall({ ctx, calls, abi: abi.userLastReward }),
+  ])
+
+  const userRewards = await multicall({
+    ctx,
+    calls: userLastRewardsIdxRes.map((reward) =>
+      isSuccess(reward) ? { target: reward.input.target, params: [ctx.address, reward.output] } : null,
+    ),
+    abi: abi.getReward,
+  })
+
+  for (let stakeIdx = 0; stakeIdx < stakers.length; stakeIdx++) {
+    const staker = stakers[stakeIdx]
+    const underlyings = staker.underlyings && (staker.underlyings as Contract[])
+    const rewards = staker.rewards?.[0] as Contract
+    const userBalance = userBalances[stakeIdx]
+    const userReward = isSuccess(userRewards[stakeIdx]) ? BigNumber.from(userRewards[stakeIdx].output.amount) : BN_ZERO
+
+    if (!isSuccess(userBalance)) {
+      continue
+    }
+
+    const balance: Balance = {
+      ...staker,
+      address: staker.token as string,
+      amount: BigNumber.from(userBalance.output),
+      underlyings,
+      rewards: [{ ...rewards, amount: userReward }],
+      category: 'stake',
+    }
+
+    if (balance.underlyings) {
+      fmtBalances.push(balance)
+      continue
+    }
+
+    balances.push(balance)
+  }
+
+  return [...balances, ...(await getUnderlyingBalances(ctx, fmtBalances))]
+}

--- a/src/adapters/timewarp/ethereum/index.ts
+++ b/src/adapters/timewarp/ethereum/index.ts
@@ -1,0 +1,36 @@
+import { Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+import { getTimeWarpStakeBalances } from '../common/stake'
+
+const stakers: Contract[] = [
+  {
+    chain: 'ethereum',
+    address: '0x55c825983783c984890ba89f7d7c9575814d83f2',
+    token: '0x1d474d4B4A62b0Ad0C819841eB2C74d1c5050524',
+    underlyings: ['0x485d17A6f1B8780392d53D64751824253011A260', '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'],
+    rewards: ['0x485d17A6f1B8780392d53D64751824253011A260'],
+  },
+  {
+    chain: 'ethereum',
+    address: '0xa106dd3bc6c42b3f28616ffab615c7d494eb629d',
+    token: '0x485d17A6f1B8780392d53D64751824253011A260',
+    rewards: ['0x485d17A6f1B8780392d53D64751824253011A260'],
+  },
+]
+
+export const getContracts = () => {
+  return {
+    contracts: { stakers },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    stakers: getTimeWarpStakeBalances,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/timewarp/index.ts
+++ b/src/adapters/timewarp/index.ts
@@ -1,0 +1,12 @@
+import { Adapter } from '@lib/adapter'
+
+import * as bsc from './bsc'
+import * as ethereum from './ethereum'
+
+const adapter: Adapter = {
+  id: 'timewarp',
+  bsc,
+  ethereum,
+}
+
+export default adapter


### PR DESCRIPTION
Add Timewarp adapter on both Ethereum & Bsc

- [x] Store contracts
- [x] Stake

### Ethereum
`npm run adapter-balances timewarp ethereum 0xaa98aa08d250e56b57b04236147ebcf049a6fe30`

![timewarp-eth-0xaa98aa08d250e56b57b04236147ebcf049a6fe30](https://user-images.githubusercontent.com/110820448/233606310-a9c430a0-c152-47e7-8247-f205cf1ffcba.png)

### BSC
`npm run adapter timewarp bsc 0xeeb3ab4100c0d608269bf3a77d2f7cd55c1fea25`

![timewarp-bsc-0xeeb3ab4100c0d608269bf3a77d2f7cd55c1fea25](https://user-images.githubusercontent.com/110820448/233606298-3a2b948a-5f9a-4727-b082-54ce6ff32cb2.png)
