### PR TITLE
Feat: Adapter, Asymetrix-protocol

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -73,6 +73,7 @@
         "api3",
         "arbitrum-exchange",
         "arrakis",
+        "asymetrix-protocol",
         "atlantis-loans",
         "atlas-usv",
         "aura",

--- a/src/adapters/asymetrix-protocol/ethereum/index.ts
+++ b/src/adapters/asymetrix-protocol/ethereum/index.ts
@@ -1,0 +1,28 @@
+import { getAsymetrixBalances } from '@adapters/asymetrix-protocol/ethereum/stake'
+import type { Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+const PST: Contract = {
+  chain: 'ethereum',
+  address: '0x82d24dd5041a3eb942cca68b319f1fda9eb0c604',
+  decimals: 18,
+  symbol: 'PST',
+  underlyings: ['0xae7ab96520de3a18e5e111b5eaab095312d7fe84'],
+  staker: '0xd1c88b7cc2f9b3a23d1cb537d53a818cef5e5e32',
+}
+
+export const getContracts = () => {
+  return {
+    contracts: { PST },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    PST: getAsymetrixBalances,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/asymetrix-protocol/ethereum/stake.ts
+++ b/src/adapters/asymetrix-protocol/ethereum/stake.ts
@@ -1,0 +1,34 @@
+import type { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { call } from '@lib/call'
+import { getSingleStakeBalance } from '@lib/stake'
+import type { Token } from '@lib/token'
+import { BigNumber } from 'ethers'
+
+const abi = {
+  getClaimableReward: {
+    inputs: [{ internalType: 'address', name: '_user', type: 'address' }],
+    name: 'getClaimableReward',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+}
+
+const ASX: Token = {
+  chain: 'ethereum',
+  address: '0x67d85a291fcdc862a78812a3c26d55e28ffb2701',
+  decimals: 18,
+  symbol: 'ASX',
+}
+
+export async function getAsymetrixBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
+  const [balance, { output: pendingReward }] = await Promise.all([
+    getSingleStakeBalance(ctx, { ...staker, address: staker.staker }),
+    call({ ctx, target: staker.address, params: [ctx.address], abi: abi.getClaimableReward }),
+  ])
+
+  return {
+    ...balance,
+    rewards: [{ ...ASX, amount: BigNumber.from(pendingReward) }],
+  }
+}

--- a/src/adapters/asymetrix-protocol/index.ts
+++ b/src/adapters/asymetrix-protocol/index.ts
@@ -1,0 +1,10 @@
+import type { Adapter } from '@lib/adapter'
+
+import * as ethereum from './ethereum'
+
+const adapter: Adapter = {
+  id: 'asymetrix-protocol',
+  ethereum,
+}
+
+export default adapter

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -13,6 +13,7 @@ import apeswapLending from '@adapters/apeswap-lending'
 import api3 from '@adapters/api3'
 import arbitrumExchange from '@adapters/arbitrum-exchange'
 import arrakis from '@adapters/arrakis'
+import asymetrixProtocol from '@adapters/asymetrix-protocol'
 import atlantisLoans from '@adapters/atlantis-loans'
 import atlasUsv from '@adapters/atlas-usv'
 import aura from '@adapters/aura'
@@ -187,6 +188,7 @@ export const adapters: Adapter[] = [
   api3,
   arbitrumExchange,
   arrakis,
+  asymetrixProtocol,
   atlantisLoans,
   atlasUsv,
   aura,


### PR DESCRIPTION
Add Asymetrix-Protocol

- [x] Store contracts
- [x] Stake

`pnpm run adapter-balances asymetrix-protocol ethereum 0xf06e055d5123900094284fdf15d7523d3ea442d3`

![asymetrix-stake-0xf06e055d5123900094284fdf15d7523d3ea442d3](https://user-images.githubusercontent.com/110820448/236503256-b4f895cc-7aa0-4ab3-a342-ba522acbe5df.png)
