### PR TITLE
Feat: Adapter, Sentiment

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -189,6 +189,7 @@
         "rocket-pool",
         "rook",
         "scream",
+        "sentiment",
         "set-protocol",
         "sharedstake",
         "shibaswap",

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -128,6 +128,7 @@ import ribbonFinance from '@adapters/ribbon-finance'
 import rocketPool from '@adapters/rocket-pool'
 import rook from '@adapters/rook'
 import scream from '@adapters/scream'
+import sentiment from '@adapters/sentiment'
 import setProtocol from '@adapters/set-protocol'
 import sharedstake from '@adapters/sharedstake'
 import shibaswap from '@adapters/shibaswap'
@@ -317,6 +318,7 @@ export const adapters: Adapter[] = [
   rocketPool,
   rook,
   scream,
+  sentiment,
   setProtocol,
   sharedstake,
   shibaswap,

--- a/src/adapters/sentiment/arbitrum/index.ts
+++ b/src/adapters/sentiment/arbitrum/index.ts
@@ -1,0 +1,47 @@
+import { getSentimentStakerBalances } from '@adapters/sentiment/arbitrum/staker'
+import type { Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+const stakers: Contract[] = [
+  {
+    chain: 'arbitrum',
+    address: '0x0ddb1ea478f8ef0e22c7706d2903a41e94b1299b',
+    underlyings: ['0xff970a61a04b1ca14834a43f5de4533ebddb5cc8'],
+  },
+  {
+    chain: 'arbitrum',
+    address: '0x4c8e1656e042a206eef7e8fcff99bac667e4623e',
+    underlyings: ['0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9'],
+  },
+  {
+    chain: 'arbitrum',
+    address: '0x2e9963ae673a885b6bfeda2f80132ce28b784c40',
+    underlyings: ['0x17fc002b466eec40dae837fc4be5c67993ddbd6f'],
+  },
+  {
+    chain: 'arbitrum',
+    address: '0xb190214d5ebac7755899f2d96e519aa7a5776bec',
+    underlyings: ['0x82af49447d8a07e3bd95bd0d56f35241523fbab1'],
+  },
+  {
+    chain: 'arbitrum',
+    address: '0x21202227bc15276e40d53889bc83e59c3cccc121',
+    underlyings: ['0x912ce59144191c1204e64559fe8253a0e49e6548'],
+  },
+]
+
+export const getContracts = () => {
+  return {
+    contracts: { stakers },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    stakers: getSentimentStakerBalances,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/sentiment/arbitrum/staker.ts
+++ b/src/adapters/sentiment/arbitrum/staker.ts
@@ -1,0 +1,47 @@
+import type { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { mapSuccessFilter } from '@lib/array'
+import { abi as erc20Abi } from '@lib/erc20'
+import { multicall } from '@lib/multicall'
+import { isSuccess } from '@lib/type'
+import { BigNumber } from 'ethers'
+
+const abi = {
+  convertToAssets: {
+    inputs: [{ internalType: 'uint256', name: 'shares', type: 'uint256' }],
+    name: 'convertToAssets',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+}
+
+export async function getSentimentStakerBalances(ctx: BalancesContext, stakers: Contract[]): Promise<Balance[]> {
+  const userBalancesRes = await multicall({
+    ctx,
+    calls: stakers.map((staker) => ({ target: staker.address, params: [ctx.address] })),
+    abi: erc20Abi.balanceOf,
+  })
+
+  const fmtBalancesRes = await multicall({
+    ctx,
+    calls: userBalancesRes.map((balance) =>
+      isSuccess(balance) ? { target: balance.input.target, params: [balance.output] } : null,
+    ),
+    abi: abi.convertToAssets,
+  })
+
+  const balances: Balance[] = mapSuccessFilter(fmtBalancesRes, (res, idx: number) => {
+    const staker = stakers[idx]
+    const underlying = staker.underlyings?.[0] as Contract
+
+    return {
+      ...staker,
+      amount: BigNumber.from(res.output),
+      underlyings: [underlying],
+      rewards: undefined,
+      category: 'stake',
+    }
+  })
+
+  return balances
+}

--- a/src/adapters/sentiment/index.ts
+++ b/src/adapters/sentiment/index.ts
@@ -1,0 +1,13 @@
+import type { Adapter } from '@lib/adapter'
+
+import * as arbitrum from './arbitrum'
+
+const adapter: Adapter = {
+  id: 'sentiment',
+  arbitrum,
+}
+
+// TODO: Lending/Borrowing
+// https://docs.sentiment.xyz/
+
+export default adapter


### PR DESCRIPTION
Add Sentiment adapter on arbitrum

- [x] Store contracts
- [x] Stake logic

`pnpm run adapter-balances sentiment arbitrum 0x8d90a4fe233c2e5f59ee8180ac497a6c1749d0f7`

![sentiment-0x8d90a4fe233c2e5f59ee8180ac497a6c1749d0f7](https://github.com/llamafolio/llamafolio-api/assets/110820448/6e2ce8e4-be5c-4643-9b5b-d8969572bfcf)
