### PR TITLE
Feat: Adapter, Cat-In-A-Box

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -76,6 +76,7 @@
         "biswap",
         "blur",
         "cap-finance",
+        "cat-in-a-box",
         "chainlink",
         "charm-finance",
         "compound",

--- a/src/adapters/cat-in-a-box/ethereum/index.ts
+++ b/src/adapters/cat-in-a-box/ethereum/index.ts
@@ -1,0 +1,61 @@
+import { Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+import { getCatMarketsBalances } from './lend'
+import { getCatStakeBalance, getCatStakeEscrowBalance } from './stake'
+
+const markets: Contract = {
+  chain: 'ethereum',
+  address: '0x7f0a0c7149a46bf943ccd412da687144b49c6014',
+}
+
+const boxFE: Contract = {
+  chain: 'ethereum',
+  address: '0x320c871b6f7721083604ffdd8070e64c1d3c5d7c',
+  token: '0xE4B91fAf8810F8895772E7cA065D4CB889120f94',
+  underlyings: ['0x7690202e2C2297bcD03664e31116d1dFfE7e3B73'],
+}
+
+const boxFEE: Contract = {
+  chain: 'ethereum',
+  address: '0xe4b91faf8810f8895772e7ca065d4cb889120f94',
+  underlyings: ['0x7690202e2C2297bcD03664e31116d1dFfE7e3B73'],
+  decimals: 18,
+  symbol: 'boxFEE',
+}
+
+const tokensLists: Contract[] = [
+  {
+    chain: 'ethereum',
+    address: '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84',
+    category: 'lend',
+    decimals: 18,
+    symbol: 'stETH',
+    underlyings: ['0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'],
+  },
+  {
+    chain: 'ethereum',
+    address: '0x7690202e2C2297bcD03664e31116d1dFfE7e3B73',
+    category: 'borrow',
+    decimals: 18,
+    symbol: 'boxETH',
+  },
+]
+
+export const getContracts = () => {
+  return {
+    contracts: { markets, boxFE, boxFEE },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    markets: (...args) => getCatMarketsBalances(...args, tokensLists),
+    boxFEE: getCatStakeEscrowBalance,
+    boxFE: getCatStakeBalance,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/cat-in-a-box/ethereum/lend.ts
+++ b/src/adapters/cat-in-a-box/ethereum/lend.ts
@@ -1,0 +1,60 @@
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { keyBy } from '@lib/array'
+import { call } from '@lib/call'
+import { Token } from '@lib/token'
+import { BigNumber } from 'ethers'
+
+const abi = {
+  debt: {
+    inputs: [{ internalType: 'address', name: '', type: 'address' }],
+    name: 'debt',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  deposited: {
+    inputs: [{ internalType: 'address', name: '', type: 'address' }],
+    name: 'deposited',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+}
+
+const WETH: Token = {
+  chain: 'ethereum',
+  address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+  decimals: 18,
+  symbol: 'WETH',
+}
+
+export async function getCatMarketsBalances(
+  ctx: BalancesContext,
+  market: Contract,
+  tokensLists: Contract[],
+): Promise<Balance[]> {
+  const [{ output: deposited }, { output: debt }] = await Promise.all([
+    call({ ctx, target: market.address, params: [ctx.address], abi: abi.deposited }),
+    call({ ctx, target: market.address, params: [ctx.address], abi: abi.debt }),
+  ])
+
+  const tokenByCategories = keyBy(tokensLists, 'category')
+
+  const lendBalance: Balance = {
+    ...tokenByCategories.lend,
+    amount: BigNumber.from(deposited),
+    underlyings: undefined,
+    rewards: undefined,
+    category: 'lend',
+  }
+
+  const borrowBalance: Balance = {
+    ...tokenByCategories.borrow,
+    amount: BigNumber.from(debt),
+    underlyings: [WETH],
+    rewards: undefined,
+    category: 'borrow',
+  }
+
+  return [lendBalance, borrowBalance]
+}

--- a/src/adapters/cat-in-a-box/ethereum/stake.ts
+++ b/src/adapters/cat-in-a-box/ethereum/stake.ts
@@ -1,0 +1,88 @@
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { call } from '@lib/call'
+import { abi as erc20Abi } from '@lib/erc20'
+import { Token } from '@lib/token'
+import { BigNumber } from 'ethers'
+
+const abi = {
+  convertToAssets: {
+    inputs: [{ internalType: 'uint256', name: 'shares', type: 'uint256' }],
+    name: 'convertToAssets',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  deposited: {
+    inputs: [{ internalType: 'address', name: '', type: 'address' }],
+    name: 'deposited',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  Owing: {
+    inputs: [{ internalType: 'address', name: '_depositor', type: 'address' }],
+    name: 'Owing',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+}
+
+const boxETH: Token = {
+  chain: 'ethereum',
+  address: '0x7690202e2C2297bcD03664e31116d1dFfE7e3B73',
+  decimals: 18,
+  symbol: 'boxETH',
+}
+
+const CONVERTER = '0xe4b91faf8810f8895772e7ca065d4cb889120f94'
+
+export async function getCatStakeEscrowBalance(ctx: BalancesContext, staker: Contract): Promise<Balance> {
+  const { output: userBalancesOfsRes } = await call({
+    ctx,
+    target: staker.address,
+    params: [ctx.address],
+    abi: erc20Abi.balanceOf,
+  })
+
+  const balance: Balance = {
+    ...staker,
+    amount: BigNumber.from(userBalancesOfsRes),
+    underlyings: [boxETH],
+    rewards: undefined,
+    category: 'stake',
+  }
+
+  return ftmCatBalances(ctx, balance)
+}
+
+export async function getCatStakeBalance(ctx: BalancesContext, staker: Contract): Promise<Balance> {
+  const [{ output: deposited }, { output: earned }] = await Promise.all([
+    call({ ctx, target: staker.address, params: [ctx.address], abi: abi.deposited }),
+    call({ ctx, target: staker.address, params: [ctx.address], abi: abi.Owing }),
+  ])
+
+  const balance: Balance = {
+    ...staker,
+    amount: BigNumber.from(deposited),
+    underlyings: [boxETH],
+    rewards: [{ ...boxETH, amount: BigNumber.from(earned) }],
+    category: 'stake',
+  }
+
+  return ftmCatBalances(ctx, balance)
+}
+
+const ftmCatBalances = async (ctx: BalancesContext, balance: Balance): Promise<Balance> => {
+  const { output: ftmBalances } = await call({
+    ctx,
+    target: CONVERTER,
+    params: [balance.amount.toString()],
+    abi: abi.convertToAssets,
+  })
+
+  return {
+    ...balance,
+    amount: BigNumber.from(ftmBalances),
+  }
+}

--- a/src/adapters/cat-in-a-box/index.ts
+++ b/src/adapters/cat-in-a-box/index.ts
@@ -1,0 +1,12 @@
+
+import { Adapter } from '@lib/adapter';
+
+import * as ethereum from './ethereum'
+
+const adapter: Adapter = {
+  id: 'cat-in-a-box',
+  ethereum
+};
+
+export default adapter;
+

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -27,6 +27,7 @@ import benqiStakedAvax from '@adapters/benqi-staked-avax'
 import biswap from '@adapters/biswap'
 import blur from '@adapters/blur'
 import capFinance from '@adapters/cap-finance'
+import catInABox from '@adapters/cat-in-a-box'
 import chainlink from '@adapters/chainlink'
 import charmFinance from '@adapters/charm-finance'
 import compound from '@adapters/compound'
@@ -186,6 +187,7 @@ export const adapters: Adapter[] = [
   biswap,
   blur,
   capFinance,
+  catInABox,
   chainlink,
   charmFinance,
   compound,


### PR DESCRIPTION
Add Cat-In-A-Box adapter

- [x] Stake
- [x] Lend/Borrow

### LENDING
`npm run adapter-balances cat-in-a-box ethereum 0xccfa0530b9d52f970d1a2daea670ce58e4176389`

![Cat-lend-0xccfa0530b9d52f970d1a2daea670ce58e4176389](https://user-images.githubusercontent.com/110820448/233936755-dffe6153-070b-4a4e-9bb2-750ee0c0330f.png)

### STAKING
`npm run adapter-balances cat-in-a-box ethereum 0x93ec55cd7c694cbf63e1391825b2ef6e31086427`

![stake_cat_0x93ec55cd7c694cbf63e1391825b2ef6e31086427](https://user-images.githubusercontent.com/110820448/233936757-5214b425-6c51-477e-99b3-91ba4e34ec82.png)
