### PR TITLE
feat: refactor lib/call to use viem

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@typescript-eslint/parser": "^5.59.5",
     "@vitest/coverage-istanbul": "^0.31.0",
     "@vitest/ui": "^0.31.0",
+    "abitype": "^0.8.4",
     "esbuild-analyzer": "^0.2.0",
     "eslint": "^8.40.0",
     "eslint-config-prettier": "^8.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ devDependencies:
   '@vitest/ui':
     specifier: ^0.31.0
     version: 0.31.0(vitest@0.31.0)
+  abitype:
+    specifier: ^0.8.4
+    version: 0.8.4(typescript@5.0.4)(zod@3.21.4)
   esbuild-analyzer:
     specifier: ^0.2.0
     version: 0.2.0
@@ -2501,6 +2504,19 @@ packages:
       typescript: 5.0.4
       zod: 3.21.4
     dev: false
+
+  /abitype@0.8.4(typescript@5.0.4)(zod@3.21.4):
+    resolution: {integrity: sha512-W6Yxm7Ln1n0H/ghI/Yror0P45/+UCQohCCtSzj7/H5Htj48jJmX9KBym/+OiFl58TvuD9y9plRTsbxdCBdBAog==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3 >=3.19.1
+    peerDependenciesMeta:
+      zod:
+        optional: true
+    dependencies:
+      typescript: 5.0.4
+      zod: 3.21.4
+    dev: true
 
   /acorn-jsx@5.3.2(acorn@8.8.2):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -7752,4 +7768,3 @@ packages:
 
   /zod@3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
-    dev: false

--- a/scripts/provider-bench.ts
+++ b/scripts/provider-bench.ts
@@ -1,5 +1,6 @@
 import '../environment'
 
+import type { Chain } from '@lib/chains'
 import { chains as tokensByChain } from '@llamafolio/tokens'
 
 import type { BaseContext } from '../src/lib/adapter'
@@ -12,7 +13,7 @@ async function main() {
   // argv[2]: ?chain
 
   try {
-    const chain = process.argv[2] || 'ethereum'
+    const chain = (process.argv[2] || 'ethereum') as Chain
     const ctx: BaseContext = { chain, adapterId: '' }
 
     const tokens = tokensByChain[ctx.chain]
@@ -37,7 +38,7 @@ async function main() {
 
       const hrend = process.hrtime(hrstart)
 
-      const errors = responses.reduce((acc, res) => acc + (res.output == null ? 1 : 0), 0)
+      const errors = responses.reduce((acc, res) => acc + (res == null ? 1 : 0), 0)
 
       console.log(`Fetched ${length} balances, found ${errors} errors in %ds %dms`, hrend[0], hrend[1] / 1000000)
     }

--- a/src/adapters/1inch-network/common/contract.ts
+++ b/src/adapters/1inch-network/common/contract.ts
@@ -19,12 +19,12 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getInchPools(ctx: BaseContext, deployer: Contract): Promise<Contract[]> {
-  const { output: allPoolsRes } = await call({ ctx, target: deployer.address, abi: abi.getAllPools })
+  const allPoolsRes = await call({ ctx, target: deployer.address, abi: abi.getAllPools })
 
-  const contracts: Contract[] = (allPoolsRes || []).map((address: string) => ({ chain: ctx.chain, address }))
+  const contracts: Contract[] = (allPoolsRes || []).map((address) => ({ chain: ctx.chain, address }))
 
   return getPairsDetails(ctx, contracts)
 }

--- a/src/adapters/1inch-network/common/locker.ts
+++ b/src/adapters/1inch-network/common/locker.ts
@@ -14,16 +14,21 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getInchLockerBalances(ctx: BalancesContext, locker: Contract): Promise<Balance> {
-  const lockerInfosRes = await call({ ctx, target: locker.address, params: [ctx.address], abi: abi.depositors })
+  const [_lockTime, unlockTime, amount] = await call({
+    ctx,
+    target: locker.address,
+    params: [ctx.address],
+    abi: abi.depositors,
+  })
 
   return {
     ...locker,
-    amount: BigNumber.from(lockerInfosRes.output.amount),
+    amount: BigNumber.from(amount),
     underlyings: locker.underlyings as Contract[],
-    unlockAt: lockerInfosRes.output.unlockTime,
+    unlockAt: unlockTime,
     rewards: undefined,
     category: 'lock',
   }

--- a/src/adapters/aave-v2/common/rewards.ts
+++ b/src/adapters/aave-v2/common/rewards.ts
@@ -30,7 +30,7 @@ export async function getLendingRewardsBalances(
     },
   })
 
-  const userRewards = BigNumber.from(userRewardsRes.output)
+  const userRewards = BigNumber.from(userRewardsRes)
 
   rewards.push({
     chain: rewardToken.chain,

--- a/src/adapters/aave-v2/common/stake.ts
+++ b/src/adapters/aave-v2/common/stake.ts
@@ -45,8 +45,8 @@ export async function getStakeBalances(ctx: BalancesContext, contract: Contract)
     }),
   ])
 
