### PR TITLE
Feat : Adapter, Horizon-Protocol

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -128,6 +128,7 @@
         "hex",
         "homora-v2",
         "honeyswap",
+        "horizon-protocol",
         "hundred-finance",
         "illuvium",
         "inverse-finance",

--- a/src/adapters/horizon-protocol/bsc/balance.ts
+++ b/src/adapters/horizon-protocol/bsc/balance.ts
@@ -1,0 +1,110 @@
+import type { Balance, BalancesContext, Contract, FarmBalance } from '@lib/adapter'
+import { call } from '@lib/call'
+import { abi as erc20Abi } from '@lib/erc20'
+import { BN_ZERO } from '@lib/math'
+import type { Call } from '@lib/multicall'
+import { multicall } from '@lib/multicall'
+import type { Token } from '@lib/token'
+import { isSuccess } from '@lib/type'
+import { getUnderlyingBalances } from '@lib/uniswap/v2/pair'
+import { BigNumber } from 'ethers'
+
+const abi = {
+  earned: {
+    constant: true,
+    inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
+    name: 'earned',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  get_balances: {
+    stateMutability: 'view',
+    type: 'function',
+    name: 'get_balances',
+    inputs: [{ name: '_pool', type: 'address' }],
+    outputs: [{ name: '', type: 'uint256[4]' }],
+    gas: 20935,
+  },
+}
+
+const HZN: Token = {
+  chain: 'bsc',
+  address: '0xc0eff7749b125444953ef89682201fb8c6a917cd',
+  decimals: 18,
+  symbol: 'HZN',
+}
+
+interface HorizonBalanceParams extends FarmBalance {
+  pool: string
+  factory: string
+  token: string
+}
+
+export async function getHorizonFarmBalances(ctx: BalancesContext, farmers: Contract[]): Promise<Balance[]> {
+  const balances: Balance[] = []
+
+  const calls: Call[] = farmers.map((farmer) => ({ target: farmer.address, params: [ctx.address] }))
+
+  const [userBalancesRes, pendingRewardsRes] = await Promise.all([
+    multicall({ ctx, calls, abi: erc20Abi.balanceOf }),
+    multicall({ ctx, calls, abi: abi.earned }),
+  ])
+
+  for (let farmerIdx = 0; farmerIdx < farmers.length; farmerIdx++) {
+    const farmer = farmers[farmerIdx]
+    const underlyings = farmer.underlyings as Contract[]
+    const userBalanceRes = userBalancesRes[farmerIdx]
+    const pendingRewardRes = pendingRewardsRes[farmerIdx]
+
+    if (!isSuccess(userBalanceRes) || !isSuccess(pendingRewardRes)) {
+      continue
+    }
+
+    balances.push({
+      ...farmer,
+      address: farmer.token!,
+      amount: BigNumber.from(userBalanceRes.output),
+      underlyings,
+      rewards: [{ ...HZN, amount: BigNumber.from(pendingRewardRes.output) }],
+      category: 'farm',
+    })
+  }
+
+  const fmtBalances = await getUnderlyingBalances(ctx, balances)
+
+  for (let i = 0; i < fmtBalances.length; i++) {
+    const contractIndex = farmers.findIndex((c) => c.token! === fmtBalances[i].address)
+    if (contractIndex !== -1) {
+      farmers[contractIndex] = Object.assign({}, farmers[contractIndex], fmtBalances[i])
+    }
+  }
+
+  await Promise.all(
+    balances
+      .filter((contract: Contract) => contract.provider === 'curve')
+      .map(async (contract) => {
+        return await getUnderlyingsCurveBalance(ctx, contract as HorizonBalanceParams)
+      }),
+  )
+
+  return balances
+}
+
+const getUnderlyingsCurveBalance = async (ctx: BalancesContext, crvBalance: HorizonBalanceParams): Promise<Balance> => {
+  const underlyings = crvBalance.underlyings as Contract[]
+
+  const [{ output: underlyingsBalances }, { output: totalSupplyRes }] = await Promise.all([
+    call({ ctx, target: crvBalance.factory, params: [crvBalance.pool], abi: abi.get_balances }),
+    call({ ctx, target: crvBalance.token!, abi: erc20Abi.totalSupply }),
+  ])
+
+  underlyings.forEach((underlying, underlyingIdx) => {
+    const underlyingBalance = underlyingsBalances[underlyingIdx]
+    ;(underlying as Balance).amount =
+      BigNumber.from(underlyingBalance).mul(crvBalance.amount).div(totalSupplyRes) || BN_ZERO
+  })
+
+  return crvBalance
+}

--- a/src/adapters/horizon-protocol/bsc/index.ts
+++ b/src/adapters/horizon-protocol/bsc/index.ts
@@ -1,0 +1,64 @@
+import { getHorizonFarmBalances } from '@adapters/horizon-protocol/bsc/balance'
+import type { Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+const farmers: Contract[] = [
+  {
+    chain: 'bsc',
+    address: '0x84838d0ab37857fad5979fcf6bddf8ddb1cc1da8',
+    token: '0xdc9a574b9b341d4a98ce29005b614e1e27430e74',
+    underlyings: ['0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c', '0xc0eff7749b125444953ef89682201fb8c6a917cd'],
+    rewards: ['0xc0eff7749b125444953ef89682201fb8c6a917cd'],
+  },
+  {
+    chain: 'bsc',
+    address: '0x5646aa2f9408c7c2ee1dc7db813c8b687a959a85',
+    token: '0xc3bf4e0ea6b76c8edd838e14be2116c862c88bdf',
+    underlyings: ['0xe9e7cea3dedca5984780bafc599bd69add087d56', '0xf0186490b18cb74619816cfc7feb51cdbe4ae7b9'],
+    rewards: ['0xc0eff7749b125444953ef89682201fb8c6a917cd'],
+  },
+  {
+    chain: 'bsc',
+    address: '0x307326d24b5287b12f8079ba3854d9f7e7a139e1',
+    token: '0x608d2fafbbca409a60d2acb5d41ddd37642a1275',
+    pool: '0x51d5B7A71F807C950A45dD8b1400E83826Fc49F3',
+    factory: '0xf65bed27e96a367c61e0e06c54e14b16b84a5870',
+    underlyings: ['0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c', '0x6DEdCEeE04795061478031b1DfB3c1ddCA80B204'],
+    rewards: ['0xc0eff7749b125444953ef89682201fb8c6a917cd'],
+    provider: 'curve',
+  },
+  {
+    chain: 'bsc',
+    address: '0xa1771dcfb7822c8853d7e64b86e58f7f1eb5e33e',
+    token: '0x0409633a72d846fc5bbe2f98d88564d35987904d',
+    rewards: ['0xc0eff7749b125444953ef89682201fb8c6a917cd'],
+  },
+  {
+    chain: 'bsc',
+    address: '0x67d5a94f444df4bba254645065a4137fc665bf98',
+    token: '0xc0eff7749b125444953ef89682201fb8c6a917cd',
+    rewards: ['0xc0eff7749b125444953ef89682201fb8c6a917cd'],
+  },
+  {
+    chain: 'bsc',
+    address: '0xd4552f3e19b91bed5ef2c76a67abdbffed5caeec',
+    token: '0xdff88a0a43271344b760b58a35076bf05524195c',
+    rewards: ['0xc0eff7749b125444953ef89682201fb8c6a917cd'],
+  },
+]
+
+export const getContracts = () => {
+  return {
+    contracts: { farmers },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    farmers: getHorizonFarmBalances,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/horizon-protocol/index.ts
+++ b/src/adapters/horizon-protocol/index.ts
@@ -1,0 +1,10 @@
+import type { Adapter } from '@lib/adapter'
+
+import * as bsc from './bsc'
+
+const adapter: Adapter = {
+  id: 'horizon-protocol',
+  bsc,
+}
+
+export default adapter

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -67,6 +67,7 @@ import hectorNetwork from '@adapters/hector-network'
 import hex from '@adapters/hex'
 import homoraV2 from '@adapters/homora-v2'
 import honeyswap from '@adapters/honeyswap'
+import horizonProtocol from '@adapters/horizon-protocol'
 import hundredFinance from '@adapters/hundred-finance'
 import illuvium from '@adapters/illuvium'
 import inverseFinance from '@adapters/inverse-finance'
@@ -250,6 +251,7 @@ export const adapters: Adapter[] = [
   hex,
   homoraV2,
   honeyswap,
+  horizonProtocol,
   hundredFinance,
   illuvium,
   inverseFinance,


### PR DESCRIPTION
Add Horizon-Protocol adapter on bsc

- [x] store contracts
- [x] logic farm

`pnpm run adapter-balances horizon-protocol bsc 0xe2ad5f71d33f8495bd96c63f567db1bd3ba82d6b`

![horizon-0xe2ad5f71d33f8495bd96c63f567db1bd3ba82d6b](https://github.com/llamafolio/llamafolio-api/assets/110820448/e11aa595-96f3-4a46-97c3-844128c36dcc)

`pnpm run adapter-balances horizon-protocol bsc 0x9fc09badcb1095d4517d4f271b994b1fb7b8d27f`

![horizon-0x9fc09badcb1095d4517d4f271b994b1fb7b8d27f](https://github.com/llamafolio/llamafolio-api/assets/110820448/1472e7fa-ad27-4934-971d-3725ec16ee22)
