### PR TITLE
fix: put back lambda types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "uuid": "^9.0.0"
       },
       "devDependencies": {
+        "@types/aws-lambda": "^8.10.114",
         "@types/jest": "^28.1.6",
         "@types/node-fetch": "^2.6.2",
         "@types/pg": "^8.6.5",
@@ -3996,6 +3997,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.114",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.114.tgz",
+      "integrity": "sha512-M8WpEGfC9iQ6V2Ccq6nGIXoQgeVc6z0Ngk8yCOL5V/TYIxshvb0MWQYLFFTZDesL0zmsoBc4OBjG9DB/4rei6w==",
       "dev": true
     },
     "node_modules/@types/babel__core": {
@@ -16586,6 +16593,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
+    "@types/aws-lambda": {
+      "version": "8.10.114",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.114.tgz",
+      "integrity": "sha512-M8WpEGfC9iQ6V2Ccq6nGIXoQgeVc6z0Ngk8yCOL5V/TYIxshvb0MWQYLFFTZDesL0zmsoBc4OBjG9DB/4rei6w==",
       "dev": true
     },
     "@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
+    "@types/aws-lambda": "^8.10.114",
     "@types/jest": "^28.1.6",
     "@types/node-fetch": "^2.6.2",
     "@types/pg": "^8.6.5",


### PR DESCRIPTION
<!-- 🦙🦙 Thanks for contributing ! 🦙🦙 -->

<!-- Please specify the adapter id in the title -->

<!-- If you're creating a new adapter, please make sure the `links` field is well specified: this info will help us review it -->

## Summary

<!-- Which issues will be closed? (if applicable) -->

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

This seems to be the way to have types for Lambda handlers even with AWS SDK v3

## Checklist

- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
