### PR TITLE
Feat: Adapter, ApolloX

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -71,6 +71,7 @@
         "apeswap-amm",
         "apeswap-lending",
         "api3",
+        "apollox",
         "arbitrum-exchange",
         "arrakis",
         "asymetrix-protocol",

--- a/src/adapters/apollox/bsc/balance.ts
+++ b/src/adapters/apollox/bsc/balance.ts
@@ -1,0 +1,113 @@
+import { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { mapSuccessFilter } from '@lib/array'
+import { call } from '@lib/call'
+import { abi as erc20Abi } from '@lib/erc20'
+import { Call, multicall } from '@lib/multicall'
+import { isSuccess } from '@lib/type'
+import { getUnderlyingBalances } from '@lib/uniswap/v2/pair'
+import { BigNumber } from 'ethers'
+
+const abi = {
+  stakeOf: {
+    inputs: [{ internalType: 'address', name: '_user', type: 'address' }],
+    name: 'stakeOf',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  totalStaked: {
+    inputs: [],
+    name: 'totalStaked',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  staked: {
+    inputs: [{ internalType: 'address', name: '_user', type: 'address' }],
+    name: 'staked',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  pendingApx: {
+    inputs: [{ internalType: 'address', name: '_user', type: 'address' }],
+    name: 'pendingApx',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+}
+
+export async function getApolloStakeBalances(ctx: BalancesContext, staker: Contract): Promise<Balance | undefined> {
+  const underlyings = staker.underlyings as Contract[]
+  if (!underlyings) {
+    return
+  }
+
+  const [{ output: balanceOf }, { output: totalSupply }, underlyingsBalancesRes] = await Promise.all([
+    call({
+      ctx,
+      target: staker.address,
+      params: [ctx.address],
+      abi: abi.stakeOf,
+    }),
+    call({
+      ctx,
+      target: staker.address,
+      abi: abi.totalStaked,
+    }),
+    multicall({
+      ctx,
+      calls: underlyings.map((underlying) => ({ target: underlying.address, params: [staker.address] })),
+      abi: erc20Abi.balanceOf,
+    }),
+  ])
+
+  const fmtUnderlyings = mapSuccessFilter(underlyingsBalancesRes, (res, idx) => {
+    return {
+      ...underlyings[idx],
+      amount: BigNumber.from(BigNumber.from(res.output).mul(balanceOf).div(totalSupply)),
+    }
+  })
+
+  return {
+    ...staker,
+    amount: BigNumber.from(balanceOf),
+    underlyings: fmtUnderlyings,
+    rewards: undefined,
+    category: 'stake',
+  }
+}
+
+export async function getApolloFarmBalances(ctx: BalancesContext, farmers: Contract[]): Promise<Balance[]> {
+  const balances: Balance[] = []
+  const calls: Call[] = farmers.map((farmer) => ({ target: farmer.address, params: [ctx.address] }))
+
+  const [userBalanceOfsRes, userPendingRewardsRes] = await Promise.all([
+    multicall({ ctx, calls, abi: abi.staked }),
+    multicall({ ctx, calls, abi: abi.pendingApx }),
+  ])
+
+  for (let farmerIdx = 0; farmerIdx < farmers.length; farmerIdx++) {
+    const farmer = farmers[farmerIdx]
+    const underlyings = farmer.underlyings as Contract[]
+    const reward = farmer.rewards?.[0] as Contract
+    const userBalanceOfRes = userBalanceOfsRes[farmerIdx]
+    const userPendingRewardRes = userPendingRewardsRes[farmerIdx]
+
+    if (!isSuccess(userBalanceOfRes) || !isSuccess(userPendingRewardRes)) {
+      continue
+    }
+
+    balances.push({
+      ...farmer,
+      address: farmer.token as string,
+      amount: BigNumber.from(userBalanceOfRes.output),
+      underlyings,
+      rewards: [{ ...reward, amount: BigNumber.from(userPendingRewardRes.output) }],
+      category: 'farm',
+    })
+  }
+
+  return getUnderlyingBalances(ctx, balances)
+}

--- a/src/adapters/apollox/bsc/index.ts
+++ b/src/adapters/apollox/bsc/index.ts
@@ -1,0 +1,51 @@
+import { getApolloFarmBalances, getApolloStakeBalances } from '@adapters/apollox/bsc/balance'
+import { Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+const staker: Contract = {
+  chain: 'bsc',
+  address: '0x1b6f2d3844c6ae7d56ceb3c3643b9060ba28feb0',
+  token: '0x4e47057f45adf24ba41375a175da0357cb3480e5',
+  underlyings: [
+    '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d',
+    '0xe9e7cea3dedca5984780bafc599bd69add087d56',
+    '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c',
+    '0x2170ed0880ac9a755fd29b2688956bd959f933f8',
+    '0x7130d2a12b9bcbfae4f2634d864a1ee1ce3ead9c',
+    '0x55d398326f99059ff775485246999027b3197955',
+  ],
+}
+
+const alpxlpStakings: Contract[] = [
+  {
+    chain: 'bsc',
+    address: '0x60d910f9de5c6fd2171716042af2fd3d2aa9d942',
+    token: '0xaf839f4d3620a1eed00ccc21ddc01119c26a75e1',
+    underlyings: ['0x78f5d389f5cdccfc41594abab4b0ed02f31398b3', '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c'],
+    rewards: ['0x78f5d389f5cdccfc41594abab4b0ed02f31398b3'],
+  },
+  {
+    chain: 'bsc',
+    address: '0x7eb5af418f199ea47494023c3a8b83a210f8846f',
+    token: '0xa0ee789a8f581cb92dd9742ed0b5d54a0916976c',
+    underlyings: ['0x78f5d389f5cdccfc41594abab4b0ed02f31398b3', '0xe9e7cea3dedca5984780bafc599bd69add087d56'],
+    rewards: ['0x78f5d389f5cdccfc41594abab4b0ed02f31398b3'],
+  },
+]
+
+export const getContracts = () => {
+  return {
+    contracts: { staker, alpxlpStakings },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    staker: getApolloStakeBalances,
+    alpxlpStakings: getApolloFarmBalances,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/apollox/index.ts
+++ b/src/adapters/apollox/index.ts
@@ -1,0 +1,10 @@
+import { Adapter } from '@lib/adapter'
+
+import * as bsc from './bsc'
+
+const adapter: Adapter = {
+  id: 'apollox',
+  bsc,
+}
+
+export default adapter

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -11,6 +11,7 @@ import angle from '@adapters/angle'
 import apeswapAmm from '@adapters/apeswap-amm'
 import apeswapLending from '@adapters/apeswap-lending'
 import api3 from '@adapters/api3'
+import apollox from '@adapters/apollox'
 import arbitrumExchange from '@adapters/arbitrum-exchange'
 import arrakis from '@adapters/arrakis'
 import asymetrixProtocol from '@adapters/asymetrix-protocol'
@@ -187,6 +188,7 @@ export const adapters: Adapter[] = [
   apeswapAmm,
   apeswapLending,
   api3,
+  apollox,
   arbitrumExchange,
   arrakis,
   asymetrixProtocol,


### PR DESCRIPTION
Add ApolloX on bsc chain

- [x] Store contracts
- [x] Stake
- [x] Farm

### Stake
`pnpm run adapter-balances apollox bsc 0xbdfa4f4492dd7b7cf211209c4791af8d52bf5c50`

![appolox-stake-0xbdfa4f4492dd7b7cf211209c4791af8d52bf5c50](https://github.com/llamafolio/llamafolio-api/assets/110820448/1dec1158-1d01-4124-ba74-27de263b0809)

### Farm
`pnpm run adapter-balances apollox bsc 0x5c5276fd5403440bf72a4decf06850baf1236286`

![apollo-farm-0x5c5276fd5403440bf72a4decf06850baf1236286](https://github.com/llamafolio/llamafolio-api/assets/110820448/6ebfb253-e2e4-4183-8ed6-102194d3ffd0)
