### PR TITLE
Feat: Adapter, Stader

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -195,6 +195,7 @@
         "spiritswap",
         "spookyswap",
         "spool",
+        "stader",
         "stake.link",
         "stakewise",
         "stargate",

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -134,6 +134,7 @@ import spartacus from '@adapters/spartacus'
 import spiritswap from '@adapters/spiritswap'
 import spookyswap from '@adapters/spookyswap'
 import spool from '@adapters/spool'
+import stader from '@adapters/stader'
 import stakeLink from '@adapters/stake.link'
 import stakewise from '@adapters/stakewise'
 import stargate from '@adapters/stargate'
@@ -314,6 +315,7 @@ export const adapters: Adapter[] = [
   spiritswap,
   spookyswap,
   spool,
+  stader,
   stakeLink,
   stakewise,
   stargate,

--- a/src/adapters/stader/bsc/farm.ts
+++ b/src/adapters/stader/bsc/farm.ts
@@ -1,0 +1,37 @@
+import type { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { call } from '@lib/call'
+import { BigNumber } from 'ethers'
+
+const abi = {
+  getUserRequestStatus: {
+    inputs: [
+      { internalType: 'address', name: '_user', type: 'address' },
+      { internalType: 'uint256', name: '_idx', type: 'uint256' },
+    ],
+    name: 'getUserRequestStatus',
+    outputs: [
+      { internalType: 'bool', name: '_isClaimable', type: 'bool' },
+      { internalType: 'uint256', name: '_amount', type: 'uint256' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+}
+
+export async function getStaderFarmBalances(ctx: BalancesContext, contract: Contract): Promise<Balance> {
+  const { output: userBalance } = await call({
+    ctx,
+    target: contract.address,
+    params: [ctx.address, 0],
+    abi: abi.getUserRequestStatus,
+  })
+
+  return {
+    ...contract,
+    address: contract.token!,
+    amount: BigNumber.from(userBalance._amount),
+    underlyings: undefined,
+    rewards: undefined,
+    category: 'farm',
+  }
+}

--- a/src/adapters/stader/bsc/index.ts
+++ b/src/adapters/stader/bsc/index.ts
@@ -1,0 +1,34 @@
+import { getStaderFarmBalances } from '@adapters/stader/bsc/farm'
+import type { Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+import { getSingleStakeBalance } from '@lib/stake'
+
+const BNBx: Contract = {
+  chain: 'bsc',
+  address: '0x1bdd3cf7f79cfb8edbb955f20ad99211551ba275',
+  decimals: 18,
+  symbol: 'BNBx',
+}
+
+const bnbXFarm: Contract = {
+  chain: 'bsc',
+  address: '0x7276241a669489e4bbb76f63d2a43bfe63080f2f',
+  token: '0x1bdd3cf7f79cfb8edbb955f20ad99211551ba275',
+}
+
+export const getContracts = () => {
+  return {
+    contracts: { BNBx, bnbXFarm },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    BNBx: getSingleStakeBalance,
+    bnbXFarm: getStaderFarmBalances,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/stader/fantom/index.ts
+++ b/src/adapters/stader/fantom/index.ts
@@ -1,0 +1,26 @@
+import type { Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+import { getSingleStakeBalance } from '@lib/stake'
+
+const sFTMX: Contract = {
+  chain: 'fantom',
+  address: '0xd7028092c830b5c8fce061af2e593413ebbc1fc1',
+  decimals: 18,
+  symbol: 'sFTMX',
+}
+
+export const getContracts = () => {
+  return {
+    contracts: { sFTMX },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    sFTMX: getSingleStakeBalance,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/stader/index.ts
+++ b/src/adapters/stader/index.ts
@@ -1,0 +1,14 @@
+import type { Adapter } from '@lib/adapter'
+
+import * as bsc from './bsc'
+import * as fantom from './fantom'
+import * as polygon from './polygon'
+
+const adapter: Adapter = {
+  id: 'stader',
+  bsc,
+  fantom,
+  polygon,
+}
+
+export default adapter

--- a/src/adapters/stader/polygon/farm.ts
+++ b/src/adapters/stader/polygon/farm.ts
@@ -1,0 +1,42 @@
+import type { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { call } from '@lib/call'
+import { BigNumber } from 'ethers'
+
+const abi = {
+  getUserMaticXSwapRequests: {
+    inputs: [{ internalType: 'address', name: '_address', type: 'address' }],
+    name: 'getUserMaticXSwapRequests',
+    outputs: [
+      {
+        components: [
+          { internalType: 'uint256', name: 'amount', type: 'uint256' },
+          { internalType: 'uint256', name: 'requestTime', type: 'uint256' },
+          { internalType: 'uint256', name: 'withdrawalTime', type: 'uint256' },
+        ],
+        internalType: 'struct IChildPool.MaticXSwapRequest[]',
+        name: '',
+        type: 'tuple[]',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+}
+
+export async function getStaderFarmBalances(ctx: BalancesContext, contract: Contract): Promise<Balance> {
+  const { output: userBalance } = await call({
+    ctx,
+    target: contract.address,
+    params: [ctx.address],
+    abi: abi.getUserMaticXSwapRequests,
+  })
+
+  return {
+    ...contract,
+    address: contract.token!,
+    amount: BigNumber.from(userBalance[0].amount),
+    underlyings: undefined,
+    rewards: undefined,
+    category: 'farm',
+  }
+}

--- a/src/adapters/stader/polygon/index.ts
+++ b/src/adapters/stader/polygon/index.ts
@@ -1,0 +1,34 @@
+import { getStaderFarmBalances } from '@adapters/stader/polygon/farm'
+import type { Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+import { getSingleStakeBalance } from '@lib/stake'
+
+const MaticX: Contract = {
+  chain: 'polygon',
+  address: '0xfa68fb4628dff1028cfec22b4162fccd0d45efb6',
+  decimals: 18,
+  symbol: 'MaticX',
+}
+
+const maticXFarm: Contract = {
+  chain: 'polygon',
+  address: '0xfd225c9e6601c9d38d8f98d8731bf59efcf8c0e3',
+  token: '0xfa68fb4628dff1028cfec22b4162fccd0d45efb6',
+}
+
+export const getContracts = () => {
+  return {
+    contracts: { MaticX, maticXFarm },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    MaticX: getSingleStakeBalance,
+    maticXFarm: getStaderFarmBalances,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}


### PR DESCRIPTION
Add Stader adapter on multichains

- [x] Store contracts
- [x] Stake (bsc/ftm/polygon)
- [x] Farm(bsc/polygon)

### Example:
**Stake**
_Polygon_
`pnpm run adapter-balances stader polygon 0x80ca0d8c38d2e2bcbab66aa1648bd1c7160500fe`

![stader-polygon-stake-0x80ca0d8c38d2e2bcbab66aa1648bd1c7160500fe](https://github.com/llamafolio/llamafolio-api/assets/110820448/6bd128e4-865b-4131-b25e-2507507e03e4)

_BSC_
`pnpm run adapter-balances stader bsc 0x16b37225889a038fad42efded462821224a509a7`

![stader-bsc-stake-0x16b37225889a038fad42efded462821224a509a7](https://github.com/llamafolio/llamafolio-api/assets/110820448/e022d2bc-19a9-4fc5-8a7d-4907b2e5bfcd)



**Farm**
_Polygon_
`pnpm run adapter-balances stader polygon 0xba881b89e179ff77c41f8deb0cd344cbdb2c53f8`

![stader-polygon-farm-0xba881b89e179ff77c41f8deb0cd344cbdb2c53f8](https://github.com/llamafolio/llamafolio-api/assets/110820448/0f06b60b-6153-4e0a-8486-ab3ff4a5b7a5)

_BSC_
`pnpm run adapter-balances stader bsc 0x4dfa03c64abd96359b77e7cca8219b451c19f27e`

![stader-bsc-farm-0x4dfa03c64abd96359b77e7cca8219b451c19f27e](https://github.com/llamafolio/llamafolio-api/assets/110820448/b3adbaf7-f376-4d72-8a5e-de3d43214086)