-  const amount = BigNumber.from(balanceOfRes.output)
-  const rewards = BigNumber.from(rewardsRes.output)
+  const amount = BigNumber.from(balanceOfRes)
+  const rewards = BigNumber.from(rewardsRes)
 
   balances.push({
     chain: ctx.chain,
@@ -103,8 +103,8 @@ export async function getStakeBalancerPoolBalances(
   ])
 
   // staked balancer pool token
-  const stakedBalance = BigNumber.from(stakingBalanceOfRes.output)
-  const stakingRewards = BigNumber.from(stakingRewardsRes.output)
+  const stakedBalance = BigNumber.from(stakingBalanceOfRes)
+  const stakingRewards = BigNumber.from(stakingRewardsRes)
 
   // Underlyings
   const totalSupplyRes = await multicall({
@@ -127,7 +127,7 @@ export async function getStakeBalancerPoolBalances(
   const stakingContractLPBalanceRes = await call({
     ctx,
     target: ABPT.address,
-    params: stakingContract.address,
+    params: [stakingContract.address],
     abi: {
       constant: true,
       inputs: [{ internalType: 'address', name: '', type: 'address' }],
@@ -141,8 +141,7 @@ export async function getStakeBalancerPoolBalances(
 
   const underlyingsTokensAddressesRes = await call({
     ctx,
-    target: bPoolRes.output,
-    params: [],
+    target: bPoolRes,
     abi: {
       constant: true,
       inputs: [],
@@ -154,9 +153,9 @@ export async function getStakeBalancerPoolBalances(
     },
   })
 
-  const underlyingsTokensAddresses = underlyingsTokensAddressesRes.output
+  const underlyingsTokensAddresses = underlyingsTokensAddressesRes
   const underlyingsTokens = await getERC20Details(ctx, underlyingsTokensAddresses)
-  if (underlyingsTokens.length !== underlyingsTokensAddressesRes.output.length) {
+  if (underlyingsTokens.length !== underlyingsTokensAddressesRes.length) {
     console.log('Failed to get underlyings details')
     return []
   }
@@ -165,7 +164,7 @@ export async function getStakeBalancerPoolBalances(
     ctx,
     calls: underlyingsTokens.map((token) => ({
       target: token.address,
-      params: [bPoolRes.output],
+      params: [bPoolRes],
     })),
     abi: {
       constant: true,
@@ -178,26 +177,26 @@ export async function getStakeBalancerPoolBalances(
     },
   })
 
-  const underlying0Balance: Balance = {
+  const underlying0Balance = {
     chain: ctx.chain,
     address: underlyingsTokens[0].address,
     decimals: underlyingsTokens[0].decimals,
     symbol: underlyingsTokens[0].symbol,
     // staking share * underlying share
     amount: stakedBalance
-      .mul(stakingContractLPBalanceRes.output)
+      .mul(stakingContractLPBalanceRes)
       .div(totalSupplyRes[0].output)
       .mul(underlyingsBalancesRes[0].output)
       .div(totalSupplyRes[1].output),
   }
-  const underlying1Balance: Balance = {
+  const underlying1Balance = {
     chain: ctx.chain,
     address: underlyingsTokens[1].address,
     decimals: underlyingsTokens[1].decimals,
     symbol: underlyingsTokens[1].symbol,
     // staking share * underlying share
     amount: stakedBalance
-      .mul(stakingContractLPBalanceRes.output)
+      .mul(stakingContractLPBalanceRes)
       .div(totalSupplyRes[0].output)
       .mul(underlyingsBalancesRes[1].output)
       .div(totalSupplyRes[1].output),

--- a/src/adapters/abracadabra/common/mStake.ts
+++ b/src/adapters/abracadabra/common/mStake.ts
@@ -35,18 +35,18 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getMStakeContract(ctx: BaseContext, contract: Contract): Promise<Contract> {
   const [underlyingTokenAddressRes, rewardTokenAddressRes] = await Promise.all([
-    call({ ctx, target: contract.address, params: [], abi: abi.spell }),
-    call({ ctx, target: contract.address, params: [], abi: abi.mim }),
+    call({ ctx, target: contract.address, abi: abi.spell }),
+    call({ ctx, target: contract.address, abi: abi.mim }),
   ])
 
   const stakeContract: Contract = {
     ...contract,
-    underlyings: [underlyingTokenAddressRes.output],
-    rewards: [rewardTokenAddressRes.output],
+    underlyings: [underlyingTokenAddressRes],
+    rewards: [rewardTokenAddressRes],
   }
 
   return stakeContract
@@ -57,7 +57,7 @@ export async function getMStakeBalance(ctx: BalancesContext, contract: Contract)
   const underlying = contract.underlyings?.[0]
   const reward = contract.rewards?.[0]
 
-  const [balanceOfRes, pendingRewardsRes] = await Promise.all([
+  const [[amount], pendingRewardsRes] = await Promise.all([
     call({
       ctx,
       target: contract.address,
@@ -73,8 +73,8 @@ export async function getMStakeBalance(ctx: BalancesContext, contract: Contract)
     }),
   ])
 
-  const balanceOf = BigNumber.from(balanceOfRes.output.amount)
-  const pendingRewards = BigNumber.from(pendingRewardsRes.output)
+  const balanceOf = BigNumber.from(amount)
+  const pendingRewards = BigNumber.from(pendingRewardsRes)
 
   if (contract) {
     const balance: Balance = {

--- a/src/adapters/abracadabra/common/sStake.ts
+++ b/src/adapters/abracadabra/common/sStake.ts
@@ -19,19 +19,18 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getSStakeContract(ctx: BaseContext, contract: Contract): Promise<Contract> {
   const underlyingTokenAddressRes = await call({
     ctx,
     target: contract.address,
-    params: [],
     abi: abi.token,
   })
 
   const stakeContract: Contract = {
     ...contract,
-    underlyings: [underlyingTokenAddressRes.output],
+    underlyings: [underlyingTokenAddressRes],
   }
 
   return stakeContract
@@ -51,7 +50,6 @@ export async function getSStakeBalance(ctx: BalancesContext, contract: Contract)
     call({
       ctx,
       target: contract.address,
-      params: [],
       abi: erc20Abi.totalSupply,
     }),
 
@@ -63,9 +61,9 @@ export async function getSStakeBalance(ctx: BalancesContext, contract: Contract)
     }),
   ])
 
-  const balanceOf = BigNumber.from(balanceOfRes.output)
-  const totalSupply = BigNumber.from(totalSupplyRes.output)
-  const balanceOfTokenInUnderlying = BigNumber.from(balanceOfTokenInUnderlyingRes.output)
+  const balanceOf = BigNumber.from(balanceOfRes)
+  const totalSupply = BigNumber.from(totalSupplyRes)
+  const balanceOfTokenInUnderlying = BigNumber.from(balanceOfTokenInUnderlyingRes)
 
   const formattedBalanceOf = balanceOf.mul(balanceOfTokenInUnderlying).div(totalSupply)
 

--- a/src/adapters/agility-lsd/ethereum/lock.ts
+++ b/src/adapters/agility-lsd/ethereum/lock.ts
@@ -31,7 +31,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const AGI: Token = {
   chain: 'ethereum',
@@ -43,7 +43,7 @@ const AGI: Token = {
 export async function getAgilityLockerBalances(ctx: BalancesContext, locker: Contract): Promise<LockBalance[]> {
   const balances: LockBalance[] = []
 
-  const { output: userRedeemsLengthsRes } = await call({
+  const userRedeemsLengthsRes = await call({
     ctx,
     target: locker.address,
     params: [ctx.address],
@@ -52,7 +52,10 @@ export async function getAgilityLockerBalances(ctx: BalancesContext, locker: Con
 
   const getUserRedeemsRes = await multicall({
     ctx,
-    calls: range(0, userRedeemsLengthsRes).map((_, idx) => ({ target: locker.address, params: [ctx.address, idx] })),
+    calls: range(0, Number(userRedeemsLengthsRes)).map((_, idx) => ({
+      target: locker.address,
+      params: [ctx.address, idx],
+    })),
     abi: abi.getUserRedeem,
   })
 

--- a/src/adapters/alchemix/common/stake.ts
+++ b/src/adapters/alchemix/common/stake.ts
@@ -48,7 +48,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const ALCX: Token = {
   chain: 'ethereum',
@@ -64,19 +64,20 @@ export interface getStakerContractsParams extends Contract {
 export async function getStakerContracts(ctx: BaseContext, staker: Contract): Promise<getStakerContractsParams[]> {
   const contracts: getStakerContractsParams[] = []
 
-  const poolLength = await call({ ctx, target: staker.address, params: [], abi: abi.poolCount })
+  const poolLengthBI = await call({ ctx, target: staker.address, abi: abi.poolCount })
+  const poolLength = Number(poolLengthBI)
 
   const tokensCalls: Call[] = []
   const rewardsCalls: Call[] = []
 
-  for (let idx = 0; idx < poolLength.output; idx++) {
+  for (let idx = 0; idx < poolLength; idx++) {
     tokensCalls.push({ target: staker.address, params: [idx] })
     rewardsCalls.push({ target: staker.address, params: [] })
   }
 
   const poolTokensRes = await multicall({ ctx, calls: tokensCalls, abi: abi.getPoolToken })
 
-  for (let idx = 0; idx < poolLength.output; idx++) {
+  for (let idx = 0; idx < poolLength; idx++) {
     const poolTokenRes = poolTokensRes[idx]
 
     if (!isSuccess(poolTokenRes)) {

--- a/src/adapters/alpaca-finance/bsc/pools.ts
+++ b/src/adapters/alpaca-finance/bsc/pools.ts
@@ -44,19 +44,18 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getPoolsContracts(ctx: BaseContext, fairLaunch: Contract) {
   const contracts: Contract[] = []
 
-  const poolsLengthRes = await call({
+  const poolsLengthBI = await call({
     ctx,
     target: fairLaunch.address,
-    params: [],
     abi: abi.poolLength,
   })
 
-  const poolsLength = parseInt(poolsLengthRes.output)
+  const poolsLength = Number(poolsLengthBI)
 
   const poolsInfoRes = await multicall({
     ctx,

--- a/src/adapters/alpaca-finance/fantom/pools.ts
+++ b/src/adapters/alpaca-finance/fantom/pools.ts
@@ -32,19 +32,18 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getPoolsContracts(ctx: BaseContext, miniFairLaunch: Contract) {
   const contracts: Contract[] = []
 
-  const poolsLengthRes = await call({
+  const poolsLengthBI = await call({
     ctx,
     target: miniFairLaunch.address,
-    params: [],
     abi: abi.poolLength,
   })
 
-  const poolsLength = parseInt(poolsLengthRes.output)
+  const poolsLength = Number(poolsLengthBI)
 
   const poolsInfoRes = await multicall({
     ctx,

--- a/src/adapters/api3/ethereum/balance.ts
+++ b/src/adapters/api3/ethereum/balance.ts
@@ -11,7 +11,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const api3Token: Token = {
   chain: 'ethereum',
@@ -27,7 +27,7 @@ export async function getApi3StakeBalances(ctx: BalancesContext, staker: Contrac
     ...staker,
     symbol: api3Token.symbol,
     decimals: api3Token.decimals,
-    amount: BigNumber.from(userStakeRes.output),
+    amount: BigNumber.from(userStakeRes),
     underlyings: [api3Token],
     rewards: undefined,
     category: 'stake',

--- a/src/adapters/apollox/bsc/balance.ts
+++ b/src/adapters/apollox/bsc/balance.ts
@@ -37,7 +37,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getApolloStakeBalances(ctx: BalancesContext, staker: Contract): Promise<Balance | undefined> {
   const underlyings = staker.underlyings as Contract[]
@@ -45,7 +45,7 @@ export async function getApolloStakeBalances(ctx: BalancesContext, staker: Contr
     return
   }
 
-  const [{ output: balanceOf }, { output: totalSupply }, underlyingsBalancesRes] = await Promise.all([
+  const [balanceOf, totalSupply, underlyingsBalancesRes] = await Promise.all([
     call({
       ctx,
       target: staker.address,
@@ -102,7 +102,7 @@ export async function getApolloFarmBalances(ctx: BalancesContext, farmers: Contr
 
     balances.push({
       ...farmer,
-      address: farmer.token as string,
+      address: farmer.token as `0x${string}`,
       amount: BigNumber.from(userBalanceOfRes.output),
       underlyings,
       rewards: [{ ...reward, amount: BigNumber.from(userPendingRewardRes.output) }],

--- a/src/adapters/arrakis/common/contracts.ts
+++ b/src/adapters/arrakis/common/contracts.ts
@@ -37,19 +37,18 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getVaults(ctx: BaseContext, factoryArrakis: Contract) {
   const poolsDeployers = await call({
     ctx,
     target: factoryArrakis.address,
-    params: [],
     abi: abi.getDeployers,
   })
 
   const deployedPools = await multicall({
     ctx,
-    calls: poolsDeployers.output.map((deployer: string) => ({
+    calls: poolsDeployers.map((deployer: string) => ({
       target: factoryArrakis.address,
       params: [deployer],
     })),

--- a/src/adapters/asymetrix-protocol/ethereum/stake.ts
+++ b/src/adapters/asymetrix-protocol/ethereum/stake.ts
@@ -12,7 +12,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const ASX: Token = {
   chain: 'ethereum',
@@ -22,7 +22,7 @@ const ASX: Token = {
 }
 
 export async function getAsymetrixBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
-  const [balance, { output: pendingReward }] = await Promise.all([
+  const [balance, pendingReward] = await Promise.all([
     getSingleStakeBalance(ctx, { ...staker, address: staker.staker }),
     call({ ctx, target: staker.address, params: [ctx.address], abi: abi.getClaimableReward }),
   ])

--- a/src/adapters/atlas-usv/common/stake.ts
+++ b/src/adapters/atlas-usv/common/stake.ts
@@ -14,7 +14,7 @@ export async function getStakeBalance(ctx: BalancesContext, contract: Contract):
     abi: abi.balanceOf,
   })
 
-  const amount = BigNumber.from(balanceOfRes.output)
+  const amount = BigNumber.from(balanceOfRes)
 
   const balance: Balance = {
     ...contract,

--- a/src/adapters/aura/ethereum/balance.ts
+++ b/src/adapters/aura/ethereum/balance.ts
@@ -55,7 +55,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const BAL: Token = {
   chain: 'ethereum',
@@ -91,8 +91,8 @@ export async function getAuraBalStakerBalances(ctx: BalancesContext, staker: Con
 
   return {
     ...auraBal,
-    amount: BigNumber.from(balanceOfRes.output),
-    rewards: [{ ...BAL, amount: BigNumber.from(earnedRes.output) }],
+    amount: BigNumber.from(balanceOfRes),
+    rewards: [{ ...BAL, amount: BigNumber.from(earnedRes) }],
     category: 'farm',
   }
 }
@@ -143,16 +143,16 @@ export const getAuraMintAmount = async (
   const balancesWithExtraRewards: Balance[] = []
 
   const [auraReductionPerCliffRes, auraMaxSupplyRes, auraTotalSupplyRes, auraTotalCliffsRes] = await Promise.all([
-    call({ ctx, target: auraRewards.address, params: [], abi: abi.reductionPerCliff }),
-    call({ ctx, target: auraRewards.address, params: [], abi: abi.EMISSIONS_MAX_SUPPLY }),
-    call({ ctx, target: auraRewards.address, params: [], abi: abi.totalSupply }),
-    call({ ctx, target: auraRewards.address, params: [], abi: abi.totalCliffs }),
+    call({ ctx, target: auraRewards.address, abi: abi.reductionPerCliff }),
+    call({ ctx, target: auraRewards.address, abi: abi.EMISSIONS_MAX_SUPPLY }),
+    call({ ctx, target: auraRewards.address, abi: abi.totalSupply }),
+    call({ ctx, target: auraRewards.address, abi: abi.totalCliffs }),
   ])
 
-  const reductionPerCliff = BigNumber.from(auraReductionPerCliffRes.output)
-  const maxSupply = BigNumber.from(auraMaxSupplyRes.output)
-  const totalSupply = BigNumber.from(auraTotalSupplyRes.output)
-  const totalCliffs = BigNumber.from(auraTotalCliffsRes.output)
+  const reductionPerCliff = BigNumber.from(auraReductionPerCliffRes)
+  const maxSupply = BigNumber.from(auraMaxSupplyRes)
+  const totalSupply = BigNumber.from(auraTotalSupplyRes)
+  const totalCliffs = BigNumber.from(auraTotalCliffsRes)
   const minterMinted = BigNumber.from(0)
 
   // e.g. emissionsMinted = 6e25 - 5e25 - 0 = 1e25;

--- a/src/adapters/aura/ethereum/pool.ts
+++ b/src/adapters/aura/ethereum/pool.ts
@@ -46,7 +46,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const BAL: Token = {
   chain: 'ethereum',
@@ -58,9 +58,9 @@ const BAL: Token = {
 export async function getAuraPools(ctx: BaseContext, booster: Contract, vault: Contract): Promise<Contract[]> {
   const pools: Contract[] = []
 
-  const poolLengthRes = await call({ ctx, target: booster.address, params: [], abi: abi.poolLength })
+  const poolLengthBI = await call({ ctx, target: booster.address, abi: abi.poolLength })
 
-  const poolLength = parseInt(poolLengthRes.output)
+  const poolLength = Number(poolLengthBI)
 
   const calls: Call[] = []
   for (let idx = 0; idx < poolLength; idx++) {

--- a/src/adapters/badger-dao/ethereum/stake.ts
+++ b/src/adapters/badger-dao/ethereum/stake.ts
@@ -11,10 +11,10 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getBadgerStakeBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
-  const [balance, { output: exchangeRate }] = await Promise.all([
+  const [balance, exchangeRate] = await Promise.all([
     getSingleStakeBalance(ctx, staker),
     call({ ctx, target: staker.address, abi: abi.pricePerShare }),
   ])

--- a/src/adapters/balancer/ethereum/locker.ts
+++ b/src/adapters/balancer/ethereum/locker.ts
@@ -31,7 +31,7 @@ const abi = {
     inputs: [],
     outputs: [{ name: '', type: 'uint256' }],
   },
-}
+} as const
 
 const BAL: Token = {
   chain: 'ethereum',
@@ -52,10 +52,10 @@ export async function getLockerBalances(
   votingEscrow: Contract,
   vault: Contract,
 ): Promise<Balance> {
-  const [balanceOf, lockedEndRes, supplyRes, tokensBalancesRes] = await Promise.all([
+  const [balanceOf, lockedEnd, totalSupply, poolTokens] = await Promise.all([
     call({ ctx, target: votingEscrow.address, params: [ctx.address], abi: erc20Abi.balanceOf }),
     call({ ctx, target: votingEscrow.address, params: [ctx.address], abi: abi.locked__end }),
-    call({ ctx, target: votingEscrow.address, params: [], abi: erc20Abi.totalSupply }),
+    call({ ctx, target: votingEscrow.address, abi: erc20Abi.totalSupply }),
     call({
       ctx,
       target: vault.address,
@@ -64,25 +64,22 @@ export async function getLockerBalances(
       abi: abi.getPoolTokens,
     }),
   ])
+  const [_tokens, balances, _lastChangeBlock] = poolTokens
 
-  const underlyings0Balances = BigNumber.from(balanceOf.output)
-    .mul(tokensBalancesRes.output.balances[0])
-    .div(supplyRes.output)
+  const underlyings0Balances = BigNumber.from(balanceOf).mul(balances[0]).div(totalSupply)
 
-  const underlyings1Balances = BigNumber.from(balanceOf.output)
-    .mul(tokensBalancesRes.output.balances[1])
-    .div(supplyRes.output)
+  const underlyings1Balances = BigNumber.from(balanceOf).mul(balances[1]).div(totalSupply)
 
   const now = Date.now() / 1000
-  const unlockAt = lockedEndRes.output
+  const unlockAt = Number(lockedEnd)
 
   return {
     chain: ctx.chain,
     address: votingEscrow.address,
     symbol: votingEscrow.symbol,
     decimals: votingEscrow.decimals,
-    amount: BigNumber.from(balanceOf.output),
-    claimable: now > unlockAt ? BigNumber.from(balanceOf.output) : BN_ZERO,
+    amount: BigNumber.from(balanceOf),
+    claimable: now > unlockAt ? BigNumber.from(balanceOf) : BN_ZERO,
     unlockAt,
     underlyings: [
       { ...BAL, amount: underlyings0Balances },

--- a/src/adapters/bancor-v3/ethereum/pools.ts
+++ b/src/adapters/bancor-v3/ethereum/pools.ts
@@ -95,7 +95,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const bancorNetwork = '0xeEF417e1D5CC832e619ae18D2F140De2999dD4fB'
 const standardRewards = '0xb0B958398ABB0b5DB4ce4d7598Fb868f5A00f372'
@@ -105,8 +105,7 @@ export interface Program extends Contract {
 }
 
 export async function getPoolsContracts(ctx: BaseContext): Promise<Contract[]> {
-  const poolCollectionsRes = await call({ ctx, target: bancorNetwork, abi: abi.poolCollections })
-  const poolCollections: string[] = poolCollectionsRes.output
+  const poolCollections = await call({ ctx, target: bancorNetwork, abi: abi.poolCollections })
 
   // standard tokens: DAI, LINK, 1INCH...
   const collectionsPoolsRes = await multicall({
@@ -144,8 +143,7 @@ export async function getPoolsBalances(ctx: BalancesContext, pools: Contract[]) 
 }
 
 export async function getProgramsContracts(ctx: BaseContext): Promise<Program[]> {
-  const programIdsRes = await call({ ctx, target: standardRewards, abi: abi.programIds })
-  const programIds = programIdsRes.output.map((str: string) => BigNumber.from(str))
+  const programIds = await call({ ctx, target: standardRewards, abi: abi.programIds })
 
   const programsRes = await call({
     ctx,
@@ -154,8 +152,8 @@ export async function getProgramsContracts(ctx: BaseContext): Promise<Program[]>
     abi: abi.programs,
   })
 
-  return programsRes.output.map((programData: any) => ({
-    id: parseInt(programData.id),
+  return programsRes.map((programData) => ({
+    id: Number(programData.id),
     chain: ctx.chain,
     address: programData.poolToken,
     // replace ETH alias

--- a/src/adapters/beefy/common/utils.ts
+++ b/src/adapters/beefy/common/utils.ts
@@ -90,7 +90,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 interface RegistryParams {
   address: string
@@ -254,7 +254,7 @@ export const fmtCurveProvider = async (
       continue
     }
 
-    const { output: poolAddress } = await call({ ctx, target: strategy, abi: abi.pool })
+    const poolAddress = await call({ ctx, target: strategy, abi: abi.pool })
 
     const calls: Call[] = []
     for (const registry of registries) {

--- a/src/adapters/bella-protocol/ethereum/contract.ts
+++ b/src/adapters/bella-protocol/ethereum/contract.ts
@@ -47,15 +47,17 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getBellaContracts(ctx: BaseContext, contract: Contract): Promise<Contract[]> {
   const contracts: Contract[] = []
 
-  const [{ output: poolLength }, { output: bellaToken }] = await Promise.all([
+  const [poolLengthBI, bellaToken] = await Promise.all([
     call({ ctx, target: contract.address, abi: abi.poolLength }),
     call({ ctx, target: contract.address, abi: abi.bella }),
   ])
+
+  const poolLength = Number(poolLengthBI)
 
   const poolInfosRes = await multicall({
     ctx,

--- a/src/adapters/benddao/ethereum/balance.ts
+++ b/src/adapters/benddao/ethereum/balance.ts
@@ -15,7 +15,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const weth: Token = {
   chain: 'ethereum',
@@ -34,15 +34,14 @@ const bend: Token = {
 export async function getBendBalances(ctx: BalancesContext, contract: Contract): Promise<Balance> {
   const [balanceOfRes, rewardsOfRes] = await Promise.all([
     call({ ctx, target: contract.address, params: [ctx.address], abi: erc20Abi.balanceOf }),
-    // @ts-ignore
     call({ ctx, target: contract.rewarder, params: [[contract.address], ctx.address], abi: abi.getRewardsBalance }),
   ])
 
   return {
     ...contract,
-    amount: BigNumber.from(balanceOfRes.output),
+    amount: BigNumber.from(balanceOfRes),
     underlyings: [weth],
-    rewards: [{ ...bend, amount: BigNumber.from(rewardsOfRes.output) }],
+    rewards: [{ ...bend, amount: BigNumber.from(rewardsOfRes) }],
     category: 'farm',
   }
 }

--- a/src/adapters/benddao/ethereum/nft.ts
+++ b/src/adapters/benddao/ethereum/nft.ts
@@ -97,7 +97,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const weth: Token = {
   chain: 'ethereum',
@@ -116,11 +116,11 @@ const ape: Token = {
 export async function getNftContracts(ctx: BaseContext, registry: Contract): Promise<Contract[]> {
   const nfts: Contract[] = []
 
-  const { output: nftsAddresses } = await call({ ctx, target: registry.address, abi: abi.getBNFTAssetList })
+  const nftsAddresses = await call({ ctx, target: registry.address, abi: abi.getBNFTAssetList })
 
   const nftsProxies = await multicall({
     ctx,
-    calls: nftsAddresses.map((nft: string) => ({ target: registry.address, params: [nft] })),
+    calls: nftsAddresses.map((nft) => ({ target: registry.address, params: [nft] })),
     abi: abi.bNftProxys,
   })
 

--- a/src/adapters/benqi-staked-avax/avalanche/stake.ts
+++ b/src/adapters/benqi-staked-avax/avalanche/stake.ts
@@ -13,7 +13,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const WAVAX: Token = {
   chain: 'avalanche',
@@ -22,25 +22,27 @@ const WAVAX: Token = {
   decimals: 18,
 }
 
-export async function getStakeBalances(ctx: BalancesContext, contract: Contract): Promise<Balance> {
-  const { output: balanceOfRes } = await call({
+export async function getStakeBalances(ctx: BalancesContext, contract: Contract) {
+  const balanceOfRes = await call({
     ctx,
     target: contract.address,
-    params: ctx.address,
+    params: [ctx.address],
     abi: erc20Abi.balanceOf,
   })
 
-  const { output: fmtBalanceOf } = await call({
+  const fmtBalanceOf = await call({
     ctx,
     target: contract.address,
     params: [balanceOfRes],
     abi: abi.getPooledAvaxByShares,
   })
 
-  return {
+  const balance: Balance = {
     ...contract,
     rewards: undefined,
     amount: BigNumber.from(fmtBalanceOf),
     underlyings: [{ ...WAVAX }],
   }
+
+  return balance
 }

--- a/src/adapters/biswap/bsc/balance.ts
+++ b/src/adapters/biswap/bsc/balance.ts
@@ -48,7 +48,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const BSW: Token = {
   chain: 'bsc',
@@ -60,19 +60,20 @@ const BSW: Token = {
 export async function getUniqueUnderlyingsMasterchefBalances(ctx: BalancesContext, masterchef: Contract) {
   const balances: Balance[] = []
 
-  const [balanceOfRes, pendingRewardsRes] = await Promise.all([
-    call({ ctx, target: masterchef.address, params: [0, ctx.address], abi: abi.userInfo }),
-    call({ ctx, target: masterchef.address, params: [0, ctx.address], abi: abi.pendingBSW }),
+  const [userInfo, pendingRewards] = await Promise.all([
+    call({ ctx, target: masterchef.address, params: [0n, ctx.address], abi: abi.userInfo }),
+    call({ ctx, target: masterchef.address, params: [0n, ctx.address], abi: abi.pendingBSW }),
   ])
+  const [amount, _rewardDebt] = userInfo
 
   balances.push({
     chain: ctx.chain,
     address: BSW.address,
     decimals: BSW.decimals,
     symbol: 'BSW-LP',
-    amount: BigNumber.from(balanceOfRes.output.amount),
+    amount: BigNumber.from(amount),
     underlyings: [BSW],
-    rewards: [{ ...BSW, amount: BigNumber.from(pendingRewardsRes.output) }],
+    rewards: [{ ...BSW, amount: BigNumber.from(pendingRewards) }],
     category: 'farm',
   })
 

--- a/src/adapters/biswap/bsc/lock.ts
+++ b/src/adapters/biswap/bsc/lock.ts
@@ -28,7 +28,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const BSW: Token = {
   chain: 'bsc',
@@ -38,10 +38,10 @@ const BSW: Token = {
 }
 
 export async function getBiswapLockerBalances(ctx: BalancesContext, locker: Contract): Promise<Balance> {
-  const { output: userInfo } = await call({ ctx, target: locker.address, params: [ctx.address], abi: abi.getUserInfo })
+  const userInfo = await call({ ctx, target: locker.address, params: [ctx.address], abi: abi.getUserInfo })
 
   const now = Date.now() / 1000
-  const unlockAt = userInfo[0].unlockTimestamp
+  const unlockAt = Number(userInfo[0].unlockTimestamp)
 
   return {
     ...locker,

--- a/src/adapters/cap-finance/arbitrum/balance.ts
+++ b/src/adapters/cap-finance/arbitrum/balance.ts
@@ -49,7 +49,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const CAP: Token = {
   chain: 'arbitrum',
@@ -165,7 +165,7 @@ export async function getStakeBalances(ctx: BalancesContext, contracts: Contract
 export async function getYieldBalances(ctx: BalancesContext, contract: Contract): Promise<Balance> {
   const underlying = contract.underlyings?.[0] as Contract
 
-  const { output: userBalancesRes } = await call({
+  const userBalances = await call({
     ctx,
     target: contract.lpToken,
     params: [ctx.address],
@@ -176,7 +176,7 @@ export async function getYieldBalances(ctx: BalancesContext, contract: Contract)
     ...contract,
     decimals: underlying.decimals,
     symbol: underlying.symbol,
-    amount: BigNumber.from(userBalancesRes),
+    amount: BigNumber.from(userBalances),
     underlyings: [underlying],
     rewards: undefined,
     category: 'farm',
@@ -184,10 +184,9 @@ export async function getYieldBalances(ctx: BalancesContext, contract: Contract)
 }
 
 export async function getDepositV2Balances(ctx: BalancesContext, contract: Contract): Promise<Balance[]> {
-  const { output: balanceOfsRes } = await call({
+  const balanceOfsRes = await call({
     ctx,
     target: contract.pool,
-    // @ts-ignore
     params: [['0x0000000000000000000000000000000000000000', '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8'], ctx.address],
     abi: abi.getUserBalances,
   })

--- a/src/adapters/cat-in-a-box/ethereum/lend.ts
+++ b/src/adapters/cat-in-a-box/ethereum/lend.ts
@@ -19,7 +19,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const WETH: Token = {
   chain: 'ethereum',
@@ -33,7 +33,7 @@ export async function getCatMarketsBalances(
   market: Contract,
   tokensLists: Contract[],
 ): Promise<Balance[]> {
-  const [{ output: deposited }, { output: debt }] = await Promise.all([
+  const [deposited, debt] = await Promise.all([
     call({ ctx, target: market.address, params: [ctx.address], abi: abi.deposited }),
     call({ ctx, target: market.address, params: [ctx.address], abi: abi.debt }),
   ])

--- a/src/adapters/cat-in-a-box/ethereum/stake.ts
+++ b/src/adapters/cat-in-a-box/ethereum/stake.ts
@@ -26,7 +26,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const boxETH: Token = {
   chain: 'ethereum',
@@ -38,7 +38,7 @@ const boxETH: Token = {
 const CONVERTER = '0xe4b91faf8810f8895772e7ca065d4cb889120f94'
 
 export async function getCatStakeEscrowBalance(ctx: BalancesContext, staker: Contract): Promise<Balance> {
-  const { output: userBalancesOfsRes } = await call({
+  const balanceOf = await call({
     ctx,
     target: staker.address,
     params: [ctx.address],
@@ -47,7 +47,7 @@ export async function getCatStakeEscrowBalance(ctx: BalancesContext, staker: Con
 
   const balance: Balance = {
     ...staker,
-    amount: BigNumber.from(userBalancesOfsRes),
+    amount: BigNumber.from(balanceOf),
     underlyings: [boxETH],
     rewards: undefined,
     category: 'stake',
@@ -57,7 +57,7 @@ export async function getCatStakeEscrowBalance(ctx: BalancesContext, staker: Con
 }
 
 export async function getCatStakeBalance(ctx: BalancesContext, staker: Contract): Promise<Balance> {
-  const [{ output: deposited }, { output: earned }] = await Promise.all([
+  const [deposited, earned] = await Promise.all([
     call({ ctx, target: staker.address, params: [ctx.address], abi: abi.deposited }),
     call({ ctx, target: staker.address, params: [ctx.address], abi: abi.Owing }),
   ])
@@ -74,10 +74,10 @@ export async function getCatStakeBalance(ctx: BalancesContext, staker: Contract)
 }
 
 const ftmCatBalances = async (ctx: BalancesContext, balance: Balance): Promise<Balance> => {
-  const { output: ftmBalances } = await call({
+  const ftmBalances = await call({
     ctx,
     target: CONVERTER,
-    params: [balance.amount.toString()],
+    params: [BigInt(balance.amount.toString())],
     abi: abi.convertToAssets,
   })
 

--- a/src/adapters/chainlink/ethereum/balance.ts
+++ b/src/adapters/chainlink/ethereum/balance.ts
@@ -18,7 +18,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const link: Token = {
   chain: 'ethereum',
@@ -28,18 +28,18 @@ const link: Token = {
 }
 
 export async function getChainlinkStakerBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
-  const [balanceOfRes, rewardsOfRes] = await Promise.all([
+  const [balanceOf, rewardsOf] = await Promise.all([
     call({ ctx, target: staker.address, params: [ctx.address], abi: abi.getStake }),
     call({ ctx, target: staker.address, params: [ctx.address], abi: abi.getBaseReward }),
   ])
 
   return {
     ...staker,
-    amount: BigNumber.from(balanceOfRes.output),
+    amount: BigNumber.from(balanceOf),
     decimals: link.decimals,
     symbol: link.symbol,
     underlyings: staker.underlyings as Contract[],
-    rewards: [{ ...link, amount: BigNumber.from(rewardsOfRes.output) }],
+    rewards: [{ ...link, amount: BigNumber.from(rewardsOf) }],
     category: 'stake',
   }
 }

--- a/src/adapters/coinwind/common/contract.ts
+++ b/src/adapters/coinwind/common/contract.ts
@@ -47,14 +47,14 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getCoinWindContracts(ctx: BaseContext, masterchef: Contract): Promise<Contract[]> {
-  const { output: poolLength } = await call({ ctx, target: masterchef.address, abi: abi.poolLength })
+  const poolLengthBI = await call({ ctx, target: masterchef.address, abi: abi.poolLength })
 
   const poolInfosRes = await multicall({
     ctx,
-    calls: range(0, poolLength).map((_, idx) => ({ target: masterchef.address, params: [idx] })),
+    calls: range(0, Number(poolLengthBI)).map((_, idx) => ({ target: masterchef.address, params: [idx] })),
     abi: abi.poolInfo,
   })
 

--- a/src/adapters/compound/common/rewards.ts
+++ b/src/adapters/compound/common/rewards.ts
@@ -53,7 +53,7 @@ export async function getRewardsBalances(
     },
   })
 
-  const compAllocatedRewards = BigNumber.from(compAllocatedRewardsRes.output.allocated)
+  const compAllocatedRewards = BigNumber.from(compAllocatedRewardsRes.allocated)
 
   rewards.push({
     chain: ctx.chain,

--- a/src/adapters/concentrator/ethereum/pool.ts
+++ b/src/adapters/concentrator/ethereum/pool.ts
@@ -117,7 +117,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const metaRegistry: Contract = {
   chain: 'ethereum',
@@ -128,8 +128,8 @@ export async function getPoolsContracts(ctx: BaseContext, contracts: Contract[])
   const pools: Contract[] = []
 
   for (const contract of contracts) {
-    const poolsCountRes = await call({ ctx, target: contract.address, params: [], abi: abi.poolLength })
-    const poolsCount: number = parseInt(poolsCountRes.output)
+    const poolsCountBI = await call({ ctx, target: contract.address, abi: abi.poolLength })
+    const poolsCount = Number(poolsCountBI)
 
     const poolInfosRes = await multicall({
       ctx,
@@ -210,8 +210,8 @@ export async function getPoolsContracts(ctx: BaseContext, contracts: Contract[])
 export async function getOldContracts(ctx: BaseContext, contract: Contract): Promise<Contract[]> {
   const pools: Contract[] = []
 
-  const poolsCountRes = await call({ ctx, target: contract.address, params: [], abi: abi.poolLength })
-  const poolsCount: number = parseInt(poolsCountRes.output)
+  const poolsCountBI = await call({ ctx, target: contract.address, abi: abi.poolLength })
+  const poolsCount = Number(poolsCountBI)
 
   const poolInfosRes = await multicall({
     ctx,

--- a/src/adapters/concentrator/ethereum/staker.ts
+++ b/src/adapters/concentrator/ethereum/staker.ts
@@ -12,7 +12,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const metaRegistry: Contract = {
   chain: 'ethereum',
@@ -21,20 +21,20 @@ const metaRegistry: Contract = {
 
 export async function getStakeBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
   const underlyings = staker.underlyings as Contract[]
-  const balanceOfRes = await call({ ctx, target: staker.address, params: [ctx.address], abi: erc20Abi.balanceOf })
+  const balanceOf = await call({ ctx, target: staker.address, params: [ctx.address], abi: erc20Abi.balanceOf })
 
   const underlyingsBalances = await call({
     ctx,
     target: staker.address,
-    params: [balanceOfRes.output],
+    params: [balanceOf],
     abi: abi.convertToAssets,
   })
 
   if (underlyings.length < 2) {
     return {
       ...staker,
-      amount: BigNumber.from(balanceOfRes.output),
-      underlyings: [{ ...underlyings[0], amount: BigNumber.from(underlyingsBalances.output) }],
+      amount: BigNumber.from(balanceOf),
+      underlyings: [{ ...underlyings[0], amount: BigNumber.from(underlyingsBalances) }],
       rewards: undefined,
       category: 'stake',
     }
@@ -42,7 +42,7 @@ export async function getStakeBalances(ctx: BalancesContext, staker: Contract): 
 
   return {
     ...staker,
-    amount: BigNumber.from(underlyingsBalances.output),
+    amount: BigNumber.from(underlyingsBalances),
     underlyings,
     rewards: undefined,
     category: 'stake',
@@ -60,11 +60,11 @@ export async function getStakeInPools(ctx: BalancesContext, stakers: Contract[])
 
 export async function getOldStaleInPools(ctx: BalancesContext, staker: Contract): Promise<Balance[]> {
   const underlyings = staker.underlyings as Contract[]
-  const balanceOfRes = await call({ ctx, target: staker.address, params: [ctx.address], abi: erc20Abi.balanceOf })
+  const balanceOf = await call({ ctx, target: staker.address, params: [ctx.address], abi: erc20Abi.balanceOf })
 
   const balance: Balance = {
     ...staker,
-    amount: BigNumber.from(balanceOfRes.output),
+    amount: BigNumber.from(balanceOf),
     underlyings,
     rewards: undefined,
     category: 'stake',

--- a/src/adapters/convex-finance/common/pool.ts
+++ b/src/adapters/convex-finance/common/pool.ts
@@ -33,18 +33,18 @@ const abi = {
     outputs: [{ name: '', type: 'address' }],
     gas: 3123,
   },
-}
+} as const
 
 export async function getConvexAltChainsPools(
   ctx: BaseContext,
   booster: Contract,
   curvePools: Contract[],
 ): Promise<Contract[]> {
-  const { output: poolLength } = await call({ ctx, target: booster.address, abi: abi.poolLength })
+  const poolLengthBI = await call({ ctx, target: booster.address, abi: abi.poolLength })
 
   const poolInfosRes = await multicall({
     ctx,
-    calls: range(0, poolLength).map((i) => ({
+    calls: range(0, Number(poolLengthBI)).map((i) => ({
       target: booster.address,
       params: [i],
     })),

--- a/src/adapters/convex-finance/ethereum/balance.ts
+++ b/src/adapters/convex-finance/ethereum/balance.ts
@@ -30,7 +30,7 @@ const abi = {
     outputs: [{ name: '', type: 'uint256' }],
     gas: 20255,
   },
-}
+} as const
 
 const CVX: Token = {
   chain: 'ethereum',
@@ -57,7 +57,7 @@ export async function getConvexGaugesBalances(
     calls.push({ target: (gaugeBalance as Contract).crvRewards, params: [ctx.address] })
   }
 
-  const [claimableRewards, cvxTotalSupplyRes] = await Promise.all([
+  const [claimableRewards, cvxTotalSupply] = await Promise.all([
     multicall({ ctx, calls, abi: abi.earned }),
     call({ ctx, target: CVX.address, abi: erc20Abi.totalSupply }),
   ])
@@ -74,7 +74,7 @@ export async function getConvexGaugesBalances(
     rewards[0].amount = BigNumber.from(claimableReward.output || BN_ZERO)
 
     // rewards[1] is the common reward for all pools: CVX
-    rewards[1].amount = getCvxCliffRatio(BigNumber.from(cvxTotalSupplyRes.output), rewards[0].amount)
+    rewards[1].amount = getCvxCliffRatio(BigNumber.from(cvxTotalSupply), rewards[0].amount)
 
     if (rewards.length < 3) {
       commonRewardsPools.push(gaugeBalance)

--- a/src/adapters/convex-finance/ethereum/pool.ts
+++ b/src/adapters/convex-finance/ethereum/pool.ts
@@ -72,7 +72,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const CRV: Token = {
   chain: 'ethereum',
@@ -96,18 +96,19 @@ const metaRegistry: Contract = {
 export async function getPoolsContracts(ctx: BaseContext, contract: Contract): Promise<Contract[]> {
   const pools: Contract[] = []
 
-  const { output: poolsCount } = await call({ ctx, target: contract.address, abi: abi.poolLength })
+  const poolLengthBI = await call({ ctx, target: contract.address, abi: abi.poolLength })
+  const poolLength = Number(poolLengthBI)
 
   const poolInfosRes = await multicall({
     ctx,
-    calls: range(0, poolsCount).map((i) => ({
+    calls: range(0, poolLength).map((i) => ({
       target: contract.address,
       params: [i],
     })),
     abi: abi.poolInfo,
   })
 
-  for (let idx = 0; idx < poolsCount; idx++) {
+  for (let idx = 0; idx < poolLength; idx++) {
     const poolInfoRes = poolInfosRes[idx]
     if (!isSuccess(poolInfoRes)) continue
 

--- a/src/adapters/convex-finance/ethereum/stake.ts
+++ b/src/adapters/convex-finance/ethereum/stake.ts
@@ -14,7 +14,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const CRV: Token = {
   chain: 'ethereum',
@@ -38,15 +38,15 @@ const cvxCRV: Token = {
 }
 
 export async function getCvxCrvStakeBalance(ctx: BalancesContext, cvxCrv: Contract): Promise<Balance> {
-  const [balanceOfRes, crvEarnedRes, cvxTotalSupplyRes] = await Promise.all([
+  const [balanceOfBI, crvEarnedBI, cvxTotalSupplyBI] = await Promise.all([
     call({ ctx, target: cvxCrv.address, params: [ctx.address], abi: erc20Abi.balanceOf }),
     call({ ctx, target: cvxCrv.address, params: [ctx.address], abi: abi.earned }),
     call({ ctx, target: CVX.address, abi: erc20Abi.totalSupply }),
   ])
 
-  const balanceOf = BigNumber.from(balanceOfRes.output || '0')
-  const crvEarned = BigNumber.from(crvEarnedRes.output || '0')
-  const cvxTotalSupply = BigNumber.from(cvxTotalSupplyRes.output || '0')
+  const balanceOf = BigNumber.from(balanceOfBI || '0')
+  const crvEarned = BigNumber.from(crvEarnedBI || '0')
+  const cvxTotalSupply = BigNumber.from(cvxTotalSupplyBI || '0')
 
   const rewards: Balance[] = []
 
@@ -67,13 +67,13 @@ export async function getCvxCrvStakeBalance(ctx: BalancesContext, cvxCrv: Contra
 }
 
 export async function getCVXStakeBalance(ctx: BalancesContext, cvxRewardPool: Contract): Promise<Balance> {
-  const [balanceOfRes, earnedRes] = await Promise.all([
+  const [balanceOfBI, earnedBI] = await Promise.all([
     call({ ctx, target: cvxRewardPool.address, params: [ctx.address], abi: erc20Abi.balanceOf }),
     call({ ctx, target: cvxRewardPool.address, params: [ctx.address], abi: abi.earned }),
   ])
 
-  const balanceOf = BigNumber.from(balanceOfRes.output)
-  const earned = BigNumber.from(earnedRes.output)
+  const balanceOf = BigNumber.from(balanceOfBI)
+  const earned = BigNumber.from(earnedBI)
 
   return {
     chain: ctx.chain,

--- a/src/adapters/curve-dex/ethereum/locker.ts
+++ b/src/adapters/curve-dex/ethereum/locker.ts
@@ -12,7 +12,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const CRV: Token = {
   chain: 'ethereum',
@@ -33,7 +33,7 @@ export async function getLockerBalances(
   contract: Contract,
   feeDistributorContract: Contract,
 ): Promise<Balance> {
-  const [lockedBalance, { output: claimableBalanceRes }] = await Promise.all([
+  const [lockedBalance, claimableBalance] = await Promise.all([
     getSingleLockerBalance(ctx, contract, CRV, 'locked'),
     call({
       ctx,
@@ -43,5 +43,5 @@ export async function getLockerBalances(
     }),
   ])
 
-  return { ...lockedBalance, rewards: [{ ...triCrv, amount: BigNumber.from(claimableBalanceRes) }] }
+  return { ...lockedBalance, rewards: [{ ...triCrv, amount: BigNumber.from(claimableBalance) }] }
 }

--- a/src/adapters/curve-dex/ethereum/pools.ts
+++ b/src/adapters/curve-dex/ethereum/pools.ts
@@ -65,7 +65,7 @@ const abiPools = {
     inputs: [{ name: '_pool', type: 'address' }],
     outputs: [{ name: '', type: 'address[8]' }],
   },
-}
+} as const
 
 const abiGauges = {
   n_gauges: {
@@ -138,20 +138,19 @@ const abiGauges = {
     outputs: [{ name: '', type: 'uint256' }],
     gas: 3034,
   },
-}
+} as const
 
 export async function getPoolsContracts(ctx: BaseContext, registry: Contract) {
   const poolContracts: Contract[] = []
   const pools: Contract[] = []
 
-  const poolsCountRes = await call({
+  const poolsCountBI = await call({
     ctx,
     target: registry.address,
-    params: [],
     abi: abiPools.pool_count,
   })
 
-  const poolsCounts = parseInt(poolsCountRes.output)
+  const poolsCounts = Number(poolsCountBI)
 
   // lists of pools
   const poolsCalls: Call[] = range(0, poolsCounts).map((i) => ({

--- a/src/adapters/dydx/ethereum/deposit.ts
+++ b/src/adapters/dydx/ethereum/deposit.ts
@@ -52,14 +52,14 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getDepositMarkets(ctx: BaseContext, staker: Contract): Promise<Contract[]> {
-  const { output: marketsLength } = await call({ ctx, target: staker.address, abi: abi.getNumMarkets })
+  const marketsLength = await call({ ctx, target: staker.address, abi: abi.getNumMarkets })
 
   const marketsAddressesRes = await multicall({
     ctx,
-    calls: range(0, marketsLength).map((idx: number) => ({ target: staker.address, params: [idx] })),
+    calls: range(0, Number(marketsLength)).map((idx: number) => ({ target: staker.address, params: [idx] })),
     abi: abi.getMarketTokenAddress,
   })
 

--- a/src/adapters/ether.fi/ethereum/stake.ts
+++ b/src/adapters/ether.fi/ethereum/stake.ts
@@ -14,19 +14,21 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getEtherBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
-  const { output: userBalanceOf } = await call({
+  const depositInfo = await call({
     ctx,
     target: staker.address,
     params: [ctx.address],
     abi: abi.depositInfo,
   })
 
+  const [_depositTime, etherBalance, _totalERC20Balance] = depositInfo
+
   return {
     ...staker,
-    amount: BigNumber.from(userBalanceOf.etherBalance),
+    amount: BigNumber.from(etherBalance),
     underlyings: undefined,
     rewards: undefined,
     category: 'stake',

--- a/src/adapters/euler/common/markets.ts
+++ b/src/adapters/euler/common/markets.ts
@@ -51,7 +51,7 @@ export async function getMarketsContracts(ctx: BaseContext): Promise<Contract[]>
 }
 
 export async function getHealthFactor(ctx: BalancesContext, lensContract: Contract): Promise<number | undefined> {
-  const getHealthFactor = await call({
+  const [_collateralValue, _liabilityValue, healthScore] = await call({
     ctx,
     target: lensContract.address,
     params: [ctx.address],
@@ -68,11 +68,11 @@ export async function getHealthFactor(ctx: BalancesContext, lensContract: Contra
     },
   })
 
-  if (!getHealthFactor.success || ethers.constants.MaxUint256.eq(getHealthFactor.output.healthScore)) {
+  if (ethers.constants.MaxUint256.eq(healthScore)) {
     return
   }
 
-  const healthFactor = parseFloat(utils.formatUnits(getHealthFactor.output.healthScore, 18))
+  const healthFactor = parseFloat(utils.formatUnits(healthScore, 18))
 
   return healthFactor
 }

--- a/src/adapters/everrise/common/stake.ts
+++ b/src/adapters/everrise/common/stake.ts
@@ -50,7 +50,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getEverriseBalances(ctx: BalancesContext, nftStaker: Contract): Promise<Balance[] | undefined> {
   const RISE = nftStaker.underlyings?.[0] as Contract
@@ -58,7 +58,7 @@ export async function getEverriseBalances(ctx: BalancesContext, nftStaker: Contr
     return
   }
 
-  const [{ output: balanceOfLength }, { output: pendingReward }] = await Promise.all([
+  const [balanceOfLength, pendingReward] = await Promise.all([
     call({
       ctx,
       target: nftStaker.address,
@@ -75,7 +75,10 @@ export async function getEverriseBalances(ctx: BalancesContext, nftStaker: Contr
 
   const tokenOfOwnerByIndexesRes = await multicall({
     ctx,
-    calls: range(0, balanceOfLength).map((_, idx) => ({ target: nftStaker.address, params: [ctx.address, idx] })),
+    calls: range(0, Number(balanceOfLength)).map((_, idx) => ({
+      target: nftStaker.address,
+      params: [ctx.address, idx],
+    })),
     abi: abi.tokenOfOwnerByIndex,
   })
 

--- a/src/adapters/fantohm/fantom/stake.ts
+++ b/src/adapters/fantohm/fantom/stake.ts
@@ -12,7 +12,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const FHM: Token = {
   chain: 'fantom',
@@ -24,10 +24,10 @@ const FHM: Token = {
 export async function getwxFHMStakeBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
   const balance = await getSingleStakeBalance(ctx, staker)
 
-  const { output: fmtBalances } = await call({
+  const fmtBalances = await call({
     ctx,
     target: staker.address,
-    params: [balance.amount.toString()],
+    params: [BigInt(balance.amount.toString())],
     abi: abi.sFHMValue,
   })
 

--- a/src/adapters/floor-dao/ethereum/stake.ts
+++ b/src/adapters/floor-dao/ethereum/stake.ts
@@ -15,14 +15,14 @@ const FLOOR: Contract = {
 export async function getStakeBalances(ctx: BalancesContext, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
-  const balanceOfRes = await call({
+  const balanceOf = await call({
     ctx,
     target: contract.address,
     params: [ctx.address],
     abi: abi.balanceOf,
   })
 
-  const amount = BigNumber.from(balanceOfRes.output)
+  const amount = BigNumber.from(balanceOf)
 
   balances.push({
     chain: ctx.chain,
@@ -40,16 +40,14 @@ export async function getStakeBalances(ctx: BalancesContext, contract: Contract)
 export async function getFormattedStakeBalances(ctx: BalancesContext, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
-  const balanceOfRes = await call({
+  const balanceOf = await call({
     ctx,
     target: contract.address,
     params: [ctx.address],
     abi: abi.balanceOf,
   })
 
-  const balanceOf = balanceOfRes.output
-
-  const formattedBalanceOfRes = await call({
+  const formattedBalanceOfBI = await call({
     ctx,
     target: contract.address,
     params: [balanceOf],
@@ -62,7 +60,7 @@ export async function getFormattedStakeBalances(ctx: BalancesContext, contract: 
     },
   })
 
-  const formattedBalanceOf = BigNumber.from(formattedBalanceOfRes.output)
+  const formattedBalanceOf = BigNumber.from(formattedBalanceOfBI)
 
   balances.push({
     chain: ctx.chain,

--- a/src/adapters/floor-dao/ethereum/vester.ts
+++ b/src/adapters/floor-dao/ethereum/vester.ts
@@ -27,7 +27,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const FLOOR: Token = {
   chain: 'ethereum',
@@ -44,7 +44,7 @@ const gFLOOR: Token = {
 }
 
 export async function getVesterBalances(ctx: BalancesContext, vester: Contract): Promise<Balance> {
-  const { output: userIndexesRes } = await call({
+  const userIndexesRes = await call({
     ctx,
     target: vester.address,
     params: [ctx.address],
@@ -53,11 +53,11 @@ export async function getVesterBalances(ctx: BalancesContext, vester: Contract):
 
   const balancesOfRes = await multicall({
     ctx,
-    calls: userIndexesRes.map((index: number) => ({ target: vester.address, params: [ctx.address, index] })),
+    calls: userIndexesRes.map((index) => ({ target: vester.address, params: [ctx.address, index.toString()] })),
     abi: abi.pendingFor,
   })
 
-  const aggregatedVestingBalances = balancesOfRes.reduce((acc: BigNumber, current: any) => {
+  const aggregatedVestingBalances = balancesOfRes.reduce((acc: BigNumber, current) => {
     const payout = isSuccess(current) ? BigNumber.from(current.output.payout_) : BN_ZERO
     return acc.add(payout)
   }, BN_ZERO)

--- a/src/adapters/frax-finance/ethereum/staker.ts
+++ b/src/adapters/frax-finance/ethereum/staker.ts
@@ -11,20 +11,20 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getStakedFraxBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
-  const { output: BalanceOfRes } = await call({
+  const balanceOf = await call({
     ctx,
     target: staker.address,
     params: [ctx.address],
     abi: erc20Abi.balanceOf,
   })
 
-  const { output: fmtBalances } = await call({
+  const fmtBalances = await call({
     ctx,
     target: staker.address,
-    params: [BalanceOfRes],
+    params: [balanceOf],
     abi: abi.convertToAssets,
   })
 

--- a/src/adapters/frax-finance/providers/convex.ts
+++ b/src/adapters/frax-finance/providers/convex.ts
@@ -70,7 +70,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const convexBooster: Contract = {
   chain: 'ethereum',
@@ -147,7 +147,7 @@ export const convexBalancesProvider = async (
 ): Promise<ProviderBalancesParams[]> => {
   for (const pool of pools) {
     if (pool.provider === 'curve') {
-      const { output: pricePerShare } = await call({ ctx, target: pool.lpToken, abi: abi.getPricePerFullShare })
+      const pricePerShare = await call({ ctx, target: pool.lpToken, abi: abi.getPricePerFullShare })
       pool.amount = pool.amount.mul(pricePerShare).div(utils.parseEther('1.0'))
     }
   }

--- a/src/adapters/fraxlend/ethereum/registry.ts
+++ b/src/adapters/fraxlend/ethereum/registry.ts
@@ -18,18 +18,16 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getPairsContracts(ctx: BaseContext, registry: string) {
   const contracts: Contract[] = []
 
-  const allPairAddressesRes = await call({
+  const pairs = await call({
     ctx,
     target: registry,
     abi: abi.getAllPairAddresses,
   })
-
-  const pairs: string[] = allPairAddressesRes.output
 
   const collateralContractsRes = await multicall({
     ctx,

--- a/src/adapters/gains-network/common/farm.ts
+++ b/src/adapters/gains-network/common/farm.ts
@@ -11,21 +11,21 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getGainsBalances(ctx: BalancesContext, farmer: Contract): Promise<Balance> {
   const underlying = farmer.underlyings?.[0] as Contract
-  const { output: balanceOfRes } = await call({
+  const balanceOf = await call({
     ctx,
     target: farmer.address,
     params: [ctx.address],
     abi: erc20Abi.balanceOf,
   })
 
-  const { output: fmtBalances } = await call({
+  const fmtBalances = await call({
     ctx,
     target: farmer.address,
-    params: [balanceOfRes],
+    params: [balanceOf],
     abi: abi.convertToAssets,
   })
 

--- a/src/adapters/gains-network/common/locker.ts
+++ b/src/adapters/gains-network/common/locker.ts
@@ -39,12 +39,12 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getGainsLockerBalances(ctx: BalancesContext, locker: Contract): Promise<LockBalance[]> {
   const balances: LockBalance[] = []
 
-  const { output: nftBalanceOfRes } = await call({
+  const nftBalanceOf = await call({
     ctx,
     target: locker.address,
     params: [ctx.address],
@@ -53,7 +53,7 @@ export async function getGainsLockerBalances(ctx: BalancesContext, locker: Contr
 
   const tokenOfOwnerByIndexes = await multicall({
     ctx,
-    calls: range(0, nftBalanceOfRes).map((index) => ({ target: locker.address, params: [ctx.address, index] })),
+    calls: range(0, Number(nftBalanceOf)).map((index) => ({ target: locker.address, params: [ctx.address, index] })),
     abi: abi.tokenOfOwnerByIndex,
   })
 

--- a/src/adapters/gains-network/common/stake.ts
+++ b/src/adapters/gains-network/common/stake.ts
@@ -16,21 +16,22 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getGainsStakeBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
   const underlying = staker.underlyings?.[0] as Contract
 
-  const { output: stakedTokens } = await call({
+  const users = await call({
     ctx,
     target: staker.address,
     params: [ctx.address],
     abi: abi.users,
   })
+  const [stakedTokens] = users
 
   return {
     ...staker,
-    amount: BigNumber.from(stakedTokens.stakedTokens),
+    amount: BigNumber.from(stakedTokens),
     underlyings: [underlying],
     rewards: undefined,
     category: 'stake',

--- a/src/adapters/gamma/ethereum/stake.ts
+++ b/src/adapters/gamma/ethereum/stake.ts
@@ -12,7 +12,7 @@ const gamma: Token = {
 }
 
 export async function getxGammaBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
-  const [{ output: userBalance }, { output: assetBalance }, { output: totalSupply }] = await Promise.all([
+  const [userBalance, assetBalance, totalSupply] = await Promise.all([
     call({ ctx, target: staker.address, params: [ctx.address], abi: erc20Abi.balanceOf }),
     call({ ctx, target: gamma.address, params: [staker.address], abi: erc20Abi.balanceOf }),
     call({ ctx, target: staker.address, abi: erc20Abi.totalSupply }),

--- a/src/adapters/gearbox/ethereum/pools.ts
+++ b/src/adapters/gearbox/ethereum/pools.ts
@@ -39,12 +39,12 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getContractsRegister(ctx: BaseContext) {
   const ADDRESS_PROVIDER = '0xcf64698aff7e5f27a11dff868af228653ba53be0'
 
-  const { output: contractsRegister } = await call({
+  const contractsRegister = await call({
     ctx,
     abi: abi.getContractsRegister,
     target: ADDRESS_PROVIDER,
@@ -56,13 +56,11 @@ export async function getContractsRegister(ctx: BaseContext) {
 export async function getPoolsContracts(ctx: BaseContext, contractsRegister: string) {
   const contracts: PoolContract[] = []
 
-  const poolsRes = await call({
+  const pools = await call({
     ctx,
     target: contractsRegister,
     abi: abi.getPools,
   })
-
-  const pools: string[] = poolsRes.output
 
   const calls: Call[] = pools.map((pool) => ({ target: pool }))
 

--- a/src/adapters/gensokishi/polygon/stake.ts
+++ b/src/adapters/gensokishi/polygon/stake.ts
@@ -12,7 +12,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const MV: Token = {
   chain: 'polygon',
@@ -29,7 +29,7 @@ const ROND: Token = {
 }
 
 export async function getGensokishiStakeBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
-  const [{ output: userBalance }, { output: earned }] = await Promise.all([
+  const [userBalance, earned] = await Promise.all([
     call({ ctx, target: staker.address, params: [ctx.address], abi: erc20Abi.balanceOf }),
     call({ ctx, target: staker.address, params: [ctx.address], abi: abi.earned }),
   ])

--- a/src/adapters/gmx/common/contracts.ts
+++ b/src/adapters/gmx/common/contracts.ts
@@ -67,7 +67,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getGMXContracts(ctx: BaseContext, gmxRouter: Contract, vault: Contract) {
   const [
@@ -82,48 +82,48 @@ export async function getGMXContracts(ctx: BaseContext, gmxRouter: Contract, vau
     glpVesterRes,
     vaultTokens,
   ] = await Promise.all([
-    call({ ctx, target: gmxRouter.address, params: [], abi: abi.stakedGmxTracker }),
-    call({ ctx, target: gmxRouter.address, params: [], abi: abi.stakedGlpTracker }),
-    call({ ctx, target: gmxRouter.address, params: [], abi: abi.gmx }),
-    call({ ctx, target: gmxRouter.address, params: [], abi: abi.glp }),
-    call({ ctx, target: gmxRouter.address, params: [], abi: abi.weth }),
-    call({ ctx, target: gmxRouter.address, params: [], abi: abi.feeGmxTracker }),
-    call({ ctx, target: gmxRouter.address, params: [], abi: abi.esGmx }),
-    call({ ctx, target: gmxRouter.address, params: [], abi: abi.gmxVester }),
-    call({ ctx, target: gmxRouter.address, params: [], abi: abi.glpVester }),
+    call({ ctx, target: gmxRouter.address, abi: abi.stakedGmxTracker }),
+    call({ ctx, target: gmxRouter.address, abi: abi.stakedGlpTracker }),
+    call({ ctx, target: gmxRouter.address, abi: abi.gmx }),
+    call({ ctx, target: gmxRouter.address, abi: abi.glp }),
+    call({ ctx, target: gmxRouter.address, abi: abi.weth }),
+    call({ ctx, target: gmxRouter.address, abi: abi.feeGmxTracker }),
+    call({ ctx, target: gmxRouter.address, abi: abi.esGmx }),
+    call({ ctx, target: gmxRouter.address, abi: abi.gmxVester }),
+    call({ ctx, target: gmxRouter.address, abi: abi.glpVester }),
     getVaultTokens(ctx, vault),
   ])
 
   // GMX
   const gmxVester: Contract = {
     chain: ctx.chain,
-    address: gmxVesterRes.output,
-    underlyings: [esGmxRes.output],
-    rewards: [gmxRes.output],
+    address: gmxVesterRes,
+    underlyings: [esGmxRes],
+    rewards: [gmxRes],
   }
 
   const gmxStaker: Contract = {
     chain: ctx.chain,
-    address: stakedGmxTrackerRes.output,
-    underlyings: [stakerGmxFeesRes.output, gmxRes.output],
-    rewards: [esGmxRes.output, wethRes.output],
+    address: stakedGmxTrackerRes,
+    underlyings: [stakerGmxFeesRes, gmxRes],
+    rewards: [esGmxRes, wethRes],
   }
 
   // GLP
   const glpStaker: Contract = {
     chain: ctx.chain,
-    address: stakedGlpTrackerRes.output,
-    fGlp: stakerGmxFeesRes.output,
-    glp: glpRes.output,
+    address: stakedGlpTrackerRes,
+    fGlp: stakerGmxFeesRes,
+    glp: glpRes,
     underlyings: vaultTokens,
-    rewards: [esGmxRes.output, wethRes.output],
+    rewards: [esGmxRes, wethRes],
   }
 
   const glpVester: Contract = {
     chain: ctx.chain,
-    address: glpVesterRes.output,
-    underlyings: [esGmxRes.output],
-    rewards: [gmxRes.output],
+    address: glpVesterRes,
+    underlyings: [esGmxRes],
+    rewards: [gmxRes],
   }
 
   return { gmxVester, gmxStaker, glpStaker, glpVester }

--- a/src/adapters/gmx/common/vault.ts
+++ b/src/adapters/gmx/common/vault.ts
@@ -23,7 +23,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getVaultTokens(ctx: BaseContext, vault: Contract) {
   const allWhitelistedTokensLengthRes = await call({
@@ -32,7 +32,7 @@ export async function getVaultTokens(ctx: BaseContext, vault: Contract) {
     target: vault.address,
   })
 
-  const allWhitelistedTokensLength = parseInt(allWhitelistedTokensLengthRes.output)
+  const allWhitelistedTokensLength = Number(allWhitelistedTokensLengthRes)
 
   const allWhitelistedTokensRes = await multicall<string, [number], string>({
     ctx,

--- a/src/adapters/gro/common/contract.ts
+++ b/src/adapters/gro/common/contract.ts
@@ -35,12 +35,13 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getGroContracts(ctx: BaseContext, masterchef: Contract): Promise<Contract[]> {
   const contracts: Contract[] = []
 
-  const { output: poolLength } = await call({ ctx, target: masterchef.address, abi: abi.poolLength })
+  const poolLengthBI = await call({ ctx, target: masterchef.address, abi: abi.poolLength })
+  const poolLength = Number(poolLengthBI)
 
   const poolInfosRes = await multicall({
     ctx,
@@ -97,7 +98,7 @@ const getUnderlyingsContracts = async (ctx: BaseContext, contracts: Contract[]):
   ).flat()
 }
 
-export async function getYieldContracts(ctx: BaseContext, pools: string[]): Promise<Contract[]> {
+export async function getYieldContracts(ctx: BaseContext, pools: `0x${string}`[]): Promise<Contract[]> {
   const contracts: Contract[] = []
 
   const underlyingsRes = await multicall({ ctx, calls: pools.map((pool) => ({ target: pool })), abi: abi.token })

--- a/src/adapters/gro/common/vest.ts
+++ b/src/adapters/gro/common/vest.ts
@@ -17,13 +17,13 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getGroVestingBalances(ctx: BalancesContext, vester: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
   const token = vester.underlyings?.[0] as Contract
 
-  const [{ output: balancesOfRes }, { output: claimableBalancesRes }] = await Promise.all([
+  const [balancesOfRes, claimableBalancesRes] = await Promise.all([
     call({ ctx, target: vester.address, params: [ctx.address], abi: abi.totalBalance }),
     call({ ctx, target: vester.address, params: [ctx.address], abi: abi.vestedBalance }),
   ])

--- a/src/adapters/gyro/bsc/locker.ts
+++ b/src/adapters/gyro/bsc/locker.ts
@@ -29,7 +29,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const GYRO: Token = {
   chain: 'bsc',
@@ -42,16 +42,17 @@ export async function getGyroLocker(ctx: BalancesContext, locker: Contract): Pro
   const balances: LockBalance[] = []
   const now = Date.now() / 1000
 
-  const { output: balancesOfsRes } = await call({
+  const balancesOfsRes = await call({
     ctx,
     target: locker.address,
     params: [ctx.address],
     abi: erc20Abi.balanceOf,
   })
+  const balancesOf = Number(balancesOfsRes)
 
   const tokenOfOwnerByIndexesRes = await multicall({
     ctx,
-    calls: range(0, balancesOfsRes).map((_, idx) => ({ target: locker.address, params: [ctx.address, idx] })),
+    calls: range(0, balancesOf).map((_, idx) => ({ target: locker.address, params: [ctx.address, idx] })),
     abi: abi.tokenOfOwnerByIndex,
   })
 
@@ -63,7 +64,7 @@ export async function getGyroLocker(ctx: BalancesContext, locker: Contract): Pro
     abi: abi.locked,
   })
 
-  for (let balanceIdx = 0; balanceIdx < balancesOfsRes; balanceIdx++) {
+  for (let balanceIdx = 0; balanceIdx < balancesOf; balanceIdx++) {
     const lockedInfosResByIndex = lockedInfosResByIndexes[balanceIdx]
 
     if (!isSuccess(lockedInfosResByIndex)) {

--- a/src/adapters/hector-network/fantom/farm.ts
+++ b/src/adapters/hector-network/fantom/farm.ts
@@ -42,7 +42,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const Helper: Contract = {
   name: 'TORCurve Helper',
@@ -93,7 +93,7 @@ const Curve_fiFactoryUSDMetapool: Contract = {
 export async function getFarmingBalances(ctx: BalancesContext, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
-  const [balanceOfRes, shareRes] = await Promise.all([
+  const [calWithdrawAndEarned, getTorAndDaiAndUsdc] = await Promise.all([
     call({
       ctx,
       target: contract.address,
@@ -103,17 +103,19 @@ export async function getFarmingBalances(ctx: BalancesContext, contract: Contrac
     call({
       ctx,
       target: Helper.address,
-      params: [],
       abi: abi.getTorAndDaiAndUsdc,
     }),
   ])
 
-  const amount = BigNumber.from(balanceOfRes.output._torWithdrawAmount)
-  const rewardsBalanceOf = BigNumber.from(balanceOfRes.output._earnedRewardAmount)
+  const [_torWithdrawAmount, _daiWithdrawAmount, _usdcWithdrawAmount, _earnedRewardAmount] = calWithdrawAndEarned
+  const [torAmount, daiAmount, usdcAmount] = getTorAndDaiAndUsdc
 
-  const TORAmount = BigNumber.from(shareRes.output.torAmount)
-  const DAIAmount = BigNumber.from(shareRes.output.daiAmount)
-  const USDCAmount = BigNumber.from(shareRes.output.usdcAmount)
+  const amount = BigNumber.from(_torWithdrawAmount)
+  const rewardsBalanceOf = BigNumber.from(_earnedRewardAmount)
+
+  const TORAmount = BigNumber.from(torAmount)
+  const DAIAmount = BigNumber.from(daiAmount)
+  const USDCAmount = BigNumber.from(usdcAmount)
   const underlyingAmounts = [TORAmount, DAIAmount, USDCAmount]
 
   const totalToken = TORAmount.add(DAIAmount).add(USDCAmount)

--- a/src/adapters/hector-network/fantom/stake.ts
+++ b/src/adapters/hector-network/fantom/stake.ts
@@ -11,7 +11,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const HEC: Contract = {
   name: 'Hector',
@@ -29,7 +29,7 @@ export async function getsStakeBalances(ctx: BalancesContext, contract: Contract
     abi: erc20Abi.balanceOf,
   })
 
-  const amount = BigNumber.from(balanceOfRes.output)
+  const amount = BigNumber.from(balanceOfRes)
 
   const balance: Balance = {
     chain: ctx.chain,
@@ -45,14 +45,12 @@ export async function getsStakeBalances(ctx: BalancesContext, contract: Contract
 }
 
 export async function getWsStakeBalances(ctx: BalancesContext, contract: Contract): Promise<Balance> {
-  const balanceOfRes = await call({
+  const balanceOf = await call({
     ctx,
     target: contract.address,
     params: [ctx.address],
     abi: erc20Abi.balanceOf,
   })
-
-  const balanceOf = balanceOfRes.output
 
   const formattedBalanceOfRes = await call({
     ctx,
@@ -61,7 +59,7 @@ export async function getWsStakeBalances(ctx: BalancesContext, contract: Contrac
     abi: abi.wsHECTosHEC,
   })
 
-  const amount = BigNumber.from(formattedBalanceOfRes.output)
+  const amount = BigNumber.from(formattedBalanceOfRes)
 
   const balance: Balance = {
     chain: ctx.chain,

--- a/src/adapters/hex/ethereum/reward.ts
+++ b/src/adapters/hex/ethereum/reward.ts
@@ -54,10 +54,9 @@ const getDecodedDataFromRangeDays = async (
 ) => {
   const data = []
 
-  const currentDayRes = await call({
+  const today = await call({
     ctx,
     target: contract.address,
-    params: [],
     abi: {
       constant: true,
       inputs: [],
@@ -69,12 +68,10 @@ const getDecodedDataFromRangeDays = async (
     },
   })
 
-  const today = currentDayRes.output
-
-  const dataRangeRes = await call({
+  const dataRange = await call({
     ctx,
     target: contract.address,
-    params: [stakeAndIndex.lockedDays, today],
+    params: [BigInt(stakeAndIndex.lockedDays), today],
     abi: {
       constant: true,
       inputs: [
@@ -89,12 +86,10 @@ const getDecodedDataFromRangeDays = async (
     },
   })
 
-  const dataRange = dataRangeRes.output
-
   for (let i = 0; i < dataRange.length; i++) {
     const dailyData = dataRange[i]
 
-    data.push(HEX_DECODER(dailyData))
+    data.push(HEX_DECODER(dailyData.toString()))
   }
   return data
 }

--- a/src/adapters/hex/ethereum/stake.ts
+++ b/src/adapters/hex/ethereum/stake.ts
@@ -26,7 +26,7 @@ export async function getStakeBalances(ctx: BalancesContext, contract: Contract)
 
   const findStakesAndIndexesRes = await multicall({
     ctx,
-    calls: range(0, stakeCountRes.output).map((i) => ({
+    calls: range(0, Number(stakeCountRes)).map((i) => ({
       target: contract.address,
       params: [ctx.address, i],
     })),

--- a/src/adapters/horizon-protocol/bsc/balance.ts
+++ b/src/adapters/horizon-protocol/bsc/balance.ts
@@ -27,7 +27,7 @@ const abi = {
     outputs: [{ name: '', type: 'uint256[4]' }],
     gas: 20935,
   },
-}
+} as const
 
 const HZN: Token = {
   chain: 'bsc',
@@ -37,9 +37,9 @@ const HZN: Token = {
 }
 
 interface HorizonBalanceParams extends FarmBalance {
-  pool: string
-  factory: string
-  token: string
+  pool: `0x${string}`
+  factory: `0x${string}`
+  token: `0x${string}`
 }
 
 export async function getHorizonFarmBalances(ctx: BalancesContext, farmers: Contract[]): Promise<Balance[]> {
@@ -95,7 +95,7 @@ export async function getHorizonFarmBalances(ctx: BalancesContext, farmers: Cont
 const getUnderlyingsCurveBalance = async (ctx: BalancesContext, crvBalance: HorizonBalanceParams): Promise<Balance> => {
   const underlyings = crvBalance.underlyings as Contract[]
 
-  const [{ output: underlyingsBalances }, { output: totalSupplyRes }] = await Promise.all([
+  const [underlyingsBalances, totalSupplyRes] = await Promise.all([
     call({ ctx, target: crvBalance.factory, params: [crvBalance.pool], abi: abi.get_balances }),
     call({ ctx, target: crvBalance.token!, abi: erc20Abi.totalSupply }),
   ])

--- a/src/adapters/inverse-finance/ethereum/balance.ts
+++ b/src/adapters/inverse-finance/ethereum/balance.ts
@@ -14,7 +14,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const INV: Token = {
   chain: 'ethereum',
@@ -30,7 +30,7 @@ export async function getInverseLendingBalances(
 ): Promise<Balance[]> {
   const rewards: Balance[] = []
 
-  const [marketsBalancesRes, { output: marketsRewardsRes }] = await Promise.all([
+  const [marketsBalancesRes, marketsRewardsRes] = await Promise.all([
     getMarketsBalances(ctx, markets),
     call({ ctx, target: comptroller.address, params: [ctx.address], abi: abi.compAccrued }),
   ])

--- a/src/adapters/izumi-finance/bsc/balance.ts
+++ b/src/adapters/izumi-finance/bsc/balance.ts
@@ -87,7 +87,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const factory: Contract = {
   chain: 'bsc',
@@ -104,7 +104,7 @@ export async function getIzumiBSCBalances(ctx: BalancesContext, contract: Contra
     abi: erc20Abi.balanceOf,
   })
 
-  const balancesLength = parseInt(balanceOf.output)
+  const balancesLength = Number(balanceOf)
 
   const tokensOfOwnerByIndexRes = await multicall({
     ctx,

--- a/src/adapters/klima-dao/common/stake.ts
+++ b/src/adapters/klima-dao/common/stake.ts
@@ -21,7 +21,7 @@ export async function getStakeBalances(ctx: BalancesContext, contract: Contract)
     abi: abi.balanceOf,
   })
 
-  const amount = BigNumber.from(balanceOfRes.output)
+  const amount = BigNumber.from(balanceOfRes)
 
   const balance: Balance = {
     chain: ctx.chain,
@@ -37,14 +37,12 @@ export async function getStakeBalances(ctx: BalancesContext, contract: Contract)
 }
 
 export async function getFormattedStakeBalances(ctx: BalancesContext, contract: Contract): Promise<Balance> {
-  const balanceOfRes = await call({
+  const balanceOf = await call({
     ctx,
     target: contract.address,
     params: [ctx.address],
     abi: abi.balanceOf,
   })
-
-  const balanceOf = balanceOfRes.output
 
   const formattedBalanceOfRes = await call({
     ctx,
@@ -59,7 +57,7 @@ export async function getFormattedStakeBalances(ctx: BalancesContext, contract: 
     },
   })
 
-  const formattedBalanceOf = BigNumber.from(formattedBalanceOfRes.output)
+  const formattedBalanceOf = BigNumber.from(formattedBalanceOfRes)
 
   const balance: Balance = {
     chain: ctx.chain,

--- a/src/adapters/lido/ethereum/stake.ts
+++ b/src/adapters/lido/ethereum/stake.ts
@@ -22,12 +22,12 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getWStEthStakeBalances(ctx: BalancesContext, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
-  const balanceOfRes = await call({
+  const balanceOf = await call({
     ctx,
     target: contract.address,
     params: [ctx.address],
@@ -37,11 +37,11 @@ export async function getWStEthStakeBalances(ctx: BalancesContext, contract: Con
   const converterWStEthToStEthRes = await call({
     ctx,
     target: contract.address,
-    params: [balanceOfRes.output],
+    params: [balanceOf],
     abi: abi.getStETHByWstETH,
   })
 
-  const formattedBalanceOf = BigNumber.from(converterWStEthToStEthRes.output)
+  const formattedBalanceOf = BigNumber.from(converterWStEthToStEthRes)
 
   balances.push({
     chain: ctx.chain,
@@ -64,7 +64,7 @@ export async function getStEthStakeBalances(ctx: BalancesContext, contract: Cont
     abi: erc20Abi.balanceOf,
   })
 
-  const balanceOf = BigNumber.from(balanceOfRes.output)
+  const balanceOf = BigNumber.from(balanceOfRes)
 
   balances.push({
     chain: ctx.chain,
@@ -91,11 +91,11 @@ export async function getStMaticBalances(ctx: BalancesContext, contract: Contrac
   const converterWStEthToStEthRes = await call({
     ctx,
     target: contract.address,
-    params: [balanceOfRes.output],
+    params: [balanceOfRes],
     abi: abi.convertStMaticToMatic,
   })
 
-  const formattedBalanceOf = BigNumber.from(converterWStEthToStEthRes.output[0])
+  const formattedBalanceOf = BigNumber.from(converterWStEthToStEthRes[0])
 
   balances.push({
     chain: ctx.chain,

--- a/src/adapters/life-dao/common/stake.ts
+++ b/src/adapters/life-dao/common/stake.ts
@@ -22,7 +22,7 @@ export async function getStakeBalances(ctx: BalancesContext, contract: Contract)
     abi: abi.balanceOf,
   })
 
-  const amount = BigNumber.from(balanceOfRes.output)
+  const amount = BigNumber.from(balanceOfRes)
 
   balances.push({
     chain: ctx.chain,

--- a/src/adapters/liqee/common/contract.ts
+++ b/src/adapters/liqee/common/contract.ts
@@ -37,7 +37,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getMarketsContracts(
   ctx: BaseContext,
@@ -45,10 +45,10 @@ export async function getMarketsContracts(
 ): Promise<Contract[]> {
   const contracts: Contract[] = []
 
-  const { output: cTokensRes } = await call({ ctx, target: comptrollerAddress, abi: abi.getAlliTokens })
+  const cTokensRes = await call({ ctx, target: comptrollerAddress, abi: abi.getAlliTokens })
 
-  const calls: Call[] = cTokensRes.map((cToken: string) => ({ target: comptrollerAddress, params: [cToken] }))
-  const underlyingsCalls: Call[] = cTokensRes.map((cToken: string) => ({ target: cToken }))
+  const calls: Call[] = cTokensRes.map((cToken) => ({ target: comptrollerAddress, params: [cToken] }))
+  const underlyingsCalls: Call[] = cTokensRes.map((cToken) => ({ target: cToken }))
 
   const [marketsRes, underlyingTokensAddressesRes] = await Promise.all([
     multicall({ ctx, calls, abi: abi.markets }),

--- a/src/adapters/liquity/ethereum/farm.ts
+++ b/src/adapters/liquity/ethereum/farm.ts
@@ -60,16 +60,16 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getFarmBalance(ctx: BalancesContext, stabilityPool: Contract) {
   const [LUSDBalanceRes, ETHBalanceRes, LQTYBalanceRes] = await Promise.all([
-    call({ ctx, target: stabilityPool.address, params: ctx.address, abi: abi.getCompoundedLUSDDeposit }),
-    call({ ctx, target: stabilityPool.address, params: ctx.address, abi: abi.getDepositorETHGain }),
-    call({ ctx, target: stabilityPool.address, params: ctx.address, abi: abi.getDepositorLQTYGain }),
+    call({ ctx, target: stabilityPool.address, params: [ctx.address], abi: abi.getCompoundedLUSDDeposit }),
+    call({ ctx, target: stabilityPool.address, params: [ctx.address], abi: abi.getDepositorETHGain }),
+    call({ ctx, target: stabilityPool.address, params: [ctx.address], abi: abi.getDepositorLQTYGain }),
   ])
 
-  const amount = BigNumber.from(LUSDBalanceRes.output)
+  const amount = BigNumber.from(LUSDBalanceRes)
 
   const balance: Balance = {
     chain: ctx.chain,
@@ -96,14 +96,14 @@ export async function getFarmBalance(ctx: BalancesContext, stabilityPool: Contra
         symbol: 'LQTY',
         decimals: 18,
         address: '0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d',
-        amount: BigNumber.from(LQTYBalanceRes.output),
+        amount: BigNumber.from(LQTYBalanceRes),
       },
       {
         chain: ctx.chain,
         symbol: 'ETH',
         decimals: 18,
         address: '0x0000000000000000000000000000000000000000',
-        amount: BigNumber.from(ETHBalanceRes.output),
+        amount: BigNumber.from(ETHBalanceRes),
       },
     ],
   }

--- a/src/adapters/liquity/ethereum/lend.ts
+++ b/src/adapters/liquity/ethereum/lend.ts
@@ -49,7 +49,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const priceFeed: Contract = {
   chain: 'ethereum',
@@ -67,7 +67,7 @@ export async function getLendBalances(ctx: BalancesContext, troveManager: Contra
     abi: abi.Troves,
   })
 
-  const troveDetails = troveDetailsRes.output
+  const [debt, coll, _stake, _status, _arrayIndex] = troveDetailsRes
 
   balances.push({
     chain: ctx.chain,
@@ -75,7 +75,7 @@ export async function getLendBalances(ctx: BalancesContext, troveManager: Contra
     symbol: 'ETH',
     decimals: 18,
     address: '0x0000000000000000000000000000000000000000',
-    amount: BigNumber.from(troveDetails.coll),
+    amount: BigNumber.from(coll),
   })
 
   balances.push({
@@ -84,7 +84,7 @@ export async function getLendBalances(ctx: BalancesContext, troveManager: Contra
     symbol: 'LUSD',
     decimals: 18,
     address: '0x5f98805A4E8be255a32880FDeC7F6728C6568bA0',
-    amount: BigNumber.from(troveDetails.debt),
+    amount: BigNumber.from(debt),
   })
 
   return balances
@@ -95,7 +95,7 @@ export const getHealthFactor = async (ctx: BalancesContext, balances: Balance[])
 
   const lendAmounts = balances
     .filter((balance) => balance.category === 'lend')
-    .map((balance) => balance.amount.mul(priceFeedRes.output).div(utils.parseEther('1.0')))
+    .map((balance) => balance.amount.mul(priceFeedRes).div(utils.parseEther('1.0')))
 
   const borrowAmounts = balances
     .filter((balance) => balance.category === 'borrow')

--- a/src/adapters/liquity/ethereum/stake.ts
+++ b/src/adapters/liquity/ethereum/stake.ts
@@ -24,7 +24,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getStakeBalances(ctx: BalancesContext, lqtyStaking: Contract) {
   const [LQTYBalanceRes, ETHBalanceRes, LUSDBalanceRes] = await Promise.all([
@@ -33,7 +33,7 @@ export async function getStakeBalances(ctx: BalancesContext, lqtyStaking: Contra
     call({ ctx, target: lqtyStaking.address, params: [ctx.address], abi: abi.getPendingLUSDGain }),
   ])
 
-  const amount = BigNumber.from(LQTYBalanceRes.output)
+  const amount = BigNumber.from(LQTYBalanceRes)
 
   const balance: Balance = {
     chain: ctx.chain,
@@ -58,7 +58,7 @@ export async function getStakeBalances(ctx: BalancesContext, lqtyStaking: Contra
         symbol: 'LUSD',
         decimals: 18,
         address: '0x5f98805a4e8be255a32880fdec7f6728c6568ba0',
-        amount: BigNumber.from(LUSDBalanceRes.output),
+        amount: BigNumber.from(LUSDBalanceRes),
         stable: true,
       },
       {
@@ -66,7 +66,7 @@ export async function getStakeBalances(ctx: BalancesContext, lqtyStaking: Contra
         symbol: 'ETH',
         decimals: 18,
         address: '0x0000000000000000000000000000000000000000',
-        amount: BigNumber.from(ETHBalanceRes.output),
+        amount: BigNumber.from(ETHBalanceRes),
       },
     ],
   }

--- a/src/adapters/lodestar-finance/arbitrum/farm.ts
+++ b/src/adapters/lodestar-finance/arbitrum/farm.ts
@@ -22,7 +22,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const LODE: Token = {
   chain: 'arbitrum',
@@ -32,15 +32,16 @@ const LODE: Token = {
 }
 
 export async function getFarmBalances(ctx: BalancesContext, farmer: Contract): Promise<Balance[]> {
-  const [{ output: userInfo }, { output: pendingReward }] = await Promise.all([
+  const [userInfo, pendingReward] = await Promise.all([
     call({ ctx, target: farmer.address, params: [ctx.address], abi: abi.userInfo }),
     call({ ctx, target: farmer.address, params: [ctx.address], abi: abi.pendingRewards }),
   ])
+  const [amount, _lodeRewardDebt] = userInfo
 
   const balance: Balance = {
     ...farmer,
-    address: farmer.token as string,
-    amount: BigNumber.from(userInfo.amount),
+    address: farmer.token as `0x${string}`,
+    amount: BigNumber.from(amount),
     underlyings: farmer.underlyings as Contract[],
     rewards: [{ ...LODE, amount: BigNumber.from(pendingReward) }],
     category: 'farm',

--- a/src/adapters/lusd-chickenbonds/ethereum/bondNFT.ts
+++ b/src/adapters/lusd-chickenbonds/ethereum/bondNFT.ts
@@ -1,4 +1,4 @@
-import type { Balance, BalancesContext, Contract } from '@lib/adapter'
+import type { Balance, BalancesContext, BaseContract, Contract } from '@lib/adapter'
 import { range } from '@lib/array'
 import { call } from '@lib/call'
 import { BN_ZERO } from '@lib/math'
@@ -47,11 +47,11 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getActiveBondsBalances(ctx: BalancesContext, bondNFT: Contract) {
-  const LUSD = bondNFT.underlyings?.[0]
-  const bLUSD = bondNFT.rewards?.[0]
+  const LUSD = bondNFT.underlyings?.[0] as BaseContract
+  const bLUSD = bondNFT.rewards?.[0] as BaseContract
   if (!LUSD || !bLUSD) {
     return []
   }
@@ -65,7 +65,7 @@ export async function getActiveBondsBalances(ctx: BalancesContext, bondNFT: Cont
     abi: abi.balanceOf,
   })
 
-  const bondsLength = balanceOfRes.output
+  const bondsLength = Number(balanceOfRes)
 
   const tokenOfOwnerByIndexRes = await multicall({
     ctx,

--- a/src/adapters/lusd-chickenbonds/ethereum/chickenBondManager.ts
+++ b/src/adapters/lusd-chickenbonds/ethereum/chickenBondManager.ts
@@ -36,7 +36,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getBondNFTContract(ctx: BaseContext) {
   const [bondNFTRes, lusdTokenRes, bLUSDTokenRes] = await Promise.all([
@@ -59,9 +59,9 @@ export async function getBondNFTContract(ctx: BaseContext) {
 
   const contract: Contract = {
     chain: 'ethereum',
-    address: bondNFTRes.output,
-    underlyings: [lusdTokenRes.output],
-    rewards: [bLUSDTokenRes.output],
+    address: bondNFTRes,
+    underlyings: [lusdTokenRes],
+    rewards: [bLUSDTokenRes],
   }
 
   return contract

--- a/src/adapters/lybra-finance/ethereum/lend.ts
+++ b/src/adapters/lybra-finance/ethereum/lend.ts
@@ -17,12 +17,12 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getLybraLendingBalances(ctx: BalancesContext, lendingPool: Contract): Promise<Balance[]> {
   console.log(lendingPool)
 
-  const [{ output: userLendingBalance }, { output: userBorrowBalance }] = await Promise.all([
+  const [userLendingBalance, userBorrowBalance] = await Promise.all([
     call({ ctx, target: lendingPool.address, params: [ctx.address], abi: abi.depositedEther }),
     call({ ctx, target: lendingPool.address, params: [ctx.address], abi: abi.getBorrowedOf }),
   ])

--- a/src/adapters/lybra-finance/ethereum/vest.ts
+++ b/src/adapters/lybra-finance/ethereum/vest.ts
@@ -25,17 +25,17 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getLybraVestBalance(ctx: BalancesContext, vester: Contract): Promise<Balance> {
-  const [{ output: userBalance }, { output: userAutoCompoundEarned }, { output: userLockTime }] = await Promise.all([
+  const [userBalance, userAutoCompoundEarned, userLockTime] = await Promise.all([
     call({ ctx, target: vester.address, params: [ctx.address], abi: abi.getClaimAbleLBR }),
     call({ ctx, target: vester.address, params: [ctx.address], abi: abi.earned }),
     call({ ctx, target: vester.address, params: [ctx.address], abi: abi.time2fullRedemption }),
   ])
 
   const now = Date.now() / 1000
-  const unlockAt = userLockTime
+  const unlockAt = Number(userLockTime)
 
   return {
     ...vester,

--- a/src/adapters/maple/ethereum/contract.ts
+++ b/src/adapters/maple/ethereum/contract.ts
@@ -49,12 +49,12 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getFarmContracts(ctx: BaseContext, contract: Contract): Promise<Contract[]> {
   const contracts: Contract[] = []
 
-  const { output: getPoolsNumber } = await call({
+  const getPoolsNumber = await call({
     ctx,
     target: contract.address,
     abi: abi.poolsCreated,
@@ -62,7 +62,7 @@ export async function getFarmContracts(ctx: BaseContext, contract: Contract): Pr
 
   const getPoolsAddresses = await multicall({
     ctx,
-    calls: range(0, getPoolsNumber).map((_, idx) => ({
+    calls: range(0, Number(getPoolsNumber)).map((_, idx) => ({
       target: contract.address,
       params: [idx],
     })),

--- a/src/adapters/maple/ethereum/stake.ts
+++ b/src/adapters/maple/ethereum/stake.ts
@@ -31,10 +31,10 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getMapleSingleStakeBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
-  const { output: balanceOfsRes } = await call({
+  const balanceOfsRes = await call({
     ctx,
     target: staker.address,
     params: [ctx.address],

--- a/src/adapters/metronome/ethereum/contract.ts
+++ b/src/adapters/metronome/ethereum/contract.ts
@@ -68,20 +68,20 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getMetronomeContracts(ctx: BaseContext, contract: Contract): Promise<Contract[]> {
   const markets: Contract[] = []
 
-  const [{ output: depositTokensRes }, { output: debtTokensRes }] = await Promise.all([
+  const [depositTokensRes, debtTokensRes] = await Promise.all([
     call({ ctx, target: contract.address, abi: abi.getDepositTokens }),
     call({ ctx, target: contract.address, abi: abi.getDebtTokens }),
   ])
 
   const [tokens, syntheticTokens, collateralFactors] = await Promise.all([
-    multicall({ ctx, calls: depositTokensRes.map((token: string) => ({ target: token })), abi: abi.underlying }),
-    multicall({ ctx, calls: debtTokensRes.map((token: string) => ({ target: token })), abi: abi.syntheticToken }),
-    multicall({ ctx, calls: depositTokensRes.map((token: string) => ({ target: token })), abi: abi.collateralFactor }),
+    multicall({ ctx, calls: depositTokensRes.map((token) => ({ target: token })), abi: abi.underlying }),
+    multicall({ ctx, calls: debtTokensRes.map((token) => ({ target: token })), abi: abi.syntheticToken }),
+    multicall({ ctx, calls: depositTokensRes.map((token) => ({ target: token })), abi: abi.collateralFactor }),
   ])
 
   const underlyings = await multicall({

--- a/src/adapters/morphex/fantom/balance.ts
+++ b/src/adapters/morphex/fantom/balance.ts
@@ -48,7 +48,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const vault: Contract = {
   chain: 'fantom',
@@ -77,7 +77,7 @@ const MPX: Token = {
 }
 
 export async function getMorphexMLPBalances(ctx: BalancesContext, contract: Contract): Promise<Balance[]> {
-  const { output: stakedBalance } = await call({
+  const stakedBalance = await call({
     ctx,
     target: contract.address,
     params: [ctx.address],
@@ -132,13 +132,11 @@ export async function getMorphexYieldBalances(ctx: BalancesContext, farmers: Con
 }
 
 export async function getMorphexStakeMLPBalances(ctx: BalancesContext, contract: Contract): Promise<Balance[]> {
-  const [{ output: stakedBalance }, { output: claimableNativeToken }, { output: claimableEsToken }] = await Promise.all(
-    [
-      call({ ctx, target: contract.address, params: [ctx.address], abi: abi.stakedAmounts }),
-      call({ ctx, target: contract.address, params: [ctx.address], abi: abi.claimable }),
-      call({ ctx, target: contract.rewarder, params: [ctx.address], abi: abi.claimable }),
-    ],
-  )
+  const [stakedBalance, claimableNativeToken, claimableEsToken] = await Promise.all([
+    call({ ctx, target: contract.address, params: [ctx.address], abi: abi.stakedAmounts }),
+    call({ ctx, target: contract.address, params: [ctx.address], abi: abi.claimable }),
+    call({ ctx, target: contract.rewarder, params: [ctx.address], abi: abi.claimable }),
+  ])
 
   const balance: Balance = {
     ...contract,
@@ -162,15 +160,9 @@ export async function getMorphexStakeMPXBalances(
   if (!underlyings) {
     return
   }
-  const [
-    { output: stakedBalance },
-    { output: claimableEsToken },
-    { output: claimableNativeToken },
-    underlyingsBalancesRes,
-  ] = await Promise.all([
+  const [stakedBalance, claimableEsToken, claimableNativeToken, underlyingsBalancesRes] = await Promise.all([
     call({ ctx, target: contract.address, params: [ctx.address], abi: abi.stakedAmounts }),
     call({ ctx, target: contract.address, params: [ctx.address], abi: abi.claimable }),
-    call({ ctx, target: contract.rewarder, params: [ctx.address], abi: abi.claimable }),
     call({ ctx, target: contract.address, abi: erc20Abi.totalSupply }),
     multicall({
       ctx,

--- a/src/adapters/morpho-aave/ethereum/balances.ts
+++ b/src/adapters/morpho-aave/ethereum/balances.ts
@@ -54,7 +54,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getMarketsContracts(ctx: BaseContext, lens: Contract): Promise<Contract[]> {
   const contracts: Contract[] = []
@@ -62,13 +62,12 @@ export async function getMarketsContracts(ctx: BaseContext, lens: Contract): Pro
   const marketsContractsRes = await call({
     ctx,
     target: lens.address,
-    params: [],
     abi: abi.getAllMarkets,
   })
 
   const underlyingsRes = await multicall({
     ctx,
-    calls: marketsContractsRes.output.map((token: string) => ({
+    calls: marketsContractsRes.map((token) => ({
       target: token,
       params: [],
     })),
@@ -76,7 +75,7 @@ export async function getMarketsContracts(ctx: BaseContext, lens: Contract): Pro
   })
 
   for (let idx = 0; idx < underlyingsRes.length; idx++) {
-    const market = marketsContractsRes.output[idx]
+    const market = marketsContractsRes[idx]
     const underlying = underlyingsRes[idx]
 
     if (!isSuccess(underlying)) {
@@ -151,9 +150,9 @@ export async function getUserHealthFactor(ctx: BalancesContext, morphoLens: Cont
     abi: abi.getUserHealthFactor,
   })
 
-  if (ethers.constants.MaxUint256.eq(userHealthFactorRes.output)) {
+  if (ethers.constants.MaxUint256.eq(userHealthFactorRes)) {
     return
   }
 
-  return userHealthFactorRes.output / 1e18
+  return Number(userHealthFactorRes) / 1e18
 }

--- a/src/adapters/morpho-compound/ethereum/healthfactor.ts
+++ b/src/adapters/morpho-compound/ethereum/healthfactor.ts
@@ -13,25 +13,25 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
+
 export async function getUserHealthFactor(
   ctx: BalancesContext,
   morphoLens: Contract,
   markets: Contract[],
 ): Promise<number | undefined> {
-  const marketsAddresses: string[] = markets.map((res) => res.address)
+  const marketsAddresses = markets.map((res) => res.address)
 
   const userHealthFactorRes = await call({
     ctx,
     target: morphoLens.address,
-    //@ts-ignore
     params: [ctx.address, marketsAddresses],
     abi: abi.getUserHealthFactor,
   })
 
-  if (ethers.constants.MaxUint256.eq(userHealthFactorRes.output)) {
+  if (ethers.constants.MaxUint256.eq(userHealthFactorRes)) {
     return
   }
 
-  return userHealthFactorRes.output / 1e18
+  return Number(userHealthFactorRes) / 1e18
 }

--- a/src/adapters/morpho-compound/ethereum/market.ts
+++ b/src/adapters/morpho-compound/ethereum/market.ts
@@ -28,10 +28,10 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getMorphoMarketsContracts(ctx: BaseContext, morphoLens: Contract): Promise<Contract[]> {
-  const { output: cTokensAddressesRes } = await call({ ctx, target: morphoLens.address, abi: abi.getAllMarkets })
+  const cTokensAddressesRes = await call({ ctx, target: morphoLens.address, abi: abi.getAllMarkets })
 
   const marketsDetailsRes = await multicall({
     ctx,
@@ -54,7 +54,7 @@ export async function getMorphoMarketsContracts(ctx: BaseContext, morphoLens: Co
   ])
 
   const markets = cTokensAddressesRes
-    .map((cToken: string, idx: number) => {
+    .map((cToken, idx) => {
       const marketsDetailRes = marketsDetailsRes[idx]
       const decimalRes = decimalsRes[idx]
       const symbolRes = symbolsRes[idx]

--- a/src/adapters/nemesis-dao/bsc/balances.ts
+++ b/src/adapters/nemesis-dao/bsc/balances.ts
@@ -21,7 +21,7 @@ export async function getStakeBalances(ctx: BalancesContext, contract: Contract)
     abi: abi.balanceOf,
   })
 
-  const balanceOf = BigNumber.from(balanceOfRes.output)
+  const balanceOf = BigNumber.from(balanceOfRes)
 
   balances.push({
     chain: ctx.chain,

--- a/src/adapters/nexus-mutual/ethereum/stake.ts
+++ b/src/adapters/nexus-mutual/ethereum/stake.ts
@@ -52,8 +52,8 @@ export async function getStakeBalances(ctx: BalancesContext, contract: Contract)
     }),
   ])
 
-  const stakeBalances = BigNumber.from(getStakeBalances.output)
-  const rewardsBalances = BigNumber.from(getRewardsBalances.output)
+  const stakeBalances = BigNumber.from(getStakeBalances)
+  const rewardsBalances = BigNumber.from(getRewardsBalances)
 
   balances.push({
     chain: NXM.chain,

--- a/src/adapters/nf3-ape/ethereum/balance.ts
+++ b/src/adapters/nf3-ape/ethereum/balance.ts
@@ -120,7 +120,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 type NFTBalances = Balance & {
   poolId: string
@@ -144,7 +144,7 @@ const apeCoin: Token = {
 export async function getApeStakeBalances(ctx: BalancesContext, staker: Contract): Promise<Balance[]> {
   const balances: NFTBalances[] = []
 
-  const { output: allStakesBalancesRes } = await call({
+  const allStakesBalancesRes = await call({
     ctx,
     target: staker.address,
     params: [ctx.address],
@@ -159,11 +159,11 @@ export async function getApeStakeBalances(ctx: BalancesContext, staker: Contract
     balances.push({
       chain: ctx.chain,
       address: staker.address,
-      symbol: symbol[poolId],
+      symbol: symbol[Number(poolId)],
       decimals: 18,
       amount: BigNumber.from(deposited),
-      poolId,
-      tokenId,
+      poolId: poolId.toString(),
+      tokenId: tokenId.toString(),
       underlyings: [apeCoin],
       rewards: [{ ...apeCoin, amount: BigNumber.from(unclaimed) }],
       category: 'stake',

--- a/src/adapters/olympus-dao/common/stake.ts
+++ b/src/adapters/olympus-dao/common/stake.ts
@@ -15,7 +15,7 @@ const abiOlympus = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const OHM: Contract = {
   name: 'Olympus',
@@ -58,14 +58,12 @@ export async function getStakeBalances(ctx: BalancesContext, stakers: Contract[]
 export async function getFormattedStakeBalances(ctx: BalancesContext, contract: Contract) {
   const balances: Balance[] = []
 
-  const balanceOfRes = await call({
+  const balanceOf = await call({
     ctx,
     target: contract.address,
     params: [ctx.address],
     abi: abi.balanceOf,
   })
-
-  const balanceOf = balanceOfRes.output
 
   const formattedBalanceOfRes = await call({
     ctx,
@@ -74,7 +72,7 @@ export async function getFormattedStakeBalances(ctx: BalancesContext, contract: 
     abi: abiOlympus.balanceFrom,
   })
 
-  const formattedBalanceOf = BigNumber.from(formattedBalanceOfRes.output)
+  const formattedBalanceOf = BigNumber.from(formattedBalanceOfRes)
 
   const balance: Balance = {
     chain: ctx.chain,

--- a/src/adapters/onyx-protocol/ethereum/contract.ts
+++ b/src/adapters/onyx-protocol/ethereum/contract.ts
@@ -26,7 +26,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const Onyx: Token = {
   chain: 'ethereum',
@@ -38,7 +38,8 @@ const Onyx: Token = {
 export async function getOnyxPoolsContracts(ctx: BaseContext, lendingPool: Contract): Promise<Contract[]> {
   const contracts: Contract[] = []
 
-  const { output: poolLength } = await call({ ctx, target: lendingPool.address, abi: abi.poolLength })
+  const poolLengthBI = await call({ ctx, target: lendingPool.address, abi: abi.poolLength })
+  const poolLength = Number(poolLengthBI)
 
   const poolsInfos = await multicall({
     ctx,

--- a/src/adapters/opyn-squeeth/ethereum/stake.ts
+++ b/src/adapters/opyn-squeeth/ethereum/stake.ts
@@ -12,7 +12,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const oSQTH: Token = {
   chain: 'ethereum',
@@ -24,11 +24,11 @@ const oSQTH: Token = {
 export async function getOpynStakeBalance(ctx: BalancesContext, staker: Contract): Promise<Balance> {
   const userBalanceOfRes = await call({ ctx, target: staker.address, params: [ctx.address], abi: erc20Abi.balanceOf })
 
-  const amount = await call({ ctx, target: staker.address, params: [userBalanceOfRes.output], abi: abi.getWsqueeth })
+  const amount = await call({ ctx, target: staker.address, params: [userBalanceOfRes], abi: abi.getWsqueeth })
 
   return {
     ...staker,
-    amount: BigNumber.from(amount.output),
+    amount: BigNumber.from(amount),
     underlyings: [oSQTH],
     rewards: undefined,
     category: 'stake',

--- a/src/adapters/origin-dollar/ethereum/locker.ts
+++ b/src/adapters/origin-dollar/ethereum/locker.ts
@@ -29,7 +29,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const OGV: Token = {
   chain: 'ethereum',
@@ -41,7 +41,7 @@ const OGV: Token = {
 export async function getOriginDollarLockerBalances(ctx: BalancesContext, locker: Contract): Promise<LockBalance[]> {
   const balances: LockBalance[] = []
 
-  const [lockupsRes, { output: rewardRes }] = await Promise.all([
+  const [lockupsRes, rewardRes] = await Promise.all([
     multicall({
       ctx,
       // There is no logic function to know in advance number of positions taken by users, as far i could checked, 10 seems to be the maximum positions length found

--- a/src/adapters/origin-dollar/ethereum/stake.ts
+++ b/src/adapters/origin-dollar/ethereum/stake.ts
@@ -12,7 +12,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const OUSD: Token = {
   chain: 'ethereum',
@@ -22,14 +22,14 @@ const OUSD: Token = {
 }
 
 export async function getOriginDollarStakerBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
-  const { output: balanceOfRes } = await call({
+  const balanceOfRes = await call({
     ctx,
     target: staker.address,
     params: [ctx.address],
     abi: erc20Abi.balanceOf,
   })
 
-  const { output: convertRateRes } = await call({
+  const convertRateRes = await call({
     ctx,
     target: staker.address,
     params: [balanceOfRes],

--- a/src/adapters/origin/ethereum/stake.ts
+++ b/src/adapters/origin/ethereum/stake.ts
@@ -18,7 +18,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const OGN: Token = {
   chain: 'ethereum',
@@ -28,7 +28,7 @@ const OGN: Token = {
 }
 
 export async function getOriginStakeBalance(ctx: BalancesContext, staker: Contract): Promise<Balance> {
-  const [{ output: userTotalStakeBalance }, { output: pendingReward }] = await Promise.all([
+  const [userTotalStakeBalance, pendingReward] = await Promise.all([
     call({
       ctx,
       target: staker.address,

--- a/src/adapters/pancakeswap/bsc/lp.ts
+++ b/src/adapters/pancakeswap/bsc/lp.ts
@@ -129,15 +129,15 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const getPancakeStablePairs = async (ctx: BaseContext, factory: Contract) => {
   const res: Contract[] = []
   const masterchefStablePools: Contract[] = []
 
-  const poolLengthRes = await call({ ctx, target: factory.address, params: [], abi: abi.pairLength })
+  const poolLengthRes = await call({ ctx, target: factory.address, abi: abi.pairLength })
 
-  const poolLength = parseInt(poolLengthRes.output)
+  const poolLength = Number(poolLengthRes)
 
   const calls: Call[] = []
   for (let idx = 0; idx < poolLength; idx++) {
@@ -200,10 +200,10 @@ const getMasterChefLpToken = async (
 
   const [masterchefStablePools, poolLengthRes] = await Promise.all([
     getPancakeStablePairs(ctx, factory),
-    call({ ctx, target: masterchef.address, params: [], abi: abi.poolLength }),
+    call({ ctx, target: masterchef.address, abi: abi.poolLength }),
   ])
 
-  const poolLength = parseInt(poolLengthRes.output)
+  const poolLength = Number(poolLengthRes)
 
   const calls: Call[] = []
   for (let idx = 0; idx < poolLength; idx++) {
@@ -286,7 +286,7 @@ const getPancakeUnderlyingsMasterChefPoolsBalances = async (
   for (let idx = 0; idx < masterchefPoolsBalances.length; idx++) {
     const masterchefPoolBalances = masterchefPoolsBalances[idx]
     const underlyingsBalanceInStablePool = underlyingsBalanceInStablePools[idx]
-    const underlyings = masterchefPoolBalances.underlyings as string[]
+    const underlyings = masterchefPoolBalances.underlyings as `0x${string}`[]
     if (!underlyings) {
       continue
     }

--- a/src/adapters/pancakeswap/bsc/stake.ts
+++ b/src/adapters/pancakeswap/bsc/stake.ts
@@ -55,7 +55,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const cake: Token = {
   chain: 'bsc',
@@ -96,8 +96,20 @@ export async function getStakersBalances(ctx: BalancesContext, stakers: Contract
 export async function getStakerCake(ctx: BalancesContext, staker: Contract) {
   const balance: Balance[] = []
 
-  const balanceOfRes = await call({ ctx, target: staker.address, params: [ctx.address], abi: abi.userInfos })
-  const balanceOf = BigNumber.from(balanceOfRes.output.lockedAmount)
+  const userInfos = await call({ ctx, target: staker.address, params: [ctx.address], abi: abi.userInfos })
+  const [
+    _shares,
+    _lastDepositedTime,
+    _cakeAtLastUserAction,
+    _lastUserActionTime,
+    _lockStartTime,
+    _lockEndTime,
+    _userBoostedShare,
+    _locked,
+    lockedAmount,
+  ] = userInfos
+
+  const balanceOf = BigNumber.from(lockedAmount)
 
   balance.push({
     ...staker,

--- a/src/adapters/pangolin/avalanche/balance.ts
+++ b/src/adapters/pangolin/avalanche/balance.ts
@@ -12,7 +12,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const pangolin: Token = {
   chain: 'avalanche',
@@ -33,9 +33,9 @@ export async function getPangolinStakeBalances(ctx: BalancesContext, staker: Con
     ...staker,
     decimals: pangolin.decimals,
     symbol: pangolin.symbol,
-    amount: BigNumber.from(userBalanceOfRes.output),
+    amount: BigNumber.from(userBalanceOfRes),
     underlyings: [pangolin],
-    rewards: [{ ...pangolin, amount: BigNumber.from(userEarnedRes.output) }],
+    rewards: [{ ...pangolin, amount: BigNumber.from(userEarnedRes) }],
     category: 'stake',
   })
 

--- a/src/adapters/perennial/arbitrum/farm.ts
+++ b/src/adapters/perennial/arbitrum/farm.ts
@@ -12,7 +12,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const USDC: Token = {
   chain: 'arbitrum',
@@ -22,14 +22,14 @@ const USDC: Token = {
 }
 
 export async function getPVAFarmBalances(ctx: BalancesContext, farmer: Contract): Promise<Balance> {
-  const { output: balanceOfRes } = await call({
+  const balanceOfRes = await call({
     ctx,
     target: farmer.address,
     params: [ctx.address],
     abi: erc20Abi.balanceOf,
   })
 
-  const { output: fmtBalances } = await call({
+  const fmtBalances = await call({
     ctx,
     target: farmer.address,
     params: [balanceOfRes],

--- a/src/adapters/piedao/ethereum/lock.ts
+++ b/src/adapters/piedao/ethereum/lock.ts
@@ -27,12 +27,12 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getPieDaoLockerBalances(ctx: BalancesContext, locker: Contract): Promise<LockBalance[]> {
   const now = Date.now() / 1000
 
-  const { output: getLocksOfLength } = await call({
+  const getLocksOfLength = await call({
     ctx,
     target: locker.address,
     params: [ctx.address],
@@ -41,7 +41,7 @@ export async function getPieDaoLockerBalances(ctx: BalancesContext, locker: Cont
 
   const locksOfRes = await multicall({
     ctx,
-    calls: range(0, getLocksOfLength).map((_, idx) => ({ target: locker.address, params: [ctx.address, idx] })),
+    calls: range(0, Number(getLocksOfLength)).map((_, idx) => ({ target: locker.address, params: [ctx.address, idx] })),
     abi: abi.locksOf,
   })
 

--- a/src/adapters/platypus-finance/avalanche/contract.ts
+++ b/src/adapters/platypus-finance/avalanche/contract.ts
@@ -57,7 +57,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const PTP: Token = {
   chain: 'avalanche',
@@ -69,8 +69,8 @@ const PTP: Token = {
 export async function getPlatypusContract(ctx: BaseContext, contract: Contract): Promise<Contract[]> {
   const contracts: Contract[] = []
 
-  const poolLengthRes = await call({ ctx, target: contract.address, params: [], abi: abi.poolLength })
-  const poolLength = parseInt(poolLengthRes.output)
+  const poolLengthRes = await call({ ctx, target: contract.address, abi: abi.poolLength })
+  const poolLength = Number(poolLengthRes)
 
   const calls: Call[] = []
   for (let idx = 0; idx < poolLength; idx++) {

--- a/src/adapters/polkastarter/common/lock.ts
+++ b/src/adapters/polkastarter/common/lock.ts
@@ -25,16 +25,16 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getPolkaLockedBalance(ctx: BalancesContext, locker: Contract): Promise<Balance | undefined> {
-  const [{ output: userBalance }, { output: lockTime }] = await Promise.all([
+  const [userBalance, lockTime] = await Promise.all([
     call({ ctx, target: locker.address, params: [ctx.address], abi: abi.stakeAmount }),
     call({ ctx, target: locker.address, params: [ctx.address], abi: abi.getUnlockTime }),
   ])
 
   const now = Date.now() / 1000
-  const unlockAt = lockTime
+  const unlockAt = Number(lockTime)
 
   return {
     ...locker,

--- a/src/adapters/popsicle-finance/common/farm.ts
+++ b/src/adapters/popsicle-finance/common/farm.ts
@@ -53,7 +53,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getPopsicleFarmContracts(ctx: BaseContext, contract: Contract): Promise<Contract[]> {
   const contracts: Contract[] = []
@@ -63,14 +63,15 @@ export async function getPopsicleFarmContracts(ctx: BaseContext, contract: Contr
     target: contract.address,
     abi: abi.poolLength,
   })
+  const poolLength = Number(poolLengthRes)
 
   const poolInfosRes = await multicall({
     ctx,
-    calls: range(0, poolLengthRes.output).map((_, idx) => ({ target: contract.address, params: [idx] })),
+    calls: range(0, poolLength).map((_, idx) => ({ target: contract.address, params: [idx] })),
     abi: abi.poolInfo,
   })
 
-  for (let poolIdx = 0; poolIdx < poolLengthRes.output; poolIdx++) {
+  for (let poolIdx = 0; poolIdx < poolLength; poolIdx++) {
     const poolInfoRes = poolInfosRes[poolIdx]
 
     if (!isSuccess(poolInfoRes)) {

--- a/src/adapters/popsicle-finance/ethereum/stake.ts
+++ b/src/adapters/popsicle-finance/ethereum/stake.ts
@@ -12,7 +12,7 @@ const Ice: Token = {
 }
 
 export async function getPopsicleStakeBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
-  const [{ output: userBalanceOf }, { output: tokenBalancesOfRes }, { output: tokenSupplyRes }] = await Promise.all([
+  const [userBalanceOf, tokenBalancesOfRes, tokenSupplyRes] = await Promise.all([
     call({ ctx, target: staker.address, params: [ctx.address], abi: erc20Abi.balanceOf }),
     call({ ctx, target: Ice.address, params: [staker.address], abi: erc20Abi.balanceOf }),
     call({ ctx, target: staker.address, abi: erc20Abi.totalSupply }),

--- a/src/adapters/radiant-v2/arbitrum/lendingPool.ts
+++ b/src/adapters/radiant-v2/arbitrum/lendingPool.ts
@@ -12,7 +12,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getLendingPoolBalances(
   ctx: BalancesContext,
@@ -25,7 +25,7 @@ export async function getLendingPoolBalances(
     call({ ctx, target: chefIncentivesController.address, params: [ctx.address], abi: abi.allPendingRewards }),
   ])
 
-  balances.push({ ...rewardToken, amount: BigNumber.from(pendingRewards.output), category: 'reward' })
+  balances.push({ ...rewardToken, amount: BigNumber.from(pendingRewards), category: 'reward' })
 
   return balances
 }

--- a/src/adapters/rage-trade/arbitrum/balance.ts
+++ b/src/adapters/rage-trade/arbitrum/balance.ts
@@ -15,7 +15,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getStakerBalances(ctx: BalancesContext, stakers: Contract[]): Promise<Balance[]> {
   const balances: Balance[] = []
@@ -62,13 +62,13 @@ export async function getPoolStakingBalances(ctx: BalancesContext, contract: Con
   const balanceOfAssetsRes = await call({
     ctx,
     target: contract.address,
-    params: [balanceOfsRes.output],
+    params: [balanceOfsRes],
     abi: abi.convertToAssets,
   })
 
   const balance: Balance = {
     ...contract,
-    amount: BigNumber.from(balanceOfAssetsRes.output),
+    amount: BigNumber.from(balanceOfAssetsRes),
     underlyings: contract.underlyings as Contract[],
     rewards: undefined,
     category: 'stake',

--- a/src/adapters/railgun/common/balance.ts
+++ b/src/adapters/railgun/common/balance.ts
@@ -29,12 +29,12 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getRailgunBalances(ctx: BalancesContext, staker: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
-  const { output: userStakeLength } = await call({
+  const userStakeLength = await call({
     ctx,
     target: staker.address,
     params: [ctx.address],
@@ -43,7 +43,7 @@ export async function getRailgunBalances(ctx: BalancesContext, staker: Contract)
 
   const userStakesRes = await multicall({
     ctx,
-    calls: range(0, userStakeLength).map((_, idx) => ({ target: staker.address, params: [ctx.address, idx] })),
+    calls: range(0, Number(userStakeLength)).map((_, idx) => ({ target: staker.address, params: [ctx.address, idx] })),
     abi: abi.stakes,
   })
 

--- a/src/adapters/redacted/ethereum/stake.ts
+++ b/src/adapters/redacted/ethereum/stake.ts
@@ -12,7 +12,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const BTRFLY: Token = {
   chain: 'ethereum',
@@ -24,10 +24,10 @@ const BTRFLY: Token = {
 export async function getwxBTRFLYStakeBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
   const balance = await getSingleStakeBalance(ctx, staker)
 
-  const { output: fmtBalances } = await call({
+  const fmtBalances = await call({
     ctx,
     target: staker.address,
-    params: [balance.amount.toString()],
+    params: [BigInt(balance.amount.toString())],
     abi: abi.xBTRFLYValue,
   })
 

--- a/src/adapters/ribbon-finance/common/contract.ts
+++ b/src/adapters/ribbon-finance/common/contract.ts
@@ -54,16 +54,16 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getFarmLPContracts(ctx: BaseContext, gaugeController: Contract): Promise<Contract[]> {
   const contracts: Contract[] = []
 
-  const gaugesLength = await call({ ctx, target: gaugeController.address, params: [], abi: abi.n_gauges })
+  const gaugesLength = await call({ ctx, target: gaugeController.address, abi: abi.n_gauges })
 
   const gaugesAddressesRes = await multicall({
     ctx,
-    calls: range(0, gaugesLength.output).map((i) => ({
+    calls: range(0, Number(gaugesLength)).map((i) => ({
       target: gaugeController.address,
       params: [i],
     })),
@@ -113,8 +113,9 @@ export async function getFarmLPContracts(ctx: BaseContext, gaugeController: Cont
     const contract = contracts[idx]
 
     if (!isSuccess(underlyings)) {
-      const underlyings = await call({ ctx, target: contract.lpToken, params: [], abi: abi.vaultParamsOptions })
-      contract.underlyings = [underlyings.output.underlying]
+      const vaultParamsOptions = await call({ ctx, target: contract.lpToken, abi: abi.vaultParamsOptions })
+      const [_decimals, underlying, _minimumSupply, _cap] = vaultParamsOptions
+      contract.underlyings = [underlying]
     } else {
       contract.underlyings = [underlyings.output.asset]
     }

--- a/src/adapters/ribbon-finance/common/locker.ts
+++ b/src/adapters/ribbon-finance/common/locker.ts
@@ -29,7 +29,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const RBN: Token = {
   chain: 'ethereum',
@@ -43,7 +43,7 @@ export async function getLockerBalance(
   locker: Contract,
   lockerPenaltyRewards: Contract,
 ): Promise<Balance> {
-  const [lockedBalance, { output: claimableLockedBalancesRewards }] = await Promise.all([
+  const [lockedBalance, claimableLockedBalancesRewards] = await Promise.all([
     getSingleLockerBalance(ctx, locker, RBN, 'locked'),
     call({ ctx, target: lockerPenaltyRewards.address, params: [ctx.address], abi: abi.claimable }),
   ])

--- a/src/adapters/scream/fantom/stake.ts
+++ b/src/adapters/scream/fantom/stake.ts
@@ -12,7 +12,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const SCREAM: Token = {
   chain: 'fantom',
@@ -22,7 +22,7 @@ const SCREAM: Token = {
 }
 
 export async function getScreamStakeBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
-  const [{ output: balanceOfRes }, { output: getShareValueRes }] = await Promise.all([
+  const [balanceOfRes, getShareValueRes] = await Promise.all([
     call({ ctx, target: staker.address, params: [ctx.address], abi: erc20Abi.balanceOf }),
     call({ ctx, target: staker.address, abi: abi.getShareValue }),
   ])

--- a/src/adapters/set-protocol/ethereum/contract.ts
+++ b/src/adapters/set-protocol/ethereum/contract.ts
@@ -18,20 +18,20 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getSetProtocolPools(ctx: BaseContext, controller: Contract): Promise<Contract[]> {
   const pools: Contract[] = []
 
-  const setsContractsRes = await call({ ctx, target: controller.address, params: [], abi: abi.getSets })
+  const setsContractsRes = await call({ ctx, target: controller.address, abi: abi.getSets })
 
   const setsUnderlyingsRes = await multicall({
     ctx,
-    calls: setsContractsRes.output.map((target: string) => ({ target })),
+    calls: setsContractsRes.map((target) => ({ target })),
     abi: abi.getComponents,
   })
 
-  for (let idx = 0; idx < setsContractsRes.output.length; idx++) {
+  for (let idx = 0; idx < setsContractsRes.length; idx++) {
     const underlyingsRes = setsUnderlyingsRes[idx]
     if (!isSuccess(underlyingsRes)) {
       continue
@@ -39,7 +39,7 @@ export async function getSetProtocolPools(ctx: BaseContext, controller: Contract
 
     pools.push({
       chain: ctx.chain,
-      address: setsContractsRes.output[idx],
+      address: setsContractsRes[idx],
       underlyings: underlyingsRes.output,
     })
   }

--- a/src/adapters/shibaswap/ethereum/balance.ts
+++ b/src/adapters/shibaswap/ethereum/balance.ts
@@ -31,18 +31,18 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getStakerBalances(ctx: BalancesContext, contract: Contract): Promise<Balance[]> {
   const underlyings = contract.underlyings![0] as Contract
 
-  const balanceOfRes = await call({ ctx, target: contract.address, params: ctx.address, abi: erc20Abi.balanceOf })
+  const balanceOfRes = await call({ ctx, target: contract.address, params: [ctx.address], abi: erc20Abi.balanceOf })
 
   return [
     {
       ...contract,
       category: 'stake',
-      amount: BigNumber.from(balanceOfRes.output),
+      amount: BigNumber.from(balanceOfRes),
       underlyings: [underlyings],
       rewards: undefined,
     },
@@ -57,5 +57,5 @@ export async function getLockerBalances(ctx: BalancesContext, contract: Contract
     abi: abi.unclaimedTokensByUser,
   })
 
-  return [{ ...bone, category: 'lock', amount: BigNumber.from(lockerBalancesOfRes.output) }]
+  return [{ ...bone, category: 'lock', amount: BigNumber.from(lockerBalancesOfRes) }]
 }

--- a/src/adapters/sideshift/ethereum/balance.ts
+++ b/src/adapters/sideshift/ethereum/balance.ts
@@ -12,7 +12,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const XAI: Token = {
   chain: 'ethereum',
@@ -22,14 +22,14 @@ const XAI: Token = {
 }
 
 export async function getsvXAIBalances(ctx: BalancesContext, contract: Contract): Promise<Balance> {
-  const { output: balanceOf } = await call({
+  const balanceOf = await call({
     ctx,
     target: contract.address,
     params: [ctx.address],
     abi: erc20Abi.balanceOf,
   })
 
-  const { output: fmtBalanceOf } = await call({
+  const fmtBalanceOf = await call({
     ctx,
     target: contract.address,
     params: [balanceOf],

--- a/src/adapters/smardex/ethereum/farm.ts
+++ b/src/adapters/smardex/ethereum/farm.ts
@@ -56,7 +56,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const SDEX: Token = {
   chain: 'ethereum',
@@ -104,7 +104,7 @@ export async function getSmarDexFarmBalances(
 const getMasterChefPoolsInfos = async (ctx: BaseContext, pairs: Pair[], masterchef: Contract): Promise<Contract[]> => {
   const pairByAddress = keyBy(pairs, 'address', { lowercase: true })
 
-  const { output: poolLengthRes } = await call({
+  const poolLengthRes = await call({
     ctx,
     target: masterchef.address,
     abi: abi.campaignInfoLen,
@@ -112,7 +112,7 @@ const getMasterChefPoolsInfos = async (ctx: BaseContext, pairs: Pair[], masterch
 
   const poolInfosRes = await multicall({
     ctx,
-    calls: range(0, poolLengthRes).map((_, idx) => ({ target: masterchef.address, params: [idx] })),
+    calls: range(0, Number(poolLengthRes)).map((_, idx) => ({ target: masterchef.address, params: [idx] })),
     abi: abi.campaignInfo,
   })
 

--- a/src/adapters/smardex/ethereum/stake.ts
+++ b/src/adapters/smardex/ethereum/stake.ts
@@ -21,7 +21,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const SDEX: Token = {
   chain: 'ethereum',
@@ -31,17 +31,19 @@ const SDEX: Token = {
 }
 
 export async function getSmarDexStakeBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
-  const { output: userBalanceOf } = await call({
+  const userInfo = await call({
     ctx,
     target: staker.address,
     params: [ctx.address],
     abi: abi.userInfo,
   })
 
-  const { output: sharesToTokens } = await call({
+  const [shares, _lastBlockUpdate] = userInfo
+
+  const sharesToTokens = await call({
     ctx,
     target: staker.address,
-    params: [userBalanceOf.shares],
+    params: [shares],
     abi: abi.sharesToTokens,
   })
 

--- a/src/adapters/smoothy/common/stake.ts
+++ b/src/adapters/smoothy/common/stake.ts
@@ -14,7 +14,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getSmoothyStakeBalances(ctx: BalancesContext, staker: Contract): Promise<Balance | undefined> {
   const balance = await getSingleStakeBalance(ctx, staker)
@@ -27,7 +27,7 @@ const getSmoothyUnderlyingsBalances = async (ctx: BalancesContext, staker: Balan
     return
   }
 
-  const [tokensBalancesRes, { output: totalSupply }] = await Promise.all([
+  const [tokensBalancesRes, totalSupply] = await Promise.all([
     multicall({
       ctx,
       calls: underlyings.map((_, idx) => ({ target: staker.address, params: [idx] })),

--- a/src/adapters/snowbank/avalanche/stake.ts
+++ b/src/adapters/snowbank/avalanche/stake.ts
@@ -12,7 +12,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const SB: Token = {
   chain: 'avalanche',
@@ -24,10 +24,10 @@ const SB: Token = {
 export async function getwsSBStakeBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
   const balance = await getSingleStakeBalance(ctx, staker)
 
-  const { output: fmtBalances } = await call({
+  const fmtBalances = await call({
     ctx,
     target: staker.address,
-    params: [balance.amount.toString()],
+    params: [BigInt(balance.amount.toString())],
     abi: abi.wsSBtosSB,
   })
 

--- a/src/adapters/solidly-v2/ethereum/lens.ts
+++ b/src/adapters/solidly-v2/ethereum/lens.ts
@@ -45,16 +45,16 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export interface GaugeContract extends Contract {
-  token: string
-  bribeAddress: string
-  feesAddress: string
+  token: `0x${string}`
+  bribeAddress: `0x${string}`
+  feesAddress: `0x${string}`
 }
 
 export async function getLensContracts(ctx: BaseContext, lens: Contract) {
-  const { output: poolsInfo } = await call({ ctx, target: lens.address, abi: abi.poolsInfo })
+  const poolsInfo = await call({ ctx, target: lens.address, abi: abi.poolsInfo })
 
   const pairs: Contract[] = (poolsInfo || []).map((pool: any) => ({
     chain: ctx.chain,

--- a/src/adapters/sonne-finance/optimism/stake.ts
+++ b/src/adapters/sonne-finance/optimism/stake.ts
@@ -15,7 +15,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const SONNE: Token = {
   chain: 'optimism',
@@ -25,7 +25,7 @@ const SONNE: Token = {
 }
 
 export async function getSonneStakeBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
-  const [{ output: balanceOfRes }, { output: claimableRewardRes }] = await Promise.all([
+  const [balanceOfRes, claimableRewardRes] = await Promise.all([
     call({ ctx, target: staker.address, params: [ctx.address], abi: erc20Abi.balanceOf }),
     call({ ctx, target: staker.address, params: [SONNE.address, ctx.address], abi: abi.getClaimable }),
   ])

--- a/src/adapters/spartacus/fantom/stake.ts
+++ b/src/adapters/spartacus/fantom/stake.ts
@@ -22,7 +22,7 @@ export async function getStakeBalances(ctx: BalancesContext, contract: Contract)
     abi: abi.balanceOf,
   })
 
-  const amount = BigNumber.from(balanceOfRes.output)
+  const amount = BigNumber.from(balanceOfRes)
 
   const balance: Balance = {
     chain: ctx.chain,

--- a/src/adapters/spiritswap/fantom/balance.ts
+++ b/src/adapters/spiritswap/fantom/balance.ts
@@ -23,14 +23,12 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const getGaugesContracts = async (ctx: BaseContext, pairs: Pair[], gaugeController: Contract): Promise<Contract[]> => {
   const gauges: Contract[] = []
 
-  const lpTokensRes = await call({ ctx, target: gaugeController.address, params: [], abi: abi.tokens })
-
-  const lpTokens = lpTokensRes.output
+  const lpTokens = await call({ ctx, target: gaugeController.address, abi: abi.tokens })
 
   const calls: Call[] = []
   for (let idx = 0; idx < lpTokens.length; idx++) {

--- a/src/adapters/spookyswap/fantom/balance.ts
+++ b/src/adapters/spookyswap/fantom/balance.ts
@@ -12,7 +12,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const BOO: Token = {
   chain: 'fantom',
@@ -24,16 +24,14 @@ const BOO: Token = {
 export async function getStakexBOOBalances(ctx: BalancesContext, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
-  const balanceOfRes = await call({ ctx, target: contract.address, params: [ctx.address], abi: erc20Abi.balanceOf })
-
-  const balanceOf = balanceOfRes.output
+  const balanceOf = await call({ ctx, target: contract.address, params: [ctx.address], abi: erc20Abi.balanceOf })
 
   const xBOOForBOORes = await call({ ctx, target: contract.address, params: [balanceOf], abi: abi.xBOOForBOO })
 
   balances.push({
     ...contract,
     amount: BigNumber.from(balanceOf),
-    underlyings: [{ ...BOO, amount: BigNumber.from(xBOOForBOORes.output) }],
+    underlyings: [{ ...BOO, amount: BigNumber.from(xBOOForBOORes) }],
     rewards: undefined,
     category: 'stake',
   })

--- a/src/adapters/spool/ethereum/stake.ts
+++ b/src/adapters/spool/ethereum/stake.ts
@@ -44,8 +44,8 @@ export async function getStakeBalances(ctx: BalancesContext, contract: Contract)
     }),
   ])
 
-  const amount = BigNumber.from(getBalances.output)
-  const earned = BigNumber.from(getEarned.output)
+  const amount = BigNumber.from(getBalances)
+  const earned = BigNumber.from(getEarned)
 
   balances.push({
     chain: ctx.chain,

--- a/src/adapters/stader/bsc/farm.ts
+++ b/src/adapters/stader/bsc/farm.ts
@@ -16,20 +16,22 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getStaderFarmBalances(ctx: BalancesContext, contract: Contract): Promise<Balance> {
-  const { output: userBalance } = await call({
+  const userRequestStatus = await call({
     ctx,
     target: contract.address,
-    params: [ctx.address, 0],
+    params: [ctx.address, 0n],
     abi: abi.getUserRequestStatus,
   })
+
+  const [_isClaimable, _amount] = userRequestStatus
 
   return {
     ...contract,
     address: contract.token!,
-    amount: BigNumber.from(userBalance._amount),
+    amount: BigNumber.from(_amount),
     underlyings: undefined,
     rewards: undefined,
     category: 'farm',

--- a/src/adapters/stader/polygon/farm.ts
+++ b/src/adapters/stader/polygon/farm.ts
@@ -21,10 +21,10 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getStaderFarmBalances(ctx: BalancesContext, contract: Contract): Promise<Balance> {
-  const { output: userBalance } = await call({
+  const userBalance = await call({
     ctx,
     target: contract.address,
     params: [ctx.address],

--- a/src/adapters/stake.link/ethereum/stake.ts
+++ b/src/adapters/stake.link/ethereum/stake.ts
@@ -12,7 +12,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const LINK: Token = {
   chain: 'ethereum',
@@ -22,7 +22,7 @@ const LINK: Token = {
 }
 
 export async function getLinkStakesBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
-  const [balance, { output: earned }] = await Promise.all([
+  const [balance, earned] = await Promise.all([
     getSingleStakeBalance(ctx, staker),
     call({ ctx, target: staker.address, params: [ctx.address], abi: abi.withdrawableRewards }),
   ])

--- a/src/adapters/stargate/ethereum/vest.ts
+++ b/src/adapters/stargate/ethereum/vest.ts
@@ -20,7 +20,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const STG: Token = {
   chain: 'ethereum',
@@ -39,7 +39,7 @@ const CONVERTER = 4
 export async function getStargateVesterBalances(ctx: BalancesContext, vester: Contract): Promise<VestBalance> {
   const now = Math.floor(Date.now() / 1000)
 
-  const [{ output: balancesOfRes }, { output: vestStartRes }, { output: vestDurationRes }] = await Promise.all([
+  const [balancesOfRes, vestStartRes, vestDurationRes] = await Promise.all([
     call({
       ctx,
       target: vester.address,
@@ -58,7 +58,7 @@ export async function getStargateVesterBalances(ctx: BalancesContext, vester: Co
     }),
   ])
 
-  const end = parseInt(vestStartRes) + parseInt(vestDurationRes)
+  const end = Number(vestStartRes) + Number(vestDurationRes)
 
   return {
     ...vester,

--- a/src/adapters/sushiswap/common/balances.ts
+++ b/src/adapters/sushiswap/common/balances.ts
@@ -16,7 +16,7 @@ export async function getXSushiStakeBalance(ctx: BalancesContext, xSushi: Contra
 
   const balance: Balance = {
     ...xSushi,
-    amount: BigNumber.from(balanceOf.output),
+    amount: BigNumber.from(balanceOf),
     underlyings: undefined,
     rewards: undefined,
     category: 'stake',
@@ -32,8 +32,8 @@ export async function getMeowshiYieldBalance(ctx: BalancesContext, meowshi: Cont
 
   const balance: Balance = {
     ...meowshi,
-    amount: BigNumber.from(balanceOf.output),
-    underlyings: [{ ...xSushi, amount: BigNumber.from(balanceOf.output).div(meowConverter) }],
+    amount: BigNumber.from(balanceOf),
+    underlyings: [{ ...xSushi, amount: BigNumber.from(balanceOf).div(meowConverter) }],
     rewards: undefined,
     category: 'farm',
   }

--- a/src/adapters/sushiswap/ethereum/balance.ts
+++ b/src/adapters/sushiswap/ethereum/balance.ts
@@ -91,7 +91,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getContractsFromMasterchefV2(
   ctx: BaseContext,
@@ -102,9 +102,9 @@ export async function getContractsFromMasterchefV2(
   const extraRewardsPools: Contract[] = []
   const nonExtraRewardsPools: Contract[] = []
 
-  const { output: poolLengthRes } = await call({ ctx, target: masterchef.address, abi: abi.poolLength })
+  const poolLengthRes = await call({ ctx, target: masterchef.address, abi: abi.poolLength })
 
-  const calls: Call[] = range(0, poolLengthRes).map((idx) => ({ target: masterchef.address, params: [idx] }))
+  const calls: Call[] = range(0, Number(poolLengthRes)).map((idx) => ({ target: masterchef.address, params: [idx] }))
 
   const [poolInfosRes, rewardersRes] = await Promise.all([
     multicall({ ctx, calls, abi: abi.lpToken }),
@@ -164,7 +164,7 @@ export async function getContractsFromMasterchefV2(
 
   const rewardTokens = await getERC20Details(
     ctx,
-    extraRewardsPools.map((pool) => (pool.rewards as string[])?.[0]),
+    extraRewardsPools.map((pool) => (pool.rewards as `0x${string}`[])?.[0]),
   )
 
   extraRewardsPools.forEach((pool, idx) => {

--- a/src/adapters/swell/ethereum/balance.ts
+++ b/src/adapters/swell/ethereum/balance.ts
@@ -12,7 +12,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const WETH: Token = {
   chain: 'ethereum',
@@ -22,14 +22,14 @@ const WETH: Token = {
 }
 
 export async function getSwellBalances(ctx: BalancesContext, contract: Contract): Promise<Balance> {
-  const { output: balanceOf } = await call({
+  const balanceOf = await call({
     ctx,
     target: contract.address,
     params: [ctx.address],
     abi: erc20Abi.balanceOf,
   })
 
-  const { output: rate } = await call({ ctx, target: contract.address, abi: abi.getRate })
+  const rate = await call({ ctx, target: contract.address, abi: abi.getRate })
 
   return {
     ...contract,

--- a/src/adapters/synapse/common/contract.ts
+++ b/src/adapters/synapse/common/contract.ts
@@ -33,13 +33,13 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getSynapseContracts(ctx: BaseContext, miniChef: Contract): Promise<Contract[]> {
   const pools: Contract[] = []
 
-  const poolLengthRes = await call({ ctx, target: miniChef.address, params: [], abi: abi.poolLength })
-  const poolLength = parseInt(poolLengthRes.output)
+  const poolLengthRes = await call({ ctx, target: miniChef.address, abi: abi.poolLength })
+  const poolLength = Number(poolLengthRes)
 
   const calls: Call[] = []
   for (let idx = 0; idx < poolLength; idx++) {

--- a/src/adapters/tangible/polygon/lock.ts
+++ b/src/adapters/tangible/polygon/lock.ts
@@ -43,7 +43,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const TNGBL: Token = {
   chain: 'polygon',
@@ -55,16 +55,17 @@ const TNGBL: Token = {
 export async function getTangibleLockerBalances(ctx: BalancesContext, locker: Contract): Promise<LockBalance[]> {
   const balances: LockBalance[] = []
 
-  const { output: balanceOfsRes } = await call({
+  const balanceOfsRes = await call({
     ctx,
     target: locker.address,
     params: [ctx.address],
     abi: erc20Abi.balanceOf,
   })
+  const balanceOf = Number(balanceOfsRes)
 
   const tokenOfOwnerByIndexesRes = await multicall({
     ctx,
-    calls: range(0, balanceOfsRes).map((idx) => ({ target: locker.address, params: [ctx.address, idx] })),
+    calls: range(0, balanceOf).map((idx) => ({ target: locker.address, params: [ctx.address, idx] })),
     abi: abi.tokenOfOwnerByIndex,
   })
 
@@ -85,7 +86,7 @@ export async function getTangibleLockerBalances(ctx: BalancesContext, locker: Co
     }),
   ])
 
-  for (let idx = 0; idx < balanceOfsRes; idx++) {
+  for (let idx = 0; idx < balanceOf; idx++) {
     const lockedRes = lockedsRes[idx]
     const earnedRes = earnedsRes[idx]
 

--- a/src/adapters/tangible/polygon/stake.ts
+++ b/src/adapters/tangible/polygon/stake.ts
@@ -12,7 +12,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const USDR: Token = {
   chain: 'polygon',
@@ -22,14 +22,14 @@ const USDR: Token = {
 }
 
 export async function getTangibleStakeBalance(ctx: BalancesContext, staker: Contract): Promise<Balance> {
-  const { output: userBalance } = await call({
+  const userBalance = await call({
     ctx,
     target: staker.address,
     params: [ctx.address],
     abi: erc20Abi.balanceOf,
   })
 
-  const { output: fmtBalance } = await call({
+  const fmtBalance = await call({
     ctx,
     target: staker.address,
     params: [userBalance],

--- a/src/adapters/templedao/ethereum/balances.ts
+++ b/src/adapters/templedao/ethereum/balances.ts
@@ -21,14 +21,12 @@ export async function getStakeBalances(
 ): Promise<Balance[]> {
   const balances: Balance[] = []
 
-  const balanceOfRes = await call({
+  const balanceOf = await call({
     ctx,
     target: contract.address,
     params: [ctx.address],
     abi: abi.balanceOf,
   })
-
-  const balanceOf = balanceOfRes.output
 
   const formattedBalanceRes = await call({
     ctx,
@@ -43,7 +41,7 @@ export async function getStakeBalances(
     },
   })
 
-  const formattedBalance = BigNumber.from(formattedBalanceRes.output)
+  const formattedBalance = BigNumber.from(formattedBalanceRes)
 
   const balance: Balance = {
     chain: ctx.chain,

--- a/src/adapters/the-idols/ethereum/stake.ts
+++ b/src/adapters/the-idols/ethereum/stake.ts
@@ -25,7 +25,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const WETH: Token = {
   chain: 'ethereum',
@@ -35,7 +35,7 @@ const WETH: Token = {
 }
 
 export async function getVirtueStakeBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
-  const [{ output: userBalance }, { output: userPendingReward }, { output: userExtraReward }] = await Promise.all([
+  const [userBalance, userPendingReward, userExtraReward] = await Promise.all([
     call({ ctx, target: staker.address, params: [ctx.address], abi: abi.getUserVirtueStake }),
     call({ ctx, target: staker.address, params: [ctx.address], abi: abi.getPendingETHGain }),
     call({ ctx, target: staker.rewarder, params: [ctx.address], abi: abi.earned }),
@@ -43,7 +43,7 @@ export async function getVirtueStakeBalances(ctx: BalancesContext, staker: Contr
 
   return {
     ...staker,
-    address: staker.token as string,
+    address: staker.token!,
     amount: BigNumber.from(userBalance),
     underlyings: undefined,
     rewards: [{ ...WETH, amount: BigNumber.from(userPendingReward).add(userExtraReward) }],

--- a/src/adapters/tokemak/ethereum/contract.ts
+++ b/src/adapters/tokemak/ethereum/contract.ts
@@ -18,16 +18,16 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getTokemakContracts(ctx: BaseContext, manager: Contract): Promise<Contract[]> {
   const pools: Contract[] = []
 
-  const { output: getPoolsAddresses } = await call({ ctx, target: manager.address, abi: abi.getPools })
+  const getPoolsAddresses = await call({ ctx, target: manager.address, abi: abi.getPools })
 
   const underlyingsAddresses = await multicall({
     ctx,
-    calls: getPoolsAddresses.map((pool: string) => ({ target: pool })),
+    calls: getPoolsAddresses.map((pool) => ({ target: pool })),
     abi: abi.underlyer,
   })
 

--- a/src/adapters/tokemak/ethereum/stake.ts
+++ b/src/adapters/tokemak/ethereum/stake.ts
@@ -24,7 +24,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const TOKE: Token = {
   chain: 'ethereum',
@@ -34,7 +34,7 @@ const TOKE: Token = {
 }
 
 export async function getTokemakStakeBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
-  const { output: balanceOfRes } = await call({
+  const balanceOfRes = await call({
     ctx,
     target: staker.address,
     params: [ctx.address],

--- a/src/adapters/tokenlon/ethereum/stake.ts
+++ b/src/adapters/tokenlon/ethereum/stake.ts
@@ -12,7 +12,7 @@ const LON: Token = {
 }
 
 export async function getxLONstakerBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
-  const [{ output: userBalanceOfRes }, { output: tokenBalanceOfRes }, { output: totalSupplyRes }] = await Promise.all([
+  const [userBalanceOfRes, tokenBalanceOfRes, totalSupplyRes] = await Promise.all([
     call({ ctx, target: staker.address, params: [ctx.address], abi: erc20Abi.balanceOf }),
     call({ ctx, target: LON.address, params: [staker.address], abi: erc20Abi.balanceOf }),
     call({ ctx, target: staker.address, abi: erc20Abi.totalSupply }),

--- a/src/adapters/tornado-cash/ethereum/stake.ts
+++ b/src/adapters/tornado-cash/ethereum/stake.ts
@@ -18,7 +18,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const TORN: Token = {
   chain: 'ethereum',
@@ -28,7 +28,7 @@ const TORN: Token = {
 }
 
 export async function getTornadoStakeBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
-  const [{ output: userBalance }, { output: pendingReward }] = await Promise.all([
+  const [userBalance, pendingReward] = await Promise.all([
     call({ ctx, target: staker.address, params: [ctx.address], abi: abi.lockedBalance }),
     call({ ctx, target: staker.rewarder, params: [ctx.address], abi: abi.checkReward }),
   ])

--- a/src/adapters/tprotocol/ethereum/balance.ts
+++ b/src/adapters/tprotocol/ethereum/balance.ts
@@ -12,7 +12,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const USDC: Token = {
   chain: 'ethereum',
@@ -22,14 +22,14 @@ const USDC: Token = {
 }
 
 export async function getTProtocolBalances(ctx: BalancesContext, contract: Contract): Promise<Balance> {
-  const { output: userBalanceOf } = await call({
+  const userBalanceOf = await call({
     ctx,
     target: contract.address,
     params: [ctx.address],
     abi: erc20Abi.balanceOf,
   })
 
-  const { output: fmtBalance } = await call({
+  const fmtBalance = await call({
     ctx,
     target: contract.address,
     params: [userBalanceOf],

--- a/src/adapters/traderjoe/avalanche/balances.ts
+++ b/src/adapters/traderjoe/avalanche/balances.ts
@@ -83,9 +83,9 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
-const pools = [
+const pools: `0x${string}`[] = [
   '0x1a731b2299e22fbac282e7094eda41046343cb51', // sJOE contract
   '0x25D85E17dD9e544F6E9F8D44F99602dbF5a97341', // veJOE contract
   '0x102D195C3eE8BF8A9A89d63FB3659432d3174d81', // rJOE contract
@@ -150,10 +150,12 @@ export async function getStakeBalance(ctx: BalancesContext) {
       abi: abi.rJoeUserInfo,
     }),
   ])
+  const [veJOEBalance] = veJOEbalanceOfRes
+  const [rJOEBalance] = rJOEbalanceOfRes
 
-  const sJOEbalanceOf = BigNumber.from(sJOEbalanceOfRes.output[0])
-  const veJOEbalanceOf = BigNumber.from(veJOEbalanceOfRes.output.balance)
-  const rJOEbalanceOf = BigNumber.from(rJOEbalanceOfRes.output.amount)
+  const sJOEbalanceOf = BigNumber.from(sJOEbalanceOfRes[0])
+  const veJOEbalanceOf = BigNumber.from(veJOEBalance)
+  const rJOEbalanceOf = BigNumber.from(rJOEBalance)
 
   const stakeAmount = [sJOEbalanceOf, veJOEbalanceOf, rJOEbalanceOf]
 
@@ -180,9 +182,9 @@ export async function getStakeBalance(ctx: BalancesContext) {
     }),
   ])
 
-  const sJOErewards = BigNumber.from(sJOErewardsRes.output)
-  const veJOErewards = BigNumber.from(veJOErewardsRes.output)
-  const rJOErewards = BigNumber.from(rJOErewardsRes.output)
+  const sJOErewards = BigNumber.from(sJOErewardsRes)
+  const veJOErewards = BigNumber.from(veJOErewardsRes)
+  const rJOErewards = BigNumber.from(rJOErewardsRes)
 
   const rewardsAmount = [sJOErewards, veJOErewards, rJOErewards]
 

--- a/src/adapters/truefi/ethereum/stake.ts
+++ b/src/adapters/truefi/ethereum/stake.ts
@@ -33,7 +33,7 @@ const abiTRU = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const TRU: Token = {
   chain: 'ethereum',
@@ -68,8 +68,8 @@ export async function getTRUStakeBalances(ctx: BalancesContext, stkTRU: Contract
     }),
   ])
 
-  const balanceOf = BigNumber.from(balanceOfRes.output)
-  const claimable = BigNumber.from(claimableRes.output)
+  const balanceOf = BigNumber.from(balanceOfRes)
+  const claimable = BigNumber.from(claimableRes)
 
   balances.push({
     chain: ctx.chain,
@@ -99,21 +99,19 @@ export async function getTUSDStakeBalances(ctx: BalancesContext, TUSD: Contract)
     call({
       ctx,
       target: TUSD.address,
-      params: [],
       abi: abiTRU.poolValue,
     }),
 
     call({
       ctx,
       target: TUSD.address,
-      params: [],
       abi: abiTRU.totalSupply,
     }),
   ])
 
-  const balanceOf = BigNumber.from(balanceOfRes.output)
-  const poolValue = BigNumber.from(poolValueRes.output)
-  const totalSupply = BigNumber.from(totalSupplyRes.output)
+  const balanceOf = BigNumber.from(balanceOfRes)
+  const poolValue = BigNumber.from(poolValueRes)
+  const totalSupply = BigNumber.from(totalSupplyRes)
 
   balances.push({
     chain: ctx.chain,

--- a/src/adapters/trustswap/ethereum/lock.ts
+++ b/src/adapters/trustswap/ethereum/lock.ts
@@ -22,13 +22,13 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getTrustLockBalances(ctx: BalancesContext, locker: Contract): Promise<LockBalance[]> {
   const balances: LockBalance[] = []
   const now = Date.now() / 1000
 
-  const { output: userLocksBalancesRes } = await call({
+  const userLocksBalancesRes = await call({
     ctx,
     target: locker.address,
     params: [ctx.address],

--- a/src/adapters/uniswap-v3/common/pools.ts
+++ b/src/adapters/uniswap-v3/common/pools.ts
@@ -95,7 +95,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getPoolsBalances(ctx: BalancesContext, nonFungiblePositionManager: Contract, factory: Contract) {
   // # of NFTs
@@ -106,7 +106,7 @@ export async function getPoolsBalances(ctx: BalancesContext, nonFungiblePosition
     abi: erc20Abi.balanceOf,
   })
 
-  const balancesLength = parseInt(balanceOf.output)
+  const balancesLength = Number(balanceOf)
 
   // token IDs
   const tokensOfOwnerByIndexRes = await multicall({

--- a/src/adapters/vector/avalanche/locker.ts
+++ b/src/adapters/vector/avalanche/locker.ts
@@ -27,7 +27,6 @@ export async function getLockerBalances(ctx: BalancesContext, contract: Contract
     call({
       ctx,
       target: contract.address,
-      params: [],
       abi: {
         inputs: [],
         name: 'rewarder',
@@ -51,8 +50,8 @@ export async function getLockerBalances(ctx: BalancesContext, contract: Contract
     }),
   ])
 
-  const userTotalDeposit = BigNumber.from(userTotalDepositRes.output)
-  const rewarderAddress = rewarderAddressRes.output
+  const userTotalDeposit = BigNumber.from(userTotalDepositRes)
+  const rewarderAddress = rewarderAddressRes
 
   const rewards = await lockedRewardsBalances(ctx, rewarderAddress)
 
@@ -69,7 +68,7 @@ export async function getLockerBalances(ctx: BalancesContext, contract: Contract
 
   const extraUserLockedBySlotsRes = await multicall({
     ctx,
-    calls: range(0, userExtraLockedSlots.output).map((i) => ({
+    calls: range(0, Number(userExtraLockedSlots)).map((i) => ({
       target: contract.address,
       params: [ctx.address, i],
     })),
@@ -113,7 +112,7 @@ export async function getLockerBalances(ctx: BalancesContext, contract: Contract
   return balances
 }
 
-const lockedRewardsBalances = async (ctx: BalancesContext, rewarder: string): Promise<Balance[]> => {
+const lockedRewardsBalances = async (ctx: BalancesContext, rewarder: `0x${string}`): Promise<Balance[]> => {
   const pendingRewardsTokensRes = await multicall({
     ctx,
     // There is no logic in the contracts to know the number of tokens in advance. Among all the contracts checked, 7 seems to be the maximum number of extra tokens used.

--- a/src/adapters/velodrome/optimism/gauge.ts
+++ b/src/adapters/velodrome/optimism/gauge.ts
@@ -25,10 +25,10 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getGaugeContract(ctx: BaseContext, gaugeFactory: Contract) {
-  const { output: address } = await call({ ctx, target: gaugeFactory.address, abi: abi.last_gauge })
+  const address = await call({ ctx, target: gaugeFactory.address, abi: abi.last_gauge })
   const contract: Contract = { chain: ctx.chain, address }
 
   return contract

--- a/src/adapters/velodrome/optimism/votingEscrow.ts
+++ b/src/adapters/velodrome/optimism/votingEscrow.ts
@@ -27,12 +27,12 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getVotingEscrowBalances(ctx: BalancesContext, votingEscrow: Contract, velo: Contract) {
   const balanceOfRes = await call({ ctx, target: votingEscrow.address, abi: erc20Abi.balanceOf, params: [ctx.address] })
 
-  const balancesLength = parseInt(balanceOfRes.output)
+  const balancesLength = Number(balanceOfRes)
 
   // token IDS
   const tokensOfOwnerByIndexRes = await multicall({

--- a/src/adapters/venus/bsc/lend.ts
+++ b/src/adapters/venus/bsc/lend.ts
@@ -14,7 +14,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const VAI: Token = {
   chain: 'bsc',
@@ -39,7 +39,7 @@ export async function getLendBorrowBalances(
     abi: abi.mintedVAIs,
   })
 
-  const VAIBalances = BigNumber.from(VAIBalancesRes.output)
+  const VAIBalances = BigNumber.from(VAIBalancesRes)
 
   VAIMinted.push({
     chain: ctx.chain,

--- a/src/adapters/venus/bsc/rewards.ts
+++ b/src/adapters/venus/bsc/rewards.ts
@@ -29,7 +29,7 @@ const abi = {
     stateMutability: 'nonpayable',
     type: 'function',
   },
-}
+} as const
 
 const XVS: Token = {
   chain: 'bsc',
@@ -52,7 +52,7 @@ export async function getRewardsBalances(
     abi: abi.getXVSBalanceMetadataExt,
   })
 
-  const XVSAllocatedRewards = BigNumber.from(XVSAllocatedRewardsRes.output.allocated)
+  const XVSAllocatedRewards = BigNumber.from(XVSAllocatedRewardsRes.allocated)
 
   rewards.push({
     chain: ctx.chain,

--- a/src/adapters/venus/bsc/stake.ts
+++ b/src/adapters/venus/bsc/stake.ts
@@ -55,7 +55,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const XVS: Token = {
   chain: 'bsc',
@@ -65,29 +65,29 @@ const XVS: Token = {
 }
 
 export async function getVAIStakeBalance(ctx: BalancesContext, staker: Contract): Promise<StakeBalance> {
-  const [{ output: stakeBalance }, { output: pendingXVS }] = await Promise.all([
+  const [stakeBalance, pendingXVS] = await Promise.all([
     call({ ctx, target: staker.address, params: [ctx.address], abi: abi.userInfo }),
     call({ ctx, target: staker.address, params: [ctx.address], abi: abi.pendingXVS }),
   ])
 
   return {
     ...staker,
-    amount: BigNumber.from(stakeBalance.amount),
+    amount: BigNumber.from(stakeBalance),
     underlyings: undefined,
-    rewards: [{ ...XVS, amount: pendingXVS }],
+    rewards: [{ ...XVS, amount: BigNumber.from(pendingXVS) }],
     category: 'stake',
   }
 }
 
 export async function getXVSStakeBalance(ctx: BalancesContext, staker: Contract): Promise<StakeBalance> {
-  const [{ output: stakeBalance }, { output: pendingXVS }] = await Promise.all([
-    call({ ctx, target: staker.address, params: [XVS.address, 0, ctx.address], abi: abi.getUserInfo }),
-    call({ ctx, target: staker.address, params: [XVS.address, 0, ctx.address], abi: abi.pendingReward }),
+  const [stakeBalance, pendingXVS] = await Promise.all([
+    call({ ctx, target: staker.address, params: [XVS.address, 0n, ctx.address], abi: abi.getUserInfo }),
+    call({ ctx, target: staker.address, params: [XVS.address, 0n, ctx.address], abi: abi.pendingReward }),
   ])
 
   return {
     ...staker,
-    amount: BigNumber.from(stakeBalance.amount),
+    amount: BigNumber.from(stakeBalance),
     underlyings: undefined,
     rewards: [{ ...XVS, amount: BigNumber.from(pendingXVS) }],
     category: 'stake',

--- a/src/adapters/wepiggy/common/rewards.ts
+++ b/src/adapters/wepiggy/common/rewards.ts
@@ -15,7 +15,7 @@ export async function getMarketsRewards(ctx: BalancesContext, piggyDistribution:
   const pendingWPCRewardsRes = await call({
     ctx,
     target: piggyDistribution.address,
-    params: [ctx.address, 'true', 'true'],
+    params: [ctx.address, true, true],
     abi: {
       inputs: [
         { internalType: 'address', name: 'holder', type: 'address' },
@@ -29,7 +29,7 @@ export async function getMarketsRewards(ctx: BalancesContext, piggyDistribution:
     },
   })
 
-  const pendingWPCRewards = BigNumber.from(pendingWPCRewardsRes.output).mul(Math.pow(10, 3))
+  const pendingWPCRewards = BigNumber.from(pendingWPCRewardsRes).mul(Math.pow(10, 3))
 
   const reward: Balance = {
     chain: ctx.chain,

--- a/src/adapters/wigoswap/fantom/balance.ts
+++ b/src/adapters/wigoswap/fantom/balance.ts
@@ -26,7 +26,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const wigo: Token = {
   chain: 'fantom',
@@ -36,14 +36,15 @@ const wigo: Token = {
 }
 
 export async function getWigoBalances(ctx: BalancesContext, pool: Contract): Promise<Balance> {
-  const [{ output: balanceOf }, { output: pricePerFullShare }] = await Promise.all([
+  const [userInfo, pricePerFullShare] = await Promise.all([
     call({ ctx, target: pool.address, params: [ctx.address], abi: abi.userInfo }),
     call({ ctx, target: pool.address, abi: abi.getPricePerFullShare }),
   ])
+  const [shares] = userInfo
 
   return {
     ...pool,
-    amount: BigNumber.from(balanceOf.shares).mul(pricePerFullShare).div(utils.parseEther('1.0')),
+    amount: BigNumber.from(shares).mul(pricePerFullShare).div(utils.parseEther('1.0')),
     underlyings: [wigo],
     rewards: undefined,
     category: 'farm',

--- a/src/adapters/wombat-exchange/common/lock.ts
+++ b/src/adapters/wombat-exchange/common/lock.ts
@@ -13,20 +13,21 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getWombatLockBalance(ctx: BalancesContext, locker: Contract): Promise<Balance> {
-  const { output: userBalances } = await call({
+  const userOverview = await call({
     ctx,
     target: locker.address,
     params: [ctx.address],
     abi: abi.getUserOverview,
   })
+  const [womLocked, veWomBalance] = userOverview
 
   return {
     ...locker,
-    amount: BigNumber.from(userBalances.veWomBalance),
-    underlyings: [{ ...(locker.underlyings?.[0] as Contract), amount: BigNumber.from(userBalances.womLocked) }],
+    amount: BigNumber.from(veWomBalance),
+    underlyings: [{ ...(locker.underlyings?.[0] as Contract), amount: BigNumber.from(womLocked) }],
     rewards: undefined,
     category: 'lock',
   }

--- a/src/adapters/wonderland/avalanche/balances.ts
+++ b/src/adapters/wonderland/avalanche/balances.ts
@@ -25,7 +25,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const TIME: Contract = {
   name: 'Time',
@@ -46,14 +46,12 @@ const wMEMO: Contract = {
 }
 
 export async function getTIMEStakeBalances(ctx: BalancesContext, contract: Contract): Promise<Balance> {
-  const balanceOfRes = await call({
+  const balanceOf = await call({
     ctx,
     target: contract.address,
     params: [ctx.address],
     abi: erc20Abi.balanceOf,
   })
-
-  const balanceOf = balanceOfRes.output
 
   const formattedBalanceOfRes = await call({
     ctx,
@@ -62,7 +60,7 @@ export async function getTIMEStakeBalances(ctx: BalancesContext, contract: Contr
     abi: abi.wMEMOToMEMO,
   })
 
-  const formattedBalanceOf = BigNumber.from(formattedBalanceOfRes.output)
+  const formattedBalanceOf = BigNumber.from(formattedBalanceOfRes)
 
   const balance: Balance = {
     chain: ctx.chain,
@@ -87,7 +85,7 @@ export async function getwMEMOStakeBalances(ctx: BalancesContext, contract: Cont
     abi: erc20Abi.balanceOf,
   })
 
-  const balanceOf = BigNumber.from(balanceOfRes.output)
+  const balanceOf = BigNumber.from(balanceOfRes)
 
   const balance: Balance = {
     chain: ctx.chain,

--- a/src/adapters/wonderland/avalanche/rewards.ts
+++ b/src/adapters/wonderland/avalanche/rewards.ts
@@ -23,7 +23,7 @@ const abiWonderland = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const wMEMO: Contract = {
   name: 'Wrapped MEMO',
@@ -38,11 +38,10 @@ export async function getRewardsMEMOFarmTokens(ctx: BaseContext, wMEMOFarm: Cont
   const rewardTokenLengthRes = await call({
     ctx,
     target: wMEMOFarm.address,
-    params: [],
     abi: abiWonderland.rewardTokenLength,
   })
 
-  const rewardTokenLength = parseInt(rewardTokenLengthRes.output)
+  const rewardTokenLength = Number(rewardTokenLengthRes)
 
   const rewardTokensRes = await multicall({
     ctx,

--- a/src/adapters/x2y2/ethereum/farm.ts
+++ b/src/adapters/x2y2/ethereum/farm.ts
@@ -11,7 +11,8 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
+
 const x2y2: Token = {
   chain: 'ethereum',
   address: '0x1E4EDE388cbc9F4b5c79681B7f94d36a11ABEBC9',
@@ -20,7 +21,7 @@ const x2y2: Token = {
 }
 
 export async function getX2Y2YieldBalances(ctx: BalancesContext, farmer: Contract): Promise<Balance> {
-  const { output: balanceOf } = await call({
+  const balanceOf = await call({
     ctx,
     target: farmer.address,
     params: [ctx.address],

--- a/src/adapters/x2y2/ethereum/stake.ts
+++ b/src/adapters/x2y2/ethereum/stake.ts
@@ -18,7 +18,8 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
+
 const x2y2: Token = {
   chain: 'ethereum',
   address: '0x1E4EDE388cbc9F4b5c79681B7f94d36a11ABEBC9',
@@ -34,7 +35,7 @@ const weth: Token = {
 }
 
 export async function getX2Y2StakerBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
-  const [{ output: balanceOf }, { output: pendingReward }] = await Promise.all([
+  const [balanceOf, pendingReward] = await Promise.all([
     call({
       ctx,
       target: staker.address,

--- a/src/adapters/yearn-finance/common/vaults.ts
+++ b/src/adapters/yearn-finance/common/vaults.ts
@@ -82,7 +82,7 @@ const abi = {
     type: 'function',
     gas: 2370,
   },
-}
+} as const
 
 type VaultBalance = Balance & {
   lpToken?: string
@@ -96,19 +96,18 @@ export async function getVaultsContracts(ctx: BaseContext, registry: Contract) {
   const assetsStaticsRes = await call({
     ctx,
     target: registry.address,
-    params: [],
     abi: abi.assetsStatic,
   })
 
-  for (let i = 0; i < assetsStaticsRes.output.length; i++) {
-    const assetsStatic = assetsStaticsRes.output[i]
+  for (let i = 0; i < assetsStaticsRes.length; i++) {
+    const assetsStatic = assetsStaticsRes[i]
 
     const contract: Contract = {
       chain: ctx.chain,
       name: assetsStatic.name,
       address: assetsStatic.id,
       symbol: assetsStatic.symbol,
-      decimals: parseInt(assetsStatic.decimals),
+      decimals: assetsStatic.decimals,
       lpToken: assetsStatic.tokenId,
       underlyings: [assetsStatic.tokenId],
     }
@@ -130,8 +129,8 @@ export async function getVaultsBalances(ctx: BalancesContext, vaults: Contract[]
     abi: abi.assetsPositionsOf,
   })
 
-  for (let i = 0; i < assetsPositionsOf.output.length; i++) {
-    const assetsPositionOf = assetsPositionsOf.output[i]
+  for (let i = 0; i < assetsPositionsOf.length; i++) {
+    const assetsPositionOf = assetsPositionsOf[i]
 
     vaultBalances.push({
       chain: ctx.chain,

--- a/src/lib/adapter.ts
+++ b/src/lib/adapter.ts
@@ -9,7 +9,7 @@ export interface BaseContext {
 }
 
 export interface BalancesContext extends BaseContext {
-  address: string
+  address: `0x${string}`
 }
 
 export type ContractStandard = 'erc20' | 'erc721'
@@ -22,9 +22,9 @@ export interface BaseContract {
   name?: string
   displayName?: string
   chain: Chain
-  address: string
+  address: `0x${string}`
   // if specified, used to retrieve token details: symbol / decimals
-  token?: string
+  token?: `0x${string}`
   symbol?: string
   decimals?: number
   stable?: boolean

--- a/src/lib/compound/v2/lending.ts
+++ b/src/lib/compound/v2/lending.ts
@@ -44,14 +44,14 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export interface GetMarketsContractsProps {
-  comptrollerAddress: string
+  comptrollerAddress: `0x${string}`
   /**
    * map of underlying tokens by address not defined in Comptroller markets (ex: cETH -> WETH).
    */
-  underlyingAddressByMarketAddress?: { [key: string]: string }
+  underlyingAddressByMarketAddress?: { [key: string]: `0x${string}` }
 }
 
 export type BalanceWithExtraProps = Balance & {
@@ -64,12 +64,11 @@ export async function getMarketsContracts(
 ): Promise<Contract[]> {
   const contracts: Contract[] = []
 
-  const cTokensAddressesRes = await call({
+  const cTokensAddresses = await call({
     ctx,
     abi: abi.getAllMarkets,
     target: comptrollerAddress,
   })
-  const cTokensAddresses: string[] = cTokensAddressesRes.output
 
   const [marketsRes, underlyingTokensAddressesRes] = await Promise.all([
     multicall({

--- a/src/lib/erc20.ts
+++ b/src/lib/erc20.ts
@@ -82,7 +82,7 @@ export const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 // See: https://github.com/o-az/evm-balances/tree/master
 const multiCoinContracts = {
@@ -106,11 +106,10 @@ export async function getERC20BalanceOf(ctx: BalancesContext, tokens: Token[]): 
   const balances: Balance[] = []
 
   if (ctx.chain in multiCoinContracts) {
-    const { output: multiBalances } = await call({
+    const multiBalances = await call({
       ctx,
       target: multiCoinContracts[ctx.chain as keyof typeof multiCoinContracts],
       abi: abi.getBalances,
-      // @ts-ignore
       params: [ctx.address, tokens.map((token) => token.address)],
     })
 
@@ -138,7 +137,7 @@ export async function getERC20BalanceOf(ctx: BalancesContext, tokens: Token[]): 
   return balances
 }
 
-export async function getERC20Details(ctx: BaseContext, tokens: string[]): Promise<Token[]> {
+export async function getERC20Details(ctx: BaseContext, tokens: readonly `0x${string}`[]): Promise<Token[]> {
   const found: { [key: string]: Token } = {}
   for (const address of tokens) {
     const tokenInfo = getToken(ctx.chain, address.toLowerCase())

--- a/src/lib/geist/lending.ts
+++ b/src/lib/geist/lending.ts
@@ -35,7 +35,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export interface GetLendingPoolContractsParams {
   ctx: BaseContext
@@ -58,11 +58,11 @@ export async function getLendingPoolContracts(
   const aaveLendingPoolContracts = await getAaveLendingPoolContracts(ctx, lendingPool)
   const aaveLendingPoolContractsByAddress = keyBy(aaveLendingPoolContracts, 'address', { lowercase: false })
 
-  const { output: lmRewardsCount } = await call({ ctx, target: chefIncentivesController.address, abi: abi.poolLength })
+  const lmRewardsCount = await call({ ctx, target: chefIncentivesController.address, abi: abi.poolLength })
 
   const registeredTokensRes = await multicall({
     ctx,
-    calls: range(0, lmRewardsCount).map((_, idx) => ({
+    calls: range(0, Number(lmRewardsCount)).map((_, idx) => ({
       target: chefIncentivesController.address,
       params: [idx],
     })),

--- a/src/lib/gmx/underlying.ts
+++ b/src/lib/gmx/underlying.ts
@@ -16,7 +16,7 @@ export const get_xLP_UnderlyingsBalances = async (
       continue
     }
 
-    const [{ output: totalSupply }, underlyingsBalancesOfsRes] = await Promise.all([
+    const [totalSupply, underlyingsBalancesOfsRes] = await Promise.all([
       call({ ctx, target: balance.address, abi: erc20Abi.totalSupply }),
       multicall({
         ctx,

--- a/src/lib/gmx/vault.ts
+++ b/src/lib/gmx/vault.ts
@@ -23,16 +23,16 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getVaultTokens(ctx: BaseContext, vault: Contract) {
-  const { output: allWhitelistedTokensLengthRes } = await call({
+  const allWhitelistedTokensLengthRes = await call({
     ctx,
     abi: abi.allWhitelistedTokensLength,
     target: vault.address,
   })
 
-  const allWhitelistedTokensLength = parseInt(allWhitelistedTokensLengthRes)
+  const allWhitelistedTokensLength = Number(allWhitelistedTokensLengthRes)
 
   const allWhitelistedTokensRes = await multicall<string, [number], string>({
     ctx,

--- a/src/lib/masterchef/masterchef.ts
+++ b/src/lib/masterchef/masterchef.ts
@@ -78,7 +78,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 /**
  * @function getMasterChefPoolsInfos used by `getMasterChefPoolsBalances` when `abi` does not includes `lpToken` function
@@ -91,9 +91,9 @@ export const getMasterChefPoolsInfos = async (
 ): Promise<Contract[]> => {
   const pools: Contract[] = []
 
-  const poolLengthRes = await call({ ctx, target: masterchef.address, params: [], abi: abi.poolLength })
+  const poolLengthRes = await call({ ctx, target: masterchef.address, abi: abi.poolLength })
 
-  const poolLength = parseInt(poolLengthRes.output)
+  const poolLength = Number(poolLengthRes)
 
   const calls: Call[] = []
   for (let idx = 0; idx < poolLength; idx++) {
@@ -148,9 +148,9 @@ export const getMasterChefLpToken = async (
 ): Promise<Contract[]> => {
   const pools: Contract[] = []
 
-  const poolLengthRes = await call({ ctx, target: masterchef.address, params: [], abi: abi.poolLength })
+  const poolLengthRes = await call({ ctx, target: masterchef.address, abi: abi.poolLength })
 
-  const poolLength = parseInt(poolLengthRes.output)
+  const poolLength = Number(poolLengthRes)
 
   const calls: Call[] = []
   for (let idx = 0; idx < poolLength; idx++) {

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -7,10 +7,6 @@ export function isZero<T extends BigNumber | string | number>(num: T) {
   return num.toString() === '0'
 }
 
-export function decimalsBN(num: BigNumber, decimals: number) {
-  return num.div(BN_TEN.pow(decimals))
-}
-
 export function sumBN(nums: BigNumber[]) {
   let res = BigNumber.from('0')
   for (const num of nums) {

--- a/src/lib/multicall.ts
+++ b/src/lib/multicall.ts
@@ -1,11 +1,12 @@
 import '@lib/providers'
 
 import type { BaseContext } from '@lib/adapter'
-import type { CallParams } from '@lib/call'
 import { providers } from '@lib/providers'
 import { isNotNullish } from '@lib/type'
 import { BigNumber } from 'ethers'
 import { getAddress } from 'viem'
+
+export type CallParams = string | number | (string | number)[] | undefined
 
 export function formatValue(value: any): any {
   if (value == null) {
@@ -45,12 +46,12 @@ export interface MultiCallOptions {
   ctx: BaseContext
   abi: any
   calls: (Call | null)[]
-  target?: string
+  target?: `0x${string}`
   chunkSize?: number
 }
 
 export interface Call {
-  target?: string
+  target?: `0x${string}`
   params?: CallParams
 }
 
@@ -63,7 +64,7 @@ export interface MultiCallResult<T = string, P = any[], O = any | null> {
   output: O
 }
 
-export async function multicall<T = string, P = any[], O = any>(params: MultiCallOptions) {
+export async function multicall<T = `0x${string}`, P = any[], O = any>(params: MultiCallOptions) {
   const results: MultiCallResult<T, P, O>[] = []
   if (!params.calls?.length) {
     return results

--- a/src/lib/stake.ts
+++ b/src/lib/stake.ts
@@ -1,16 +1,11 @@
 import type { Balance, BalancesContext, Contract } from '@lib/adapter'
-import type { CallOptions } from '@lib/call'
 import { call } from '@lib/call'
 import type { Category } from '@lib/category'
 import { abi as erc20ABI, getERC20BalanceOf } from '@lib/erc20'
 import type { Token } from '@lib/token'
 import { BigNumber } from 'ethers'
 
-export async function getSingleStakeBalance(
-  ctx: BalancesContext,
-  contract: Contract,
-  callOptions?: Partial<CallOptions>,
-) {
+export async function getSingleStakeBalance(ctx: BalancesContext, contract: Contract, callOptions?: any) {
   const amountRes = await call({
     ctx,
     abi: erc20ABI.balanceOf,
@@ -19,7 +14,7 @@ export async function getSingleStakeBalance(
     ...callOptions,
   })
 
-  const amount = BigNumber.from(amountRes.output)
+  const amount = BigNumber.from(amountRes)
 
   const balance: Balance = {
     ...(contract as Balance),

--- a/src/lib/token.ts
+++ b/src/lib/token.ts
@@ -10,7 +10,7 @@ export const ETH_ADDR = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
 
 export interface Token {
   chain: Chain
-  address: string
+  address: `0x${string}`
   symbol: string
   decimals: number
   native?: boolean

--- a/src/lib/uniswap/v2/factory.ts
+++ b/src/lib/uniswap/v2/factory.ts
@@ -43,7 +43,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export interface getPairsContractsParams {
   ctx: BaseContext
@@ -71,7 +71,7 @@ export async function getPairsContracts({
     target: factoryAddress,
   })
 
-  const allPairsLength = parseInt(allPairsLengthRes.output)
+  const allPairsLength = Number(allPairsLengthRes)
   const end = Math.min(offset + limit, allPairsLength)
 
   const pids = range(offset, end)


### PR DESCRIPTION
<!-- 🦙🦙 Thanks for contributing ! 🦙🦙 -->

<!-- Please specify the adapter id in the title -->

<!-- If you're creating a new adapter, please make sure the `links` field is well specified: this info will help us review it -->

## Summary

<!-- Which issues will be closed? (if applicable) -->

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

Add inferred ABI type definitions and refactor `lib/call` to use viem outputs directly (no transformation)

This is the 2nd step of the "viem refactoring".

Next step is to refactor `lib/multicall` to use viem outputs directly (no transformation)

Finally we should be able to replace BigNumber with less trouble

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
