### PR TITLE
Feat: Adapter, Polkastarter

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -172,6 +172,7 @@
         "piedao",
         "pika-protocol",
         "platypus-finance",
+        "polkastarter",
         "popsicle-finance",
         "quickswap-dex",
         "radiant-v1",

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -111,6 +111,7 @@ import perennial from '@adapters/perennial'
 import piedao from '@adapters/piedao'
 import pikaProtocol from '@adapters/pika-protocol'
 import platypusFinance from '@adapters/platypus-finance'
+import polkastarter from '@adapters/polkastarter'
 import popsicleFinance from '@adapters/popsicle-finance'
 import quickswapDex from '@adapters/quickswap-dex'
 import radiantV1 from '@adapters/radiant-v1'
@@ -294,6 +295,7 @@ export const adapters: Adapter[] = [
   piedao,
   pikaProtocol,
   platypusFinance,
+  polkastarter,
   popsicleFinance,
   quickswapDex,
   radiantV1,

--- a/src/adapters/polkastarter/bsc/index.ts
+++ b/src/adapters/polkastarter/bsc/index.ts
@@ -1,0 +1,25 @@
+import { getPolkaLockedBalance } from '@adapters/polkastarter/common/lock'
+import type { Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+const locker: Contract = {
+  chain: 'bsc',
+  address: '0xd558675a8c8e1fd45002010bac970b115163de3a',
+  token: '0x7e624fa0e1c4abfd309cc15719b7e2580887f570',
+}
+
+export const getContracts = () => {
+  return {
+    contracts: { locker },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    locker: getPolkaLockedBalance,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/polkastarter/common/lock.ts
+++ b/src/adapters/polkastarter/common/lock.ts
@@ -1,0 +1,49 @@
+import type { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { call } from '@lib/call'
+import { BN_ZERO } from '@lib/math'
+import { BigNumber } from 'ethers'
+
+const abi = {
+  getUnlockTime: {
+    inputs: [{ internalType: 'address', name: '_staker', type: 'address' }],
+    name: 'getUnlockTime',
+    outputs: [{ internalType: 'uint48', name: 'unlockTime', type: 'uint48' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  stakeAmount: {
+    inputs: [{ internalType: 'address', name: '_staker', type: 'address' }],
+    name: 'stakeAmount',
+    outputs: [{ internalType: 'uint256', name: 'balance', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  getEarnedRewardTokens: {
+    inputs: [{ internalType: 'address', name: '_staker', type: 'address' }],
+    name: 'getEarnedRewardTokens',
+    outputs: [{ internalType: 'uint256', name: 'claimableRewardTokens', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+}
+
+export async function getPolkaLockedBalance(ctx: BalancesContext, locker: Contract): Promise<Balance | undefined> {
+  const [{ output: userBalance }, { output: lockTime }] = await Promise.all([
+    call({ ctx, target: locker.address, params: [ctx.address], abi: abi.stakeAmount }),
+    call({ ctx, target: locker.address, params: [ctx.address], abi: abi.getUnlockTime }),
+  ])
+
+  const now = Date.now() / 1000
+  const unlockAt = lockTime
+
+  return {
+    ...locker,
+    address: locker.token!,
+    amount: BigNumber.from(userBalance),
+    claimable: now > unlockAt ? BigNumber.from(userBalance) : BN_ZERO,
+    unlockAt,
+    underlyings: undefined,
+    rewards: undefined,
+    category: 'lock',
+  }
+}

--- a/src/adapters/polkastarter/ethereum/index.ts
+++ b/src/adapters/polkastarter/ethereum/index.ts
@@ -1,0 +1,25 @@
+import { getPolkaLockedBalance } from '@adapters/polkastarter/common/lock'
+import type { Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+const locker: Contract = {
+  chain: 'ethereum',
+  address: '0xc24a365a870821eb83fd216c9596edd89479d8d7',
+  token: '0x83e6f1E41cdd28eAcEB20Cb649155049Fac3D5Aa',
+}
+
+export const getContracts = () => {
+  return {
+    contracts: { locker },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    locker: getPolkaLockedBalance,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/polkastarter/index.ts
+++ b/src/adapters/polkastarter/index.ts
@@ -1,0 +1,12 @@
+import type { Adapter } from '@lib/adapter'
+
+import * as bsc from './bsc'
+import * as ethereum from './ethereum'
+
+const adapter: Adapter = {
+  id: 'polkastarter',
+  ethereum,
+  bsc,
+}
+
+export default adapter


### PR DESCRIPTION
Add Polkastarter lock on bsc/eth

- [x] Store contracts
- [x] Lock on both mainnet + bsc

`pnpm run adapter-balances polkastarter ethereum 0xd1c84c57b0301f36c78869d72eace6459a1464ff`

![polkastarter-0xd1c84c57b0301f36c78869d72eace6459a1464ff](https://github.com/llamafolio/llamafolio-api/assets/110820448/54d6789e-eaa1-40b1-b110-9799ce4aa8a6)



