### PR TITLE
feat: lib viem multicall

### DIFF
--- a/bench/multi-balanceOf.ts
+++ b/bench/multi-balanceOf.ts
@@ -44,7 +44,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 function help() {
   console.log('npm run multi-balanceOf {chain} {address}')
@@ -61,7 +61,7 @@ async function main() {
   }
 
   const chain = process.argv[2] as Chain
-  const address = process.argv[3].toLowerCase()
+  const address = process.argv[3].toLowerCase() as `0x${string}`
 
   const ctx: BalancesContext = { chain, adapterId: '', address }
 
@@ -69,8 +69,8 @@ async function main() {
     const hrstart = process.hrtime()
 
     const batchSize = 1000
-    const tokens = tokensByChain[chain] as any[]
-    const slices: any[][] = sliceIntoChunks(tokens, batchSize)
+    const tokens = tokensByChain[chain]
+    const slices = sliceIntoChunks(tokens, batchSize)
 
     let errorsCount = 0
 
@@ -86,7 +86,8 @@ async function main() {
 
     let callIdx = 0
     for (let sliceIdx = 0; sliceIdx < slices.length; sliceIdx++) {
-      if (!balances[sliceIdx].success || balances[sliceIdx].output == null) {
+      const balancesSlice = balances[sliceIdx]
+      if (!balancesSlice.success) {
         console.error(
           `Could not get balanceOf for tokens ${ctx.chain}:`,
           slices[sliceIdx].map((token) => token.address),
@@ -97,7 +98,7 @@ async function main() {
 
       for (let tokenIdx = 0; tokenIdx < slices[sliceIdx].length; tokenIdx++) {
         const token = tokens[callIdx]
-        token.amount = BigNumber.from(balances[sliceIdx].output[tokenIdx] || '0')
+        token.amount = BigNumber.from(balancesSlice.output[tokenIdx] || '0')
         callIdx++
       }
     }

--- a/scripts/update-balances.ts
+++ b/scripts/update-balances.ts
@@ -44,7 +44,7 @@ async function main() {
     return help()
   }
 
-  const address = process.argv[2].toLowerCase()
+  const address = process.argv[2].toLowerCase() as `0x${string}`
 
   const client = await pool.connect()
 

--- a/src/adapters/1inch-network/bsc/index.ts
+++ b/src/adapters/1inch-network/bsc/index.ts
@@ -6,7 +6,7 @@ import { getInchBalances } from '../common/farm'
 import { getLpInchBalances } from '../common/lp'
 import { getInchStakingBalances } from '../common/stake'
 
-const farmingPoolsAddresses: string[] = ['0x5d0ec1f843c1233d304b96dbde0cab9ec04d71ef']
+const farmingPoolsAddresses: `0x${string}`[] = ['0x5d0ec1f843c1233d304b96dbde0cab9ec04d71ef']
 
 const poolDeployer: Contract = {
   chain: 'bsc',

--- a/src/adapters/1inch-network/common/contract.ts
+++ b/src/adapters/1inch-network/common/contract.ts
@@ -29,7 +29,7 @@ export async function getInchPools(ctx: BaseContext, deployer: Contract): Promis
   return getPairsDetails(ctx, contracts)
 }
 
-export async function getInchFarmingPools(ctx: BaseContext, pools: string[]): Promise<Contract[]> {
+export async function getInchFarmingPools(ctx: BaseContext, pools: `0x${string}`[]): Promise<Contract[]> {
   const lpTokensRes = await multicall({ ctx, calls: pools.map((pool) => ({ target: pool })), abi: abi.mooniswap })
 
   const contracts: Contract[] = mapSuccessFilter(lpTokensRes, (res, idx) => ({

--- a/src/adapters/1inch-network/common/lp.ts
+++ b/src/adapters/1inch-network/common/lp.ts
@@ -1,9 +1,8 @@
 import type { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { ADDRESS_ZERO } from '@lib/contract'
 import { abi as erc20Abi } from '@lib/erc20'
-import { BN_ZERO, isZero } from '@lib/math'
+import { BN_ZERO } from '@lib/math'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 import { BigNumber } from 'ethers'
 
 const abi = {
@@ -26,9 +25,9 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
-const ADDRESS: { [key: string]: string } = {
+const ADDRESS: { [key: string]: `0x${string}` } = {
   ethereum: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
   bsc: '0x55f5af28075f37e6e02d0c741e268e462215ca33',
 }
@@ -39,17 +38,20 @@ export async function getLpInchBalances(ctx: BalancesContext, pools: Contract[])
   const [balanceOfsRes, totalSuppliesRes, getUnderlyingsBalancesRes] = await Promise.all([
     multicall({
       ctx,
-      calls: pools.map((pool) => ({ target: pool.address, params: [ctx.address] })),
+      calls: pools.map((pool) => ({ target: pool.address, params: [ctx.address] } as const)),
       abi: erc20Abi.balanceOf,
     }),
     multicall({ ctx, calls: pools.map((pool) => ({ target: pool.address })), abi: erc20Abi.totalSupply }),
     multicall({
       ctx,
       calls: pools.flatMap((pool) =>
-        pool.underlyings!.map((underlying) => ({
-          target: pool.address,
-          params: [(underlying as Contract).address],
-        })),
+        pool.underlyings!.map(
+          (underlying) =>
+            ({
+              target: pool.address,
+              params: [(underlying as Contract).address],
+            } as const),
+        ),
       ),
       abi: abi.getBalanceForAddition,
     }),
@@ -60,7 +62,7 @@ export async function getLpInchBalances(ctx: BalancesContext, pools: Contract[])
     const totalSupplyRes = totalSuppliesRes[poolIdx]
     const underlyings = pool.underlyings as Contract[]
 
-    if (!underlyings || !isSuccess(balanceOfRes) || !isSuccess(totalSupplyRes) || isZero(totalSupplyRes.output)) {
+    if (!underlyings || !balanceOfRes.success || !totalSupplyRes.success || totalSupplyRes.output === 0n) {
       return
     }
 
@@ -78,9 +80,10 @@ export async function getLpInchBalances(ctx: BalancesContext, pools: Contract[])
       // replace native token alias
       const underlyingAddress = underlying.address === ADDRESS_ZERO ? ADDRESS[ctx.chain] : underlying.address
 
-      const underlyingBalance = isSuccess(getUnderlyingsBalanceRes)
-        ? BigNumber.from(getUnderlyingsBalanceRes.output).mul(balanceOfRes.output).div(totalSupplyRes.output)
-        : BN_ZERO
+      const underlyingBalance =
+        getUnderlyingsBalanceRes.success && balanceOfRes.success && totalSupplyRes.success
+          ? BigNumber.from(getUnderlyingsBalanceRes.output).mul(balanceOfRes.output).div(totalSupplyRes.output)
+          : BN_ZERO
 
       balance.underlyings!.push({
         ...underlying,

--- a/src/adapters/aave-v2/common/stake.ts
+++ b/src/adapters/aave-v2/common/stake.ts
@@ -162,10 +162,13 @@ export async function getStakeBalancerPoolBalances(
 
   const underlyingsBalancesRes = await multicall({
     ctx,
-    calls: underlyingsTokens.map((token) => ({
-      target: token.address,
-      params: [bPoolRes],
-    })),
+    calls: underlyingsTokens.map(
+      (token) =>
+        ({
+          target: token.address,
+          params: [bPoolRes],
+        } as const),
+    ),
     abi: {
       constant: true,
       inputs: [{ internalType: 'address', name: '', type: 'address' }],
@@ -174,7 +177,7 @@ export async function getStakeBalancerPoolBalances(
       payable: false,
       stateMutability: 'view',
       type: 'function',
-    },
+    } as const,
   })
 
   const underlying0Balance = {
@@ -186,7 +189,7 @@ export async function getStakeBalancerPoolBalances(
     amount: stakedBalance
       .mul(stakingContractLPBalanceRes)
       .div(totalSupplyRes[0].output)
-      .mul(underlyingsBalancesRes[0].output)
+      .mul(underlyingsBalancesRes[0].success ? underlyingsBalancesRes[0].output : 0n)
       .div(totalSupplyRes[1].output),
   }
   const underlying1Balance = {
@@ -198,7 +201,7 @@ export async function getStakeBalancerPoolBalances(
     amount: stakedBalance
       .mul(stakingContractLPBalanceRes)
       .div(totalSupplyRes[0].output)
-      .mul(underlyingsBalancesRes[1].output)
+      .mul(underlyingsBalancesRes[1].success ? underlyingsBalancesRes[1].output : 0n)
       .div(totalSupplyRes[1].output),
   }
 

--- a/src/adapters/abracadabra/arbitrum/index.ts
+++ b/src/adapters/abracadabra/arbitrum/index.ts
@@ -23,7 +23,7 @@ const MIM: Contract = {
   wallet: true,
 }
 
-const cauldrons = [
+const cauldrons: `0x${string}`[] = [
   //  v2
   '0xC89958B03A55B5de2221aCB25B58B89A000215E6', // WETH
   '0x5698135CA439f21a57bDdbe8b582C62f090406D5', // GLP Self-Repaying

--- a/src/adapters/abracadabra/avalanche/index.ts
+++ b/src/adapters/abracadabra/avalanche/index.ts
@@ -23,7 +23,7 @@ const MIM: Contract = {
   wallet: true,
 }
 
-const cauldrons = [
+const cauldrons: `0x${string}`[] = [
   '0x3CFEd0439aB822530b1fFBd19536d897EF30D2a2',
   '0x3b63f81Ad1fc724E44330b4cf5b5B6e355AD964B',
   '0x95cCe62C3eCD9A33090bBf8a9eAC50b699B54210',

--- a/src/adapters/abracadabra/ethereum/index.ts
+++ b/src/adapters/abracadabra/ethereum/index.ts
@@ -72,7 +72,7 @@ const abracadabraFarm: Contract = {
   address: '0xf43480afe9863da4acbd4419a47d9cc7d25a647f',
 }
 
-const cauldrons = [
+const cauldrons: `0x${string}`[] = [
   //  Active v2
   '0x7b7473a76D6ae86CE19f7352A1E89F6C9dc39020', // ALCX
   '0xc1879bf24917ebE531FbAA20b0D05Da027B592ce', // AGLD

--- a/src/adapters/abracadabra/fantom/index.ts
+++ b/src/adapters/abracadabra/fantom/index.ts
@@ -23,7 +23,7 @@ const MIM: Contract = {
   wallet: true,
 }
 
-const cauldrons = [
+const cauldrons: `0x${string}`[] = [
   '0x7208d9F9398D7b02C5C22c334c2a7A3A98c0A45d',
   '0x4fdfFa59bf8dda3F4d5b38F260EAb8BFaC6d7bC1',
   '0x8E45Af6743422e488aFAcDad842cE75A09eaEd34',

--- a/src/adapters/across/ethereum/v1/contract.ts
+++ b/src/adapters/across/ethereum/v1/contract.ts
@@ -10,7 +10,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getAcrossContracts(ctx: BaseContext, pools: Contract[]): Promise<Contract[]> {
   const lpTokensRes = await multicall({ ctx, calls: pools.map((pool) => ({ target: pool.address })), abi: abi.l1Token })

--- a/src/adapters/angle/ethereum/index.ts
+++ b/src/adapters/angle/ethereum/index.ts
@@ -21,14 +21,20 @@ const locker: Contract = {
   symbol: 'veAngle',
 }
 
-const poolsAddresses: Record<string, string[]> = {
-  swap: ['0xBa625B318483516F7483DD2c4706aC92d44dBB2B', '0xd6282C5aEAaD4d776B932451C44b8EB453E44244'],
-  gelato: ['0xEB7547a8a734b6fdDBB8Ce0C314a9E6485100a3C', '0x3785Ce82be62a342052b9E5431e9D3a839cfB581'],
-}
+const swapPools: `0x${string}`[] = [
+  '0xBa625B318483516F7483DD2c4706aC92d44dBB2B',
+  '0xd6282C5aEAaD4d776B932451C44b8EB453E44244',
+]
+
+const gelatoPools: `0x${string}`[] = [
+  '0xEB7547a8a734b6fdDBB8Ce0C314a9E6485100a3C',
+  '0x3785Ce82be62a342052b9E5431e9D3a839cfB581',
+]
+
 export const getContracts = async (ctx: BaseContext) => {
   const [stablePools, pools] = await Promise.all([
     getStablePoolContractsFromAPI(ctx, 1),
-    getAnglePoolsContract(ctx, poolsAddresses),
+    getAnglePoolsContract(ctx, swapPools, gelatoPools),
   ])
 
   return {

--- a/src/adapters/arrakis/common/balances.ts
+++ b/src/adapters/arrakis/common/balances.ts
@@ -12,7 +12,6 @@ export async function getLpBalances(ctx: BalancesContext, contracts: Contract[])
   const nonZeroBalances = balancesRaw.filter((balance) => balance.amount.gt(0))
 
   const calls = nonZeroBalances.map((balance) => ({
-    params: [],
     target: balance.address,
   }))
 
@@ -60,16 +59,20 @@ export async function getLpBalances(ctx: BalancesContext, contracts: Contract[])
   ])
 
   for (let i = 0; i < calls.length; i++) {
-    if (!underlyingBalancesRes[i].success || !totalSupplyRes[i].success) {
+    const underlyingBalances = underlyingBalancesRes[i]
+    const totalSupply = totalSupplyRes[i]
+    if (!underlyingBalances.success || !totalSupply.success) {
       continue
     }
 
+    const [amount0Current, amount1Current] = underlyingBalances.output
+
     ;(nonZeroBalances[i].underlyings![0] as Balance).amount = BigNumber.from(nonZeroBalances[i].amount)
-      .mul(underlyingBalancesRes[i].output.amount0Current)
-      .div(totalSupplyRes[i].output)
+      .mul(amount0Current)
+      .div(totalSupply.output)
     ;(nonZeroBalances[i].underlyings![1] as Balance).amount = BigNumber.from(nonZeroBalances[i].amount)
-      .mul(underlyingBalancesRes[i].output.amount1Current)
-      .div(totalSupplyRes[i].output)
+      .mul(amount1Current)
+      .div(totalSupply.output)
 
     nonZeroBalances[i].category = 'lp'
     balances.push(nonZeroBalances[i])

--- a/src/adapters/arrakis/common/contracts.ts
+++ b/src/adapters/arrakis/common/contracts.ts
@@ -1,7 +1,6 @@
 import type { BaseContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 import { getPairsDetails } from '@lib/uniswap/v2/factory'
 
 const abi = {
@@ -48,17 +47,20 @@ export async function getVaults(ctx: BaseContext, factoryArrakis: Contract) {
 
   const deployedPools = await multicall({
     ctx,
-    calls: poolsDeployers.map((deployer: string) => ({
-      target: factoryArrakis.address,
-      params: [deployer],
-    })),
+    calls: poolsDeployers.map(
+      (deployer) =>
+        ({
+          target: factoryArrakis.address,
+          params: [deployer],
+        } as const),
+    ),
     abi: abi.getPools,
   })
 
   const pools: Contract[] = []
   for (let idx = 0; idx < deployedPools.length; idx++) {
     const deployedPool = deployedPools[idx]
-    if (!isSuccess(deployedPool)) {
+    if (!deployedPool.success) {
       continue
     }
 

--- a/src/adapters/aura/ethereum/balance.ts
+++ b/src/adapters/aura/ethereum/balance.ts
@@ -5,7 +5,6 @@ import { abi as erc20Abi } from '@lib/erc20'
 import type { Call } from '@lib/multicall'
 import { multicall } from '@lib/multicall'
 import type { Token } from '@lib/token'
-import { isSuccess } from '@lib/type'
 import { BigNumber } from 'ethers/lib/ethers'
 
 const abi = {
@@ -105,7 +104,7 @@ export async function getAuraPoolsBalances(
   const balanceWithRewards: Balance[] = []
   const balances: Balance[] = await getBalancerPoolsBalances(ctx, pools, vault)
 
-  const calls: Call[] = []
+  const calls: Call<typeof abi.earned>[] = []
   for (const balance of balances) {
     calls.push({ target: (balance as Contract).gauge, params: [ctx.address] })
   }
@@ -116,7 +115,7 @@ export async function getAuraPoolsBalances(
     const balance = balances[idx]
     const earnedRes = earnedsRes[idx]
 
-    if (!isSuccess(earnedRes)) {
+    if (!earnedRes.success) {
       continue
     }
 

--- a/src/adapters/babylon-finance/ethereum/balance.ts
+++ b/src/adapters/babylon-finance/ethereum/balance.ts
@@ -2,7 +2,6 @@ import type { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { abi as erc20Abi } from '@lib/erc20'
 import { BN_TEN } from '@lib/math'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 import { BigNumber } from 'ethers'
 
 const abi = {
@@ -13,7 +12,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getBabylonBalances(ctx: BalancesContext, contracts: Contract[]): Promise<Balance[]> {
   const balances: Balance[] = []
@@ -21,7 +20,7 @@ export async function getBabylonBalances(ctx: BalancesContext, contracts: Contra
   const [balancesOfRes, pricePerSharesRes] = await Promise.all([
     multicall({
       ctx,
-      calls: contracts.map((contract) => ({ target: contract.address, params: [ctx.address] })),
+      calls: contracts.map((contract) => ({ target: contract.address, params: [ctx.address] } as const)),
       abi: erc20Abi.balanceOf,
     }),
     multicall({
@@ -36,13 +35,15 @@ export async function getBabylonBalances(ctx: BalancesContext, contracts: Contra
     const balanceOfRes = balancesOfRes[poolIdx]
     const pricePerShareRes = pricePerSharesRes[poolIdx]
 
-    if (!isSuccess(balanceOfRes) || !isSuccess(pricePerShareRes)) {
+    if (!balanceOfRes.success || !pricePerShareRes.success) {
       continue
     }
 
     balances.push({
       ...contract,
-      amount: BigNumber.from(balanceOfRes.output).mul(pricePerShareRes.output).div(BN_TEN.pow(contract.decimals!)),
+      amount: BigNumber.from(balanceOfRes.output)
+        .mul(pricePerShareRes.output)
+        .div(BN_TEN.pow(contract.decimals || 0)),
       underlyings: contract.underlyings as Contract[],
       rewards: undefined,
       category: 'stake',

--- a/src/adapters/babylon-finance/ethereum/contract.ts
+++ b/src/adapters/babylon-finance/ethereum/contract.ts
@@ -1,6 +1,5 @@
 import type { BaseContext, Contract } from '@lib/adapter'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 
 const abi = {
   reserveAsset: {
@@ -10,9 +9,9 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
-export async function getBabylonContracts(ctx: BaseContext, pools: string[]): Promise<Contract[]> {
+export async function getBabylonContracts(ctx: BaseContext, pools: `0x${string}`[]): Promise<Contract[]> {
   const contracts: Contract[] = []
 
   const reserveAssetsRes = await multicall({
@@ -25,7 +24,7 @@ export async function getBabylonContracts(ctx: BaseContext, pools: string[]): Pr
     const pool = pools[poolIdx]
     const reserveAssetRes = reserveAssetsRes[poolIdx]
 
-    if (!isSuccess(reserveAssetRes)) {
+    if (!reserveAssetRes.success) {
       continue
     }
 

--- a/src/adapters/babylon-finance/ethereum/index.ts
+++ b/src/adapters/babylon-finance/ethereum/index.ts
@@ -4,7 +4,7 @@ import { resolveBalances } from '@lib/balance'
 import { getBabylonBalances } from './balance'
 import { getBabylonContracts } from './contract'
 
-const pools: string[] = [
+const pools: `0x${string}`[] = [
   '0xb5bd20248cfe9480487cc0de0d72d0e19ee0acb6',
   '0xd42b3a30ca89155d6c3499c81f0c4e5a978be5c2',
   '0x1d50c4f18d7af4fce2ea93c7942aae6260788596',

--- a/src/adapters/balancer/common/pool.ts
+++ b/src/adapters/balancer/common/pool.ts
@@ -1,7 +1,6 @@
 import type { BaseContext, Contract } from '@lib/adapter'
 import type { Call } from '@lib/multicall'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 import request, { gql } from 'graphql-request'
 
 const abi = {
@@ -19,7 +18,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getBalancerPools(ctx: BaseContext, url: string, gaugeController: Contract): Promise<Contract[]> {
   const contracts: Contract[] = []
@@ -55,7 +54,7 @@ export async function getBalancerPools(ctx: BaseContext, url: string, gaugeContr
     })
   }
 
-  const calls: Call[] = []
+  const calls: Call<typeof abi.getPoolGauge>[] = []
   for (const contract of contracts) {
     calls.push({ target: gaugeController.address, params: [contract.address] })
   }
@@ -70,12 +69,12 @@ export async function getBalancerPools(ctx: BaseContext, url: string, gaugeContr
     const gaugeRes = gaugesRes[idx]
     const rewarderRes = rewardersRes[idx]
 
-    if (!isSuccess(gaugeRes)) {
+    if (!gaugeRes.success) {
       contract.gauge = undefined
     }
     contract.gauge = gaugeRes.output
 
-    if (!isSuccess(rewarderRes)) {
+    if (!rewarderRes.success) {
       contract.rewarder = undefined
     }
     contract.rewarder = rewarderRes.output

--- a/src/adapters/cega/ethereum/contract.ts
+++ b/src/adapters/cega/ethereum/contract.ts
@@ -1,6 +1,5 @@
 import type { BaseContext, Contract } from '@lib/adapter'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 
 const abi = {
   asset: {
@@ -17,9 +16,9 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
-export async function getCegaContracts(ctx: BaseContext, vaults: string[]): Promise<Contract[]> {
+export async function getCegaContracts(ctx: BaseContext, vaults: `0x${string}`[]): Promise<Contract[]> {
   const contracts: Contract[] = []
 
   const [assetsRes, addressesRes] = await Promise.all([
@@ -39,11 +38,11 @@ export async function getCegaContracts(ctx: BaseContext, vaults: string[]): Prom
     const assetRes = assetsRes[vaultIdx]
     const addressRes = addressesRes[vaultIdx]
 
-    if (!isSuccess(assetRes) || !isSuccess(addressRes)) {
+    if (!assetRes.success || !addressRes.success) {
       return
     }
 
-    addressRes.output.forEach((address: string) => {
+    addressRes.output.forEach((address) => {
       contracts.push({
         chain: ctx.chain,
         address,

--- a/src/adapters/cega/ethereum/index.ts
+++ b/src/adapters/cega/ethereum/index.ts
@@ -3,7 +3,7 @@ import { getCegaBalances } from '@adapters/cega/ethereum/farm'
 import type { BaseContext, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
 
-const vaultAddresses: string[] = [
+const vaultAddresses: `0x${string}`[] = [
   '0x80ec1c0da9bfbb8229a1332d40615c5ba2abbea8',
   '0xcf81b51aecf6d88df12ed492b7b7f95bbc24b8af',
   '0xab8631417271dbb928169f060880e289877ff158',

--- a/src/adapters/coinwind/common/balance.ts
+++ b/src/adapters/coinwind/common/balance.ts
@@ -26,7 +26,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getCoinwindBalances(
   ctx: BalancesContext,
@@ -35,13 +35,13 @@ export async function getCoinwindBalances(
 ): Promise<Balance[]> {
   const userInfosRes = await multicall({
     ctx,
-    calls: pools.map((pool) => ({ target: masterchef.address, params: [pool.pid, ctx.address] })),
+    calls: pools.map((pool) => ({ target: masterchef.address, params: [pool.pid, ctx.address] } as const)),
     abi: abi.userInfo,
   })
 
   const balances: Balance[] = mapSuccessFilter(userInfosRes, (res, idx: number) => ({
     ...pools[idx],
-    amount: BigNumber.from(res.output.amount),
+    amount: BigNumber.from(res.output[0]),
     underlyings: undefined,
     rewards: undefined,
     category: 'farm',

--- a/src/adapters/coinwind/common/contract.ts
+++ b/src/adapters/coinwind/common/contract.ts
@@ -54,13 +54,15 @@ export async function getCoinWindContracts(ctx: BaseContext, masterchef: Contrac
 
   const poolInfosRes = await multicall({
     ctx,
-    calls: range(0, Number(poolLengthBI)).map((_, idx) => ({ target: masterchef.address, params: [idx] })),
+    calls: range(0, Number(poolLengthBI)).map(
+      (_, idx) => ({ target: masterchef.address, params: [BigInt(idx)] } as const),
+    ),
     abi: abi.poolInfo,
   })
 
   const contracts: Contract[] = mapSuccessFilter(poolInfosRes, (res, idx: number) => ({
     chain: ctx.chain,
-    address: res.output.token,
+    address: res.output[0],
     pid: idx,
   }))
 

--- a/src/adapters/compound-v3/common/rewards.ts
+++ b/src/adapters/compound-v3/common/rewards.ts
@@ -1,7 +1,6 @@
 import type { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { multicall } from '@lib/multicall'
 import type { Token } from '@lib/token'
-import { isSuccess } from '@lib/type'
 import { BigNumber } from 'ethers'
 
 const abi = {
@@ -25,7 +24,7 @@ const abi = {
     stateMutability: 'nonpayable',
     type: 'function',
   },
-}
+} as const
 
 const COMP: Token = {
   chain: 'ethereum',
@@ -43,14 +42,16 @@ export async function getRewardBalances(
 
   const pendingCompRewardsRes = await multicall({
     ctx,
-    calls: compounders.map((contract) => ({ target: rewarder.address, params: [contract.address, ctx.address] })),
+    calls: compounders.map(
+      (contract) => ({ target: rewarder.address, params: [contract.address, ctx.address] } as const),
+    ),
     abi: abi.getRewardOwed,
   })
 
   for (let idx = 0; idx < compounders.length; idx++) {
     const pendingCompRewardRes = pendingCompRewardsRes[idx]
 
-    if (!isSuccess(pendingCompRewardRes)) {
+    if (!pendingCompRewardRes.success) {
       continue
     }
 

--- a/src/adapters/compound-v3/common/stake.ts
+++ b/src/adapters/compound-v3/common/stake.ts
@@ -1,7 +1,6 @@
 import type { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { abi } from '@lib/erc20'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 import { BigNumber } from 'ethers'
 
 export async function getStakeBalances(ctx: BalancesContext, contracts: Contract[]): Promise<Balance[]> {
@@ -9,7 +8,7 @@ export async function getStakeBalances(ctx: BalancesContext, contracts: Contract
 
   const balanceOfsRes = await multicall({
     ctx,
-    calls: contracts.map((contract) => ({ target: contract.address, params: [ctx.address] })),
+    calls: contracts.map((contract) => ({ target: contract.address, params: [ctx.address] } as const)),
     abi: abi.balanceOf,
   })
 
@@ -19,7 +18,7 @@ export async function getStakeBalances(ctx: BalancesContext, contracts: Contract
 
     const balanceOfRes = balanceOfsRes[idx]
 
-    if (!isSuccess(balanceOfRes)) {
+    if (!balanceOfRes.success) {
       continue
     }
 

--- a/src/adapters/concentrator/ethereum/pool.ts
+++ b/src/adapters/concentrator/ethereum/pool.ts
@@ -4,7 +4,6 @@ import { call } from '@lib/call'
 import { ADDRESS_ZERO } from '@lib/contract'
 import { multicall } from '@lib/multicall'
 import { ETH_ADDR } from '@lib/token'
-import { isSuccess } from '@lib/type'
 
 const abi = {
   poolLength: {
@@ -133,26 +132,29 @@ export async function getPoolsContracts(ctx: BaseContext, contracts: Contract[])
 
     const poolInfosRes = await multicall({
       ctx,
-      calls: range(0, poolsCount).map((i) => ({
-        target: contract.address,
-        params: [i],
-      })),
+      calls: range(0, poolsCount).map(
+        (i) =>
+          ({
+            target: contract.address,
+            params: [BigInt(i)],
+          } as const),
+      ),
       abi: abi.poolInfo,
     })
 
     for (let idx = 0; idx < poolsCount; idx++) {
       const poolInfoRes = poolInfosRes[idx]
-      if (!isSuccess(poolInfoRes)) {
+      if (!poolInfoRes.success) {
         continue
       }
 
-      const { lpToken: address, convexPoolId, crvRewards } = poolInfoRes.output
+      const [_totalUnderlying, _totalShare, _accRewardPerShare, convexPoolId, lpToken, crvRewards] = poolInfoRes.output
       pools.push({
         chain: ctx.chain,
-        address,
+        address: lpToken,
         pid: idx,
         convexPoolId,
-        lpToken: address,
+        lpToken,
         crvRewards,
         vaultName: contract.name,
         vaultAddress: poolInfoRes.input.target,
@@ -162,17 +164,20 @@ export async function getPoolsContracts(ctx: BaseContext, contracts: Contract[])
 
     const poolsAddressesRes = await multicall({
       ctx,
-      calls: pools.map(({ address }) => ({
-        target: metaRegistry.address,
-        params: [address],
-      })),
+      calls: pools.map(
+        ({ address }) =>
+          ({
+            target: metaRegistry.address,
+            params: [address],
+          } as const),
+      ),
       abi: abi.getPoolFromLPToken,
     })
 
     for (let poolIdx = 0; poolIdx < pools.length; poolIdx++) {
       const pool = pools[poolIdx]
       const poolAddressRes = poolsAddressesRes[poolIdx]
-      if (!isSuccess(poolAddressRes)) {
+      if (!poolAddressRes.success) {
         continue
       }
 
@@ -181,17 +186,20 @@ export async function getPoolsContracts(ctx: BaseContext, contracts: Contract[])
 
     const underlyingsRes = await multicall({
       ctx,
-      calls: pools.map(({ pool }) => ({
-        target: metaRegistry.address,
-        params: [pool],
-      })),
+      calls: pools.map(
+        ({ pool }) =>
+          ({
+            target: metaRegistry.address,
+            params: [pool],
+          } as const),
+      ),
       abi: abi.getUnderlyingsCoins,
     })
 
     for (let poolIdx = 0; poolIdx < pools.length; poolIdx++) {
       const pool = pools[poolIdx]
       const underlyingRes = underlyingsRes[poolIdx]
-      if (!isSuccess(underlyingRes)) {
+      if (!underlyingRes.success) {
         continue
       }
 
@@ -215,16 +223,19 @@ export async function getOldContracts(ctx: BaseContext, contract: Contract): Pro
 
   const poolInfosRes = await multicall({
     ctx,
-    calls: range(0, poolsCount).map((i) => ({
-      target: contract.address,
-      params: [i],
-    })),
+    calls: range(0, poolsCount).map(
+      (i) =>
+        ({
+          target: contract.address,
+          params: [BigInt(i)],
+        } as const),
+    ),
     abi: abi.poolInfoOld,
   })
 
   for (let idx = 0; idx < poolsCount; idx++) {
     const poolInfoRes = poolInfosRes[idx]
-    if (!isSuccess(poolInfoRes)) {
+    if (!poolInfoRes.success) {
       continue
     }
 
@@ -241,17 +252,20 @@ export async function getOldContracts(ctx: BaseContext, contract: Contract): Pro
 
   const poolsAddressesRes = await multicall({
     ctx,
-    calls: pools.map(({ address }) => ({
-      target: metaRegistry.address,
-      params: [address],
-    })),
+    calls: pools.map(
+      ({ address }) =>
+        ({
+          target: metaRegistry.address,
+          params: [address],
+        } as const),
+    ),
     abi: abi.getPoolFromLPToken,
   })
 
   for (let poolIdx = 0; poolIdx < pools.length; poolIdx++) {
     const pool = pools[poolIdx]
     const poolAddressRes = poolsAddressesRes[poolIdx]
-    if (!isSuccess(poolAddressRes)) {
+    if (!poolAddressRes.success) {
       continue
     }
 
@@ -260,17 +274,20 @@ export async function getOldContracts(ctx: BaseContext, contract: Contract): Pro
 
   const underlyingsRes = await multicall({
     ctx,
-    calls: pools.map(({ pool }) => ({
-      target: metaRegistry.address,
-      params: [pool],
-    })),
+    calls: pools.map(
+      ({ pool }) =>
+        ({
+          target: metaRegistry.address,
+          params: [pool],
+        } as const),
+    ),
     abi: abi.getUnderlyingsCoins,
   })
 
   for (let poolIdx = 0; poolIdx < pools.length; poolIdx++) {
     const pool = pools[poolIdx]
     const underlyingRes = underlyingsRes[poolIdx]
-    if (!isSuccess(underlyingRes)) {
+    if (!underlyingRes.success) {
       continue
     }
 

--- a/src/adapters/convex-finance/common/pool.ts
+++ b/src/adapters/convex-finance/common/pool.ts
@@ -44,15 +44,18 @@ export async function getConvexAltChainsPools(
 
   const poolInfosRes = await multicall({
     ctx,
-    calls: range(0, Number(poolLengthBI)).map((i) => ({
-      target: booster.address,
-      params: [i],
-    })),
+    calls: range(0, Number(poolLengthBI)).map(
+      (i) =>
+        ({
+          target: booster.address,
+          params: [BigInt(i)],
+        } as const),
+    ),
     abi: abi.poolInfo,
   })
 
   const pools: Contract[] = mapSuccessFilter(poolInfosRes, (res) => {
-    const { lptoken: address, rewards, gauge, factory } = res.output
+    const [address, gauge, rewards, _shutdown, factory] = res.output
 
     return {
       chain: ctx.chain,

--- a/src/adapters/curve-dex/common/gauges.ts
+++ b/src/adapters/curve-dex/common/gauges.ts
@@ -3,7 +3,6 @@ import { ADDRESS_ZERO } from '@lib/contract'
 import type { Call } from '@lib/multicall'
 import { multicall } from '@lib/multicall'
 import type { Token } from '@lib/token'
-import { isSuccess } from '@lib/type'
 
 const abi = {
   get_gauge_from_lp_token: {
@@ -21,12 +20,12 @@ const abi = {
     outputs: [{ name: '', type: 'address' }],
     gas: 3787,
   },
-}
+} as const
 
 export async function getGaugesContracts(ctx: BaseContext, pools: Contract[], gaugeFactory: Contract, CRV: Token) {
   const gauges: Contract[] = []
 
-  const calls: Call[] = []
+  const calls: Call<typeof abi.get_gauge_from_lp_token>[] = []
   for (const pool of pools) {
     calls.push({ target: gaugeFactory.address, params: [pool.lpToken] })
   }
@@ -37,15 +36,15 @@ export async function getGaugesContracts(ctx: BaseContext, pools: Contract[], ga
     const pool = pools[idx]
     const gauge = gaugesAddressesRes[idx]
 
-    if (!isSuccess(gauge) || gauge.output === ADDRESS_ZERO) {
+    if (!gauge.success || gauge.output === ADDRESS_ZERO) {
       continue
     }
     gauges.push({ ...pool, address: gauge.output, gauge: gauge.output, rewards: [CRV] })
   }
 
-  const gaugeRewardsCalls: Call[] = []
+  const gaugeRewardsCalls: Call<typeof abi.reward_tokens>[] = []
   for (const gauge of gauges) {
-    gaugeRewardsCalls.push({ target: gauge.address, params: [0] })
+    gaugeRewardsCalls.push({ target: gauge.address, params: [0n] })
   }
 
   const rewardsTokensRes = await multicall({ ctx, calls: gaugeRewardsCalls, abi: abi.reward_tokens })
@@ -54,7 +53,7 @@ export async function getGaugesContracts(ctx: BaseContext, pools: Contract[], ga
     const gauge = gauges[gaugeIdx]
     const rewardTokenRes = rewardsTokensRes[gaugeIdx]
 
-    if (!isSuccess(rewardTokenRes) || rewardTokenRes.output === ADDRESS_ZERO) {
+    if (!rewardTokenRes.success || rewardTokenRes.output === ADDRESS_ZERO) {
       continue
     }
     gauge!.rewards?.push(rewardTokenRes.output)

--- a/src/adapters/curve-dex/common/registries.ts
+++ b/src/adapters/curve-dex/common/registries.ts
@@ -32,9 +32,9 @@ export const Registries: { [key in Registry]: number } = {
 }
 
 export const getRegistries = async (ctx: BaseContext, registries: Registry[]) => {
-  const res: Partial<Record<Registry, string>> = {}
+  const res: Partial<Record<Registry, `0x${string}`>> = {}
 
-  const registriesAddressRes = await multicall<string, [number], string>({
+  const registriesAddressRes = await multicall({
     ctx,
     calls: registries.map((id) => ({
       params: [Registries[id]],
@@ -53,5 +53,5 @@ export const getRegistries = async (ctx: BaseContext, registries: Registry[]) =>
     res[registries[i]] = registriesAddressRes[i].output
   }
 
-  return res as Record<Registry, string>
+  return res
 }

--- a/src/adapters/equalizer-exchange/fantom/pair.ts
+++ b/src/adapters/equalizer-exchange/fantom/pair.ts
@@ -69,9 +69,9 @@ export interface Token {
 }
 
 export interface GaugeContract extends Contract {
-  token: string
-  bribeAddress?: string
-  feesAddress?: string
+  token: `0x${string}`
+  bribeAddress?: `0x${string}`
+  feesAddress?: `0x${string}`
 }
 
 export async function getPairsContracts(ctx: BaseContext) {

--- a/src/adapters/euler/common/markets.ts
+++ b/src/adapters/euler/common/markets.ts
@@ -3,6 +3,20 @@ import { call } from '@lib/call'
 import { ethers, utils } from 'ethers'
 import { gql, request } from 'graphql-request'
 
+const abi = {
+  getAccountStatus: {
+    inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
+    name: 'getAccountStatus',
+    outputs: [
+      { internalType: 'uint256', name: 'collateralValue', type: 'uint256' },
+      { internalType: 'uint256', name: 'liabilityValue', type: 'uint256' },
+      { internalType: 'uint256', name: 'healthScore', type: 'uint256' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
 const THE_GRAPH_URL = 'https://api.thegraph.com/subgraphs/name/euler-xyz/euler-mainnet'
 
 const marketsQuery = gql`
@@ -55,17 +69,7 @@ export async function getHealthFactor(ctx: BalancesContext, lensContract: Contra
     ctx,
     target: lensContract.address,
     params: [ctx.address],
-    abi: {
-      inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
-      name: 'getAccountStatus',
-      outputs: [
-        { internalType: 'uint256', name: 'collateralValue', type: 'uint256' },
-        { internalType: 'uint256', name: 'liabilityValue', type: 'uint256' },
-        { internalType: 'uint256', name: 'healthScore', type: 'uint256' },
-      ],
-      stateMutability: 'view',
-      type: 'function',
-    },
+    abi: abi.getAccountStatus,
   })
 
   if (ethers.constants.MaxUint256.eq(healthScore)) {

--- a/src/adapters/fantohm/fantom/locker.ts
+++ b/src/adapters/fantohm/fantom/locker.ts
@@ -1,7 +1,6 @@
 import type { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { multicall } from '@lib/multicall'
 import type { Token } from '@lib/token'
-import { isSuccess } from '@lib/type'
 import { BigNumber } from 'ethers'
 
 const abi = {
@@ -12,7 +11,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const FHM: Token = {
   chain: 'fantom',
@@ -25,7 +24,7 @@ export async function getFantohmLockerBalances(ctx: BalancesContext, lockers: Co
   const balances: Balance[] = []
   const balancesOfsRes = await multicall({
     ctx,
-    calls: lockers.map((locker) => ({ target: locker.address, params: [ctx.address] })),
+    calls: lockers.map((locker) => ({ target: locker.address, params: [ctx.address] } as const)),
     abi: abi.balanceOfVotingToken,
   })
 
@@ -33,7 +32,7 @@ export async function getFantohmLockerBalances(ctx: BalancesContext, lockers: Co
     const locker = lockers[lockerIdx]
     const balancesOfRes = balancesOfsRes[lockerIdx]
 
-    if (!isSuccess(balancesOfRes)) {
+    if (!balancesOfRes.success) {
       continue
     }
 

--- a/src/adapters/fantohm/fantom/vest.ts
+++ b/src/adapters/fantohm/fantom/vest.ts
@@ -3,7 +3,6 @@ import { BN_ZERO } from '@lib/math'
 import { multicall } from '@lib/multicall'
 import { providers } from '@lib/providers'
 import type { Token } from '@lib/token'
-import { isSuccess } from '@lib/type'
 import { BigNumber } from 'ethers'
 
 const abi = {
@@ -19,7 +18,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const FHM: Token = {
   chain: 'fantom',
@@ -34,7 +33,7 @@ export async function getFHMVesterBalances(ctx: BalancesContext, vesters: Contra
 
   const bondInfosRes = await multicall({
     ctx,
-    calls: vesters.map((vester) => ({ target: vester.address, params: [ctx.address] })),
+    calls: vesters.map((vester) => ({ target: vester.address, params: [ctx.address] } as const)),
     abi: abi.bondInfo,
   })
 
@@ -42,17 +41,19 @@ export async function getFHMVesterBalances(ctx: BalancesContext, vesters: Contra
     const vester = vesters[vesterIdx]
     const bondInfoRes = bondInfosRes[vesterIdx]
 
-    if (!isSuccess(bondInfoRes)) {
+    if (!bondInfoRes.success) {
       continue
     }
 
+    const [payout, _vesting, lastBlock] = bondInfoRes.output
+
     const provider = providers[ctx.chain]
-    const unlockAt = (await provider.getBlock(parseInt(bondInfoRes.output.lastBlock))).timestamp
+    const unlockAt = Number((await provider.getBlock({ blockNumber: lastBlock })).timestamp)
 
     balances.push({
       ...vester,
-      amount: BigNumber.from(bondInfoRes.output.payout),
-      claimable: now > unlockAt ? BigNumber.from(bondInfoRes.output.payout) : BN_ZERO,
+      amount: BigNumber.from(payout),
+      claimable: now > unlockAt ? BigNumber.from(payout) : BN_ZERO,
       unlockAt,
       decimals: 9,
       underlyings: [FHM],

--- a/src/adapters/flamincome/ethereum/stake.ts
+++ b/src/adapters/flamincome/ethereum/stake.ts
@@ -1,7 +1,6 @@
 import type { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { abi as erc20Abi } from '@lib/erc20'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 import { BigNumber, utils } from 'ethers'
 
 const abi = {
@@ -12,7 +11,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getFlamincomeFarmBalances(ctx: BalancesContext, farmers: Contract[]): Promise<Balance[]> {
   const balances: Balance[] = []
@@ -20,7 +19,7 @@ export async function getFlamincomeFarmBalances(ctx: BalancesContext, farmers: C
   const [balancesOfsRes, exchangeRatesRes] = await Promise.all([
     multicall({
       ctx,
-      calls: farmers.map((farmer) => ({ target: farmer.address, params: [ctx.address] })),
+      calls: farmers.map((farmer) => ({ target: farmer.address, params: [ctx.address] } as const)),
       abi: erc20Abi.balanceOf,
     }),
     multicall({
@@ -36,7 +35,7 @@ export async function getFlamincomeFarmBalances(ctx: BalancesContext, farmers: C
     const balanceOfRes = balancesOfsRes[farmerIdx]
     const exchangeRateRes = exchangeRatesRes[farmerIdx]
 
-    if (!underlying || !isSuccess(balanceOfRes) || !isSuccess(exchangeRateRes)) {
+    if (!underlying || !balanceOfRes.success || !exchangeRateRes.success) {
       continue
     }
 

--- a/src/adapters/frax-finance/arbitrum/providers/curve.ts
+++ b/src/adapters/frax-finance/arbitrum/providers/curve.ts
@@ -1,8 +1,7 @@
 import type { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { abi as erc20Abi } from '@lib/erc20'
-import { BN_ZERO, isZero } from '@lib/math'
+import { BN_ZERO } from '@lib/math'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 import { BigNumber } from 'ethers'
 
 const abi = {
@@ -14,7 +13,7 @@ const abi = {
     outputs: [{ name: '', type: 'uint256[2]' }],
     gas: 4707,
   },
-}
+} as const
 
 import type { ProviderBalancesParams } from '../../providers/interface'
 
@@ -33,12 +32,7 @@ export const curveBalancesProvider = async (
     const underlyingsBalanceRes = underlyingsBalancesRes[poolIdx]
     const poolSupplyRes = poolSuppliesRes[poolIdx]
 
-    if (
-      !underlyings ||
-      !isSuccess(underlyingsBalanceRes) ||
-      !isSuccess(poolSupplyRes) ||
-      isZero(poolSupplyRes.output)
-    ) {
+    if (!underlyings || !underlyingsBalanceRes.success || !poolSupplyRes.success || poolSupplyRes.output === 0n) {
       continue
     }
 

--- a/src/adapters/frax-finance/ethereum/balance.ts
+++ b/src/adapters/frax-finance/ethereum/balance.ts
@@ -3,7 +3,6 @@ import { groupBy } from '@lib/array'
 import { BN_ZERO } from '@lib/math'
 import type { Call } from '@lib/multicall'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 import { BigNumber } from 'ethers/lib/ethers'
 
 import { aaveBalancesProvider } from '../providers/aave'
@@ -31,12 +30,15 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getFraxBalances(ctx: BalancesContext, pools: Contract[]): Promise<Balance[]> {
   const balances: Balance[] = []
 
-  const calls: Call[] = pools.map((pool) => ({ target: pool.stakeAddress, params: [ctx.address] }))
+  const calls: Call<typeof abi.lockedLiquidityOf>[] = pools.map((pool) => ({
+    target: pool.stakeAddress,
+    params: [ctx.address],
+  }))
 
   const [balancesOfsRes, earnedsRes] = await Promise.all([
     multicall({ ctx, calls, abi: abi.lockedLiquidityOf }),
@@ -50,15 +52,17 @@ export async function getFraxBalances(ctx: BalancesContext, pools: Contract[]): 
     }
 
     rewards.forEach((reward, idx) => {
+      const earnedRes = earnedsRes[poolIdx]
+
       ;(reward as Balance).amount =
-        isSuccess(earnedsRes[poolIdx]) && earnedsRes[poolIdx].output.length > 0
-          ? BigNumber.from(earnedsRes[poolIdx].output[idx])
-          : BN_ZERO
+        earnedRes.success && earnedRes.output.length > 0 ? BigNumber.from(earnedRes.output[idx]) : BN_ZERO
     })
+
+    const balanceOf = balancesOfsRes[poolIdx]
 
     balances.push({
       ...pool,
-      amount: isSuccess(balancesOfsRes[poolIdx]) ? BigNumber.from(balancesOfsRes[poolIdx].output) : BN_ZERO,
+      amount: balanceOf.success ? BigNumber.from(balanceOf.output) : BN_ZERO,
       rewards: rewards as Balance[],
       underlyings: pool.underlyings as Contract[],
       category: 'farm',

--- a/src/adapters/frax-finance/ethereum/locker.ts
+++ b/src/adapters/frax-finance/ethereum/locker.ts
@@ -1,7 +1,7 @@
 import type { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { getSingleLockerBalances } from '@lib/lock'
 import { multicall } from '@lib/multicall'
-import { isNotNullish, isSuccess } from '@lib/type'
+import { isNotNullish } from '@lib/type'
 import { BigNumber } from 'ethers'
 
 const abi = {
@@ -12,7 +12,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getFraxLockerBalances(ctx: BalancesContext, lockers: Contract[]): Promise<Balance[]> {
   const balances: Balance[] = []
@@ -21,7 +21,7 @@ export async function getFraxLockerBalances(ctx: BalancesContext, lockers: Contr
     getSingleLockerBalances(ctx, lockers, 'locked'),
     multicall({
       ctx,
-      calls: lockers.map((locker) => ({ target: locker.rewarder, params: [ctx.address] })),
+      calls: lockers.map((locker) => ({ target: locker.rewarder, params: [ctx.address] } as const)),
       abi: abi.earned,
     }),
   ])
@@ -32,7 +32,7 @@ export async function getFraxLockerBalances(ctx: BalancesContext, lockers: Contr
       const reward = lockedBalance.underlyings?.[0] as Contract
       const incentiveEarnedRes = incentivesEarnedRes[idx]
 
-      if (!isSuccess(incentiveEarnedRes)) {
+      if (!incentiveEarnedRes.success) {
         return null
       }
 

--- a/src/adapters/frax-finance/providers/fraxpool.ts
+++ b/src/adapters/frax-finance/providers/fraxpool.ts
@@ -1,6 +1,5 @@
 import type { BalancesContext, BaseContext, Contract } from '@lib/adapter'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 import { utils } from 'ethers'
 
 import type { ProviderBalancesParams } from './interface'
@@ -13,7 +12,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export const fraxpoolProvider = async (_ctx: BaseContext, pools: Contract[]): Promise<Contract[]> => {
   for (const pool of pools) {
@@ -37,7 +36,7 @@ export const fraxpoolBalancesProvider = async (
     const pool = pools[poolIdx]
     const fmtBalanceOfRes = fmtBalancesOfRes[poolIdx]
 
-    if (!isSuccess(fmtBalanceOfRes)) {
+    if (!fmtBalanceOfRes.success) {
       continue
     }
 

--- a/src/adapters/frax-finance/providers/interface.ts
+++ b/src/adapters/frax-finance/providers/interface.ts
@@ -2,11 +2,11 @@ import type { Balance } from '@lib/adapter'
 import type { BigNumber } from 'ethers'
 
 export type ProviderBalancesParams = Balance & {
-  stakeAddress?: string
+  stakeAddress?: `0x${string}`
   amount: BigNumber
   totalSupply: BigNumber
-  lpToken: string
+  lpToken: `0x{string}`
   provider: string
-  curvePool?: string
-  uniPoolAddress?: string
+  curvePool?: `0x${string}`
+  uniPoolAddress?: `0x${string}`
 }

--- a/src/adapters/fraxlend/ethereum/registry.ts
+++ b/src/adapters/fraxlend/ethereum/registry.ts
@@ -1,7 +1,6 @@
 import type { BaseContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 
 const abi = {
   collateralContract: {
@@ -20,7 +19,7 @@ const abi = {
   },
 } as const
 
-export async function getPairsContracts(ctx: BaseContext, registry: string) {
+export async function getPairsContracts(ctx: BaseContext, registry: `0x${string}`) {
   const contracts: Contract[] = []
 
   const pairs = await call({
@@ -33,7 +32,6 @@ export async function getPairsContracts(ctx: BaseContext, registry: string) {
     ctx,
     calls: pairs.map((address) => ({
       target: address,
-      params: [],
     })),
     abi: abi.collateralContract,
   })
@@ -42,7 +40,7 @@ export async function getPairsContracts(ctx: BaseContext, registry: string) {
     const pair = pairs[pairIdx]
     const collateralContractRes = collateralContractsRes[pairIdx]
 
-    if (!isSuccess(collateralContractRes)) {
+    if (!collateralContractRes.success) {
       continue
     }
 

--- a/src/adapters/gmx/common/vault.ts
+++ b/src/adapters/gmx/common/vault.ts
@@ -1,8 +1,7 @@
 import type { BaseContext, Contract } from '@lib/adapter'
-import { range } from '@lib/array'
+import { mapSuccessFilter, range } from '@lib/array'
 import { call } from '@lib/call'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 
 const abi = {
   allWhitelistedTokensLength: {
@@ -34,14 +33,13 @@ export async function getVaultTokens(ctx: BaseContext, vault: Contract) {
 
   const allWhitelistedTokensLength = Number(allWhitelistedTokensLengthRes)
 
-  const allWhitelistedTokensRes = await multicall<string, [number], string>({
+  const allWhitelistedTokensRes = await multicall({
     ctx,
-    calls: range(0, allWhitelistedTokensLength).map((idx) => ({
-      target: vault.address,
-      params: [idx],
-    })),
+    calls: range(0, allWhitelistedTokensLength).map(
+      (idx) => ({ target: vault.address, params: [BigInt(idx)] } as const),
+    ),
     abi: abi.allWhitelistedTokens,
   })
 
-  return allWhitelistedTokensRes.filter(isSuccess).map((res) => res.output)
+  return mapSuccessFilter(allWhitelistedTokensRes, (res) => res.output)
 }

--- a/src/adapters/gro/avalanche/index.ts
+++ b/src/adapters/gro/avalanche/index.ts
@@ -4,7 +4,7 @@ import { resolveBalances } from '@lib/balance'
 import { getYieldBalances } from '../common/balance'
 import { getYieldContracts } from '../common/contract'
 
-const poolsAddresses: string[] = [
+const poolsAddresses: `0x${string}`[] = [
   '0x2eb05cffa24309b9aaf300392a4d8db745d4e592', // USDC.e
   '0x6063597b9356b246e706fd6a48c780f897e3ef55', // DAI.e
   '0x471f4b4b9a97f82c3a25b034b33a8e306ee9beb5', // USDT.e

--- a/src/adapters/hex/ethereum/reward.ts
+++ b/src/adapters/hex/ethereum/reward.ts
@@ -5,10 +5,10 @@ import { BigNumber } from 'ethers'
 
 interface stakeAndIndexParams {
   stakeId: number
-  stake: string
-  share: string
-  stakedDays: string
-  lockedDays: string
+  stake: bigint
+  share: bigint
+  stakedDays: number
+  lockedDays: number
 }
 
 interface decodedDataParams {

--- a/src/adapters/hex/ethereum/stake.ts
+++ b/src/adapters/hex/ethereum/stake.ts
@@ -1,69 +1,71 @@
 import type { Balance, BalancesContext, Contract } from '@lib/adapter'
-import { range } from '@lib/array'
+import { mapSuccessFilter, range } from '@lib/array'
 import { call } from '@lib/call'
 import { sumBN } from '@lib/math'
 import { multicall } from '@lib/multicall'
+import { BigNumber } from 'ethers'
 
 import { getRewardsBalances } from './reward'
+
+const abi = {
+  stakeCount: {
+    constant: true,
+    inputs: [{ internalType: 'address', name: 'stakerAddr', type: 'address' }],
+    name: 'stakeCount',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  stakeLists: {
+    constant: true,
+    inputs: [
+      { internalType: 'address', name: '', type: 'address' },
+      { internalType: 'uint256', name: '', type: 'uint256' },
+    ],
+    name: 'stakeLists',
+    outputs: [
+      { internalType: 'uint40', name: 'stakeId', type: 'uint40' },
+      { internalType: 'uint72', name: 'stakedHearts', type: 'uint72' },
+      { internalType: 'uint72', name: 'stakeShares', type: 'uint72' },
+      { internalType: 'uint16', name: 'lockedDay', type: 'uint16' },
+      { internalType: 'uint16', name: 'stakedDays', type: 'uint16' },
+      { internalType: 'uint16', name: 'unlockedDay', type: 'uint16' },
+      { internalType: 'bool', name: 'isAutoStake', type: 'bool' },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
 
 export async function getStakeBalances(ctx: BalancesContext, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
 
-  const stakeCountRes = await call({
-    ctx,
-    target: contract.address,
-    params: [ctx.address],
-    abi: {
-      constant: true,
-      inputs: [{ internalType: 'address', name: 'stakerAddr', type: 'address' }],
-      name: 'stakeCount',
-      outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-      payable: false,
-      stateMutability: 'view',
-      type: 'function',
-    },
-  })
+  const stakeCountRes = await call({ ctx, target: contract.address, params: [ctx.address], abi: abi.stakeCount })
 
   const findStakesAndIndexesRes = await multicall({
     ctx,
-    calls: range(0, Number(stakeCountRes)).map((i) => ({
-      target: contract.address,
-      params: [ctx.address, i],
-    })),
-    abi: {
-      constant: true,
-      inputs: [
-        { internalType: 'address', name: '', type: 'address' },
-        { internalType: 'uint256', name: '', type: 'uint256' },
-      ],
-      name: 'stakeLists',
-      outputs: [
-        { internalType: 'uint40', name: 'stakeId', type: 'uint40' },
-        { internalType: 'uint72', name: 'stakedHearts', type: 'uint72' },
-        { internalType: 'uint72', name: 'stakeShares', type: 'uint72' },
-        { internalType: 'uint16', name: 'lockedDay', type: 'uint16' },
-        { internalType: 'uint16', name: 'stakedDays', type: 'uint16' },
-        { internalType: 'uint16', name: 'unlockedDay', type: 'uint16' },
-        { internalType: 'bool', name: 'isAutoStake', type: 'bool' },
-      ],
-      payable: false,
-      stateMutability: 'view',
-      type: 'function',
-    },
+    calls: range(0, Number(stakeCountRes)).map(
+      (i) => ({ target: contract.address, params: [ctx.address, BigInt(i)] } as const),
+    ),
+    abi: abi.stakeLists,
   })
 
-  const stakesAndIndexes = findStakesAndIndexesRes
-    .filter((res) => res.success)
-    .map((res, i) => ({
-      id: i,
-      stakeId: res.output.stakeId,
-      stake: res.output.stakedHearts,
-      share: res.output.stakeShares,
-      stakedDays: res.output.stakedDays,
-      lockedDays: res.output.lockedDay,
-    }))
+  const stakesAndIndexes = mapSuccessFilter(findStakesAndIndexesRes, (res, i) => {
+    const [stakeId, stakedHearts, stakeShares, lockedDay, stakedDays, _unlockedDay, _isAutoStake] = res.output
 
-  const amount = sumBN(stakesAndIndexes.map((balance) => balance.stake))
+    return {
+      id: i,
+      stakeId: stakeId,
+      stake: stakedHearts,
+      share: stakeShares,
+      stakedDays: stakedDays,
+      lockedDays: lockedDay,
+    }
+  })
+
+  const amount = sumBN(stakesAndIndexes.map((balance) => BigNumber.from(balance.stake)))
 
   const rewards = await getRewardsBalances(ctx, contract, stakesAndIndexes)
   const totalRewards = sumBN(rewards)

--- a/src/adapters/homora-v2/avalanche/index.ts
+++ b/src/adapters/homora-v2/avalanche/index.ts
@@ -4,7 +4,7 @@ import { resolveBalances } from '@lib/balance'
 import { getHomoraBalances } from '../common/balance'
 import { getPoolsContract } from '../common/contract'
 
-const pools = [
+const pools: `0x${string}`[] = [
   '0x21C630B7824D15BcDFeefA73CBd4e49cAfe9F836', // AVAX
   '0x858D6353A52c25C53Df1869230282d22b41f5790', // USDT.e
   '0xD3843b60e69f958eF93BeC299467e6Ed301CbEeB', // USDC.e

--- a/src/adapters/homora-v2/common/balance.ts
+++ b/src/adapters/homora-v2/common/balance.ts
@@ -4,7 +4,6 @@ import { BN_TEN, isZero } from '@lib/math'
 import type { Call } from '@lib/multicall'
 import { multicall } from '@lib/multicall'
 import type { Token } from '@lib/token'
-import { isSuccess } from '@lib/type'
 
 const abi = {
   exchangeRateCurrent: {
@@ -16,12 +15,12 @@ const abi = {
     stateMutability: 'nonpayable',
     type: 'function',
   },
-}
+} as const
 
 export async function getHomoraBalances(ctx: BalancesContext, contracts: Contract[]): Promise<Balance[]> {
   const balances: Balance[] = []
 
-  const calls: Call[] = []
+  const calls: Call<typeof abi.exchangeRateCurrent>[] = []
   for (const contract of contracts) {
     calls.push({ target: contract.cToken })
   }
@@ -35,7 +34,7 @@ export async function getHomoraBalances(ctx: BalancesContext, contracts: Contrac
     const tokensBalance = tokensBalances[balanceIdx]
     const exchangeRatesOf = exchangeRatesOfs[balanceIdx]
 
-    if (isZero(tokensBalance.amount) || !isSuccess(exchangeRatesOf)) {
+    if (isZero(tokensBalance.amount) || !exchangeRatesOf.success) {
       continue
     }
 

--- a/src/adapters/homora-v2/common/contract.ts
+++ b/src/adapters/homora-v2/common/contract.ts
@@ -28,9 +28,9 @@ const abi = {
     stateMutability: 'nonpayable',
     type: 'function',
   },
-}
+} as const
 
-export async function getPoolsContract(ctx: BaseContext, pools: string[]): Promise<Contract[]> {
+export async function getPoolsContract(ctx: BaseContext, pools: `0x${string}`[]): Promise<Contract[]> {
   const cTokensRes = await multicall({ ctx, calls: pools.map((pool) => ({ target: pool })), abi: abi.cToken })
 
   const underlyingsTokens = await multicall({

--- a/src/adapters/homora-v2/ethereum/index.ts
+++ b/src/adapters/homora-v2/ethereum/index.ts
@@ -4,7 +4,7 @@ import { resolveBalances } from '@lib/balance'
 import { getHomoraBalances } from '../common/balance'
 import { getPoolsContract } from '../common/contract'
 
-const pools = [
+const pools: `0x${string}`[] = [
   '0xeEa3311250FE4c3268F8E684f7C87A82fF183Ec1', // ETH
   '0xee8389d235E092b2945fE363e97CDBeD121A0439', // DAI
   '0x020eDC614187F9937A1EfEeE007656C6356Fb13A', // USDT

--- a/src/adapters/homora-v2/fantom/index.ts
+++ b/src/adapters/homora-v2/fantom/index.ts
@@ -4,7 +4,7 @@ import { resolveBalances } from '@lib/balance'
 import { getHomoraBalances } from '../common/balance'
 import { getPoolsContract } from '../common/contract'
 
-const pools = [
+const pools: `0x${string}`[] = [
   '0xfFE5030Da862Ff61aeF933303C3d124Ca3C65AF6', //  FTM
   '0x5196e0a4fb2A459856e1D41Ab4975316BbdF19F8', // USDC
   '0xa575163C0DA0bEc6887b5BC01be7231FA7Cb2c0b', // ETH

--- a/src/adapters/homora-v2/optimism/index.ts
+++ b/src/adapters/homora-v2/optimism/index.ts
@@ -4,7 +4,7 @@ import { resolveBalances } from '@lib/balance'
 import { getHomoraBalances } from '../common/balance'
 import { getPoolsContract } from '../common/contract'
 
-const pools = [
+const pools: `0x${string}`[] = [
   '0x14bC6Cf95a8BEFD4B07e0f824c60bC1401fE9D23', // WETH
   '0xbCb8b7Ce255aD6268924407342b78c065Df5986d', // DAI
   '0x080a165204Af7665dc980BD093125125A2Bca375', // USDC

--- a/src/adapters/illuvium/ethereum/contract.ts
+++ b/src/adapters/illuvium/ethereum/contract.ts
@@ -1,7 +1,6 @@
 import type { BaseContext, Contract } from '@lib/adapter'
 import { multicall } from '@lib/multicall'
 import type { Token } from '@lib/token'
-import { isSuccess } from '@lib/type'
 
 import type { IPools } from '.'
 
@@ -13,7 +12,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const ILV: Token = {
   chain: 'ethereum',
@@ -23,7 +22,7 @@ const ILV: Token = {
 }
 
 export interface ILVContract extends Contract {
-  token: string
+  token: `0x${string}`
 }
 
 export async function getILVContracts(ctx: BaseContext, pools: IPools[]): Promise<Contract[]> {
@@ -38,7 +37,7 @@ export async function getILVContracts(ctx: BaseContext, pools: IPools[]): Promis
   pools.forEach(async (pool, poolIdx) => {
     const poolTokenRes = poolTokensRes[poolIdx]
 
-    if (!isSuccess(poolTokenRes)) {
+    if (!poolTokenRes.success) {
       return
     }
 

--- a/src/adapters/illuvium/ethereum/index.ts
+++ b/src/adapters/illuvium/ethereum/index.ts
@@ -5,7 +5,7 @@ import { getILVBalances } from './balance'
 import { getILVContracts } from './contract'
 
 export interface IPools {
-  address: string
+  address: `0x${string}`
   provider: string
   staker: string
 }

--- a/src/adapters/iron-bank/optimism/farm.ts
+++ b/src/adapters/iron-bank/optimism/farm.ts
@@ -2,7 +2,6 @@ import type { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { keyBy } from '@lib/array'
 import { abi as erc20Abi } from '@lib/erc20'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 import { BigNumber, utils } from 'ethers'
 
 const abi = {
@@ -25,7 +24,7 @@ const abi = {
     stateMutability: 'nonpayable',
     type: 'function',
   },
-}
+} as const
 
 const pools: Contract[] = [
   {
@@ -120,12 +119,12 @@ export async function getIronFarmBalances(ctx: BalancesContext, markets: Contrac
   const [balanceOfsRes, earnedOfsRes, exchangeRatesCurrentsRes] = await Promise.all([
     multicall({
       ctx,
-      calls: contracts.map((contract) => ({ target: contract.staker, params: [ctx.address] })),
+      calls: contracts.map((contract) => ({ target: contract.staker, params: [ctx.address] } as const)),
       abi: erc20Abi.balanceOf,
     }),
     multicall({
       ctx,
-      calls: contracts.map((contract) => ({ target: contract.staker, params: [IB.address, ctx.address] })),
+      calls: contracts.map((contract) => ({ target: contract.staker, params: [IB.address, ctx.address] } as const)),
       abi: abi.earned,
     }),
     multicall({
@@ -142,7 +141,7 @@ export async function getIronFarmBalances(ctx: BalancesContext, markets: Contrac
     const earnedOfRes = earnedOfsRes[marketIdx]
     const exchangeRatesCurrentRes = exchangeRatesCurrentsRes[marketIdx]
 
-    if (!isSuccess(balanceOfRes) || !isSuccess(earnedOfRes) || !isSuccess(exchangeRatesCurrentRes)) {
+    if (!balanceOfRes.success || !earnedOfRes.success || !exchangeRatesCurrentRes.success) {
       continue
     }
 

--- a/src/adapters/liqee/common/balance.ts
+++ b/src/adapters/liqee/common/balance.ts
@@ -6,6 +6,27 @@ import type { Token } from '@lib/token'
 import { isNotNullish } from '@lib/type'
 import { BigNumber } from 'ethers'
 
+const abi = {
+  borrowBalanceCurrent: {
+    constant: false,
+    inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
+    name: 'borrowBalanceCurrent',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  exchangeRateCurrent: {
+    constant: false,
+    inputs: [],
+    name: 'exchangeRateCurrent',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+} as const
+
 export async function getMarketsBalances(ctx: BalancesContext, contracts: Contract[]): Promise<Balance[]> {
   const cTokenByAddress: { [key: string]: Contract } = {}
   for (const contract of contracts) {
@@ -17,36 +38,14 @@ export async function getMarketsBalances(ctx: BalancesContext, contracts: Contra
 
     multicall({
       ctx,
-      calls: contracts.map((token) => ({
-        target: token.address,
-        params: [ctx.address],
-      })),
-      abi: {
-        constant: false,
-        inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
-        name: 'borrowBalanceCurrent',
-        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-        payable: false,
-        stateMutability: 'nonpayable',
-        type: 'function',
-      },
+      calls: contracts.map((token) => ({ target: token.address, params: [ctx.address] } as const)),
+      abi: abi.borrowBalanceCurrent,
     }),
 
     multicall({
       ctx,
-      calls: contracts.map((token) => ({
-        target: token.address,
-        params: [],
-      })),
-      abi: {
-        constant: false,
-        inputs: [],
-        name: 'exchangeRateCurrent',
-        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-        payable: false,
-        stateMutability: 'nonpayable',
-        type: 'function',
-      },
+      calls: contracts.map((token) => ({ target: token.address })),
+      abi: abi.exchangeRateCurrent,
     }),
   ])
 

--- a/src/adapters/llama-airforce/ethereum/balance.ts
+++ b/src/adapters/llama-airforce/ethereum/balance.ts
@@ -2,15 +2,14 @@ import type { Balance, BalancesContext, Contract, FarmBalance } from '@lib/adapt
 import { groupBy } from '@lib/array'
 import { abi as erc20Abi } from '@lib/erc20'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 import { BigNumber } from 'ethers'
 
 import { convexProvider, curveProvider, llamaProvider } from './provider'
 
 export interface LlamaBalancesParams extends FarmBalance {
   provider: string
-  lpToken?: string
-  pool?: string
+  lpToken?: `0x${string}`
+  pool?: `0x${string}`
 }
 
 export async function getLlamaBalances(ctx: BalancesContext, pools: Contract[]): Promise<Balance[]> {
@@ -18,7 +17,7 @@ export async function getLlamaBalances(ctx: BalancesContext, pools: Contract[]):
 
   const balanceOfsRes = await multicall({
     ctx,
-    calls: pools.map((pool) => ({ target: pool.address, params: [ctx.address] })),
+    calls: pools.map((pool) => ({ target: pool.address, params: [ctx.address] } as const)),
     abi: erc20Abi.balanceOf,
   })
 
@@ -26,7 +25,7 @@ export async function getLlamaBalances(ctx: BalancesContext, pools: Contract[]):
     const pool = pools[poolIdx]
     const balanceOfRes = balanceOfsRes[poolIdx]
 
-    if (!isSuccess(balanceOfRes)) {
+    if (!balanceOfRes.success) {
       continue
     }
 

--- a/src/adapters/lusd-chickenbonds/ethereum/chickenBondManager.ts
+++ b/src/adapters/lusd-chickenbonds/ethereum/chickenBondManager.ts
@@ -40,21 +40,9 @@ const abi = {
 
 export async function getBondNFTContract(ctx: BaseContext) {
   const [bondNFTRes, lusdTokenRes, bLUSDTokenRes] = await Promise.all([
-    call({
-      ctx,
-      target: chickenBondManager.address,
-      abi: abi.bondNFT,
-    }),
-    call({
-      ctx,
-      target: chickenBondManager.address,
-      abi: abi.lusdToken,
-    }),
-    call({
-      ctx,
-      target: chickenBondManager.address,
-      abi: abi.bLUSDToken,
-    }),
+    call({ ctx, target: chickenBondManager.address, abi: abi.bondNFT }),
+    call({ ctx, target: chickenBondManager.address, abi: abi.lusdToken }),
+    call({ ctx, target: chickenBondManager.address, abi: abi.bLUSDToken }),
   ])
 
   const contract: Contract = {
@@ -67,13 +55,10 @@ export async function getBondNFTContract(ctx: BaseContext) {
   return contract
 }
 
-export function getAccruedBLUSD(ctx: BalancesContext, tokenIDs: number[]) {
+export function getAccruedBLUSD(ctx: BalancesContext, tokenIDs: bigint[]) {
   return multicall({
     ctx,
-    calls: tokenIDs.map((tokenID) => ({
-      target: chickenBondManager.address,
-      params: [tokenID],
-    })),
+    calls: tokenIDs.map((tokenID) => ({ target: chickenBondManager.address, params: [tokenID] } as const)),
     abi: abi.calcAccruedBLUSD,
   })
 }

--- a/src/adapters/lyra/common/lp.ts
+++ b/src/adapters/lyra/common/lp.ts
@@ -1,7 +1,6 @@
 import type { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { abi as erc20Abi } from '@lib/erc20'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 import { BigNumber, utils } from 'ethers'
 
 const abi = {
@@ -12,7 +11,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getLpLyraBalances(ctx: BalancesContext, contracts: Contract[]): Promise<Balance[]> {
   const balances: Balance[] = []
@@ -20,7 +19,7 @@ export async function getLpLyraBalances(ctx: BalancesContext, contracts: Contrac
   const [balancesOfsRes, multiplierTokensRes] = await Promise.all([
     multicall({
       ctx,
-      calls: contracts.map((contract) => ({ target: contract.staker, params: [ctx.address] })),
+      calls: contracts.map((contract) => ({ target: contract.staker, params: [ctx.address] } as const)),
       abi: erc20Abi.balanceOf,
     }),
     multicall({
@@ -36,7 +35,7 @@ export async function getLpLyraBalances(ctx: BalancesContext, contracts: Contrac
     const multiplierTokenRes = multiplierTokensRes[idx]
     const underlyings = contract.underlyings as Contract[]
 
-    if (!isSuccess(balancesOfRes) || !isSuccess(multiplierTokenRes)) {
+    if (!balancesOfRes.success || !multiplierTokenRes.success) {
       continue
     }
 

--- a/src/adapters/maple/ethereum/farm.ts
+++ b/src/adapters/maple/ethereum/farm.ts
@@ -1,6 +1,5 @@
 import type { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 import { BigNumber } from 'ethers'
 
 const abi = {
@@ -11,14 +10,14 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getMapleFarmBalances(ctx: BalancesContext, farmers: Contract[]): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const balanceOfsRes = await multicall({
     ctx,
-    calls: farmers.map((farmer) => ({ target: farmer.address, params: [ctx.address] })),
+    calls: farmers.map((farmer) => ({ target: farmer.address, params: [ctx.address] } as const)),
     abi: abi.balanceOfAssets,
   })
 
@@ -26,7 +25,7 @@ export async function getMapleFarmBalances(ctx: BalancesContext, farmers: Contra
     const farmer = farmers[farmerIdx]
     const balanceOfRes = balanceOfsRes[farmerIdx]
 
-    if (!isSuccess(balanceOfRes)) {
+    if (!balanceOfRes.success) {
       continue
     }
 

--- a/src/adapters/metronome/ethereum/balance.ts
+++ b/src/adapters/metronome/ethereum/balance.ts
@@ -1,7 +1,6 @@
 import type { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { abi as erc20Abi } from '@lib/erc20'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 import { BigNumber, utils } from 'ethers'
 
 const abi = {
@@ -12,7 +11,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getMetronomeBalances(ctx: BalancesContext, markets: Contract[]): Promise<Balance[]> {
   const balances: Balance[] = []
@@ -20,34 +19,32 @@ export async function getMetronomeBalances(ctx: BalancesContext, markets: Contra
   const [balanceOfsRes, pricePerSharesRes] = await Promise.all([
     multicall({
       ctx,
-      calls: markets.map((market) => ({ target: market.address, params: [ctx.address] })),
+      calls: markets.map((market) => ({ target: market.address, params: [ctx.address] } as const)),
       abi: erc20Abi.balanceOf,
     }),
     multicall({
       ctx,
-      calls: markets.map((market) => ({ target: market.token })),
+      calls: markets.map((market) => (market.token ? { target: market.token } : null)),
       abi: abi.pricePerShare,
     }),
   ])
 
   for (let marketIdx = 0; marketIdx < markets.length; marketIdx++) {
     const market = markets[marketIdx]
-    const { underlyings, category } = market
+    const { underlyings } = market
     const balanceOfRes = balanceOfsRes[marketIdx]
-    const pricePerShareRes = isSuccess(pricePerSharesRes[marketIdx])
-      ? pricePerSharesRes[marketIdx].output
-      : utils.parseEther('1.0')
+    const pricePerShareRes = pricePerSharesRes[marketIdx]
+    const pricePerShare = pricePerShareRes.success ? pricePerShareRes.output : utils.parseEther('1.0')
 
-    if (!isSuccess(balanceOfRes) || !pricePerShareRes) {
+    if (!balanceOfRes.success || !pricePerShare) {
       continue
     }
 
     balances.push({
-      ...market,
-      amount: BigNumber.from(balanceOfRes.output).mul(pricePerShareRes).div(utils.parseEther('1.0')),
+      ...(market as Balance),
+      amount: BigNumber.from(balanceOfRes.output).mul(pricePerShare).div(utils.parseEther('1.0')),
       underlyings: underlyings as Contract[],
       rewards: undefined,
-      category,
     })
   }
 

--- a/src/adapters/metronome/ethereum/contract.ts
+++ b/src/adapters/metronome/ethereum/contract.ts
@@ -2,7 +2,6 @@ import type { BaseContext, Contract } from '@lib/adapter'
 import { mapSuccess } from '@lib/array'
 import { call } from '@lib/call'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 
 const abi = {
   getDepositTokens: {
@@ -93,12 +92,12 @@ export async function getMetronomeContracts(ctx: BaseContext, contract: Contract
   for (let depositIdx = 0; depositIdx < depositTokensRes.length; depositIdx++) {
     const depositTokenRes = depositTokensRes[depositIdx]
     const token = tokens[depositIdx]
-    const underlying = isSuccess(underlyings[depositIdx])
+    const underlying = underlyings[depositIdx].success
       ? underlyings[depositIdx].output
       : underlyings[depositIdx].input.target
     const collateralFactor = collateralFactors[depositIdx]
 
-    if (!isSuccess(token) || !isSuccess(collateralFactor) || !underlying) {
+    if (!token.success || !collateralFactor.success || !underlying) {
       continue
     }
 
@@ -116,7 +115,7 @@ export async function getMetronomeContracts(ctx: BaseContext, contract: Contract
     const debtTokenRes = debtTokensRes[debtIdx]
     const syntheticToken = syntheticTokens[debtIdx]
 
-    if (!isSuccess(syntheticToken)) {
+    if (!syntheticToken.success) {
       continue
     }
 

--- a/src/adapters/olympus-dao/common/stake.ts
+++ b/src/adapters/olympus-dao/common/stake.ts
@@ -4,7 +4,6 @@ import { call } from '@lib/call'
 import { abi } from '@lib/erc20'
 import type { Call } from '@lib/multicall'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 import { BigNumber } from 'ethers/lib/ethers'
 
 const abiOlympus = {
@@ -28,7 +27,7 @@ const OHM: Contract = {
 export async function getStakeBalances(ctx: BalancesContext, stakers: Contract[]) {
   const balances: Balance[] = []
 
-  const calls: Call[] = []
+  const calls: Call<typeof abi.balanceOf>[] = []
   for (const staker of stakers) {
     calls.push({ target: staker.address, params: [ctx.address] })
   }
@@ -39,7 +38,7 @@ export async function getStakeBalances(ctx: BalancesContext, stakers: Contract[]
     const staker = stakers[idx]
     const balanceOfRes = balancesOfRes[idx]
 
-    if (!isSuccess(balanceOfRes)) {
+    if (!balanceOfRes.success) {
       continue
     }
 

--- a/src/adapters/pancakeswap/bsc/stake.ts
+++ b/src/adapters/pancakeswap/bsc/stake.ts
@@ -67,7 +67,10 @@ const cake: Token = {
 export async function getStakersBalances(ctx: BalancesContext, stakers: Contract[]) {
   const balances: Balance[] = []
 
-  const calls: Call[] = stakers.map((staker) => ({ target: staker.address, params: [ctx.address] }))
+  const calls: Call<typeof abi.userInfo>[] = stakers.map((staker) => ({
+    target: staker.address,
+    params: [ctx.address],
+  }))
 
   const [userBalanceOfRes, pendingRewardsRes] = await Promise.all([
     multicall({ ctx, calls, abi: abi.userInfo }),
@@ -76,7 +79,7 @@ export async function getStakersBalances(ctx: BalancesContext, stakers: Contract
 
   for (let stakerIdx = 0; stakerIdx < stakers.length; stakerIdx++) {
     const staker = stakers[stakerIdx]
-    const amount = BigNumber.from(userBalanceOfRes[stakerIdx].output?.amount || '0')
+    const amount = BigNumber.from(userBalanceOfRes[stakerIdx].output?.[0] || '0')
     const rewardsAmount = BigNumber.from(pendingRewardsRes[stakerIdx].output || '0')
 
     balances.push({

--- a/src/adapters/piedao/ethereum/lock.ts
+++ b/src/adapters/piedao/ethereum/lock.ts
@@ -41,14 +41,16 @@ export async function getPieDaoLockerBalances(ctx: BalancesContext, locker: Cont
 
   const locksOfRes = await multicall({
     ctx,
-    calls: range(0, Number(getLocksOfLength)).map((_, idx) => ({ target: locker.address, params: [ctx.address, idx] })),
+    calls: range(0, Number(getLocksOfLength)).map(
+      (_, idx) => ({ target: locker.address, params: [ctx.address, BigInt(idx)] } as const),
+    ),
     abi: abi.locksOf,
   })
 
   const test: LockBalance[] = mapSuccessFilter(locksOfRes, (res) => {
-    const { lockedAt, lockDuration, amount } = res.output
+    const [amount, lockedAt, lockDuration] = res.output
 
-    const unlockAt = parseInt(lockedAt) + parseInt(lockDuration)
+    const unlockAt = Number(lockedAt + lockDuration)
     const isClaimable = now > unlockAt
 
     return {

--- a/src/adapters/piedao/ethereum/providers/balancer.ts
+++ b/src/adapters/piedao/ethereum/providers/balancer.ts
@@ -3,7 +3,6 @@ import { groupBy, mapSuccessFilter } from '@lib/array'
 import { abi as erc20Abi } from '@lib/erc20'
 import type { Call } from '@lib/multicall'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 import { BigNumber } from 'ethers'
 
 const abi = {
@@ -16,12 +15,12 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export const balancerProvider = async (ctx: BalancesContext, pools: Balance[]): Promise<Balance[]> => {
   const balances: Balance[] = []
 
-  const calls: Call[] = pools.flatMap((pool) =>
+  const calls: Call<typeof abi.getBalance>[] = pools.flatMap((pool) =>
     pool.underlyings!.map((underlying) => ({ target: pool.address, params: [underlying.address] })),
   )
 
@@ -44,7 +43,7 @@ export const balancerProvider = async (ctx: BalancesContext, pools: Balance[]): 
     const underlyings = pool.underlyings as Contract[]
     const poolSupplyRes = poolSuppliesRes[poolIdx]
 
-    if (!underlyings || !isSuccess(poolSupplyRes)) {
+    if (!underlyings || !poolSupplyRes.success) {
       continue
     }
 

--- a/src/adapters/piedao/ethereum/stake.ts
+++ b/src/adapters/piedao/ethereum/stake.ts
@@ -11,12 +11,12 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getPieDaoStakeBalances(ctx: BalancesContext, stakers: Contract[]): Promise<Balance[]> {
   const userBalances = await multicall({
     ctx,
-    calls: stakers.map((staker) => ({ target: staker.address, params: [ctx.address] })),
+    calls: stakers.map((staker) => ({ target: staker.address, params: [ctx.address] } as const)),
     abi: abi.ethBalanceOf,
   })
 

--- a/src/adapters/popsicle-finance/common/yield.ts
+++ b/src/adapters/popsicle-finance/common/yield.ts
@@ -1,8 +1,6 @@
 import type { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { abi as erc20Abi } from '@lib/erc20'
-import { isZero } from '@lib/math'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 import { BigNumber } from 'ethers'
 
 const abi = {
@@ -16,7 +14,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getPopsicleYieldBalances(ctx: BalancesContext, pairs: Contract[]): Promise<Balance[]> {
   const balances: Balance[] = []
@@ -24,7 +22,7 @@ export async function getPopsicleYieldBalances(ctx: BalancesContext, pairs: Cont
   const [balancesOfsRes, tokensAmounts, totalSuppliesRes] = await Promise.all([
     multicall({
       ctx,
-      calls: pairs.map((pair) => ({ target: pair.address, params: [ctx.address] })),
+      calls: pairs.map((pair) => ({ target: pair.address, params: [ctx.address] } as const)),
       abi: erc20Abi.balanceOf,
     }),
     multicall({
@@ -48,10 +46,10 @@ export async function getPopsicleYieldBalances(ctx: BalancesContext, pairs: Cont
 
     if (
       !underlyings ||
-      !isSuccess(balancesOfRes) ||
-      !isSuccess(tokensAmount) ||
-      !isSuccess(totalSupplyRes) ||
-      isZero(totalSupplyRes.output)
+      !balancesOfRes.success ||
+      !tokensAmount.success ||
+      !totalSupplyRes.success ||
+      totalSupplyRes.output === 0n
     ) {
       continue
     }

--- a/src/adapters/quickswap-dex/polygon/stake.ts
+++ b/src/adapters/quickswap-dex/polygon/stake.ts
@@ -1,6 +1,5 @@
 import type { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 import { BigNumber } from 'ethers'
 
 const abi = {
@@ -11,14 +10,14 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getQuickswapBalances(ctx: BalancesContext, stakers: Contract[]): Promise<Balance[]> {
   const balances: Balance[] = []
 
   const balancesOfsRes = await multicall({
     ctx,
-    calls: stakers.map((staker) => ({ target: staker.address, params: [ctx.address] })),
+    calls: stakers.map((staker) => ({ target: staker.address, params: [ctx.address] } as const)),
     abi: abi.QUICKBalance,
   })
 
@@ -27,7 +26,7 @@ export async function getQuickswapBalances(ctx: BalancesContext, stakers: Contra
     const underlyings = staker.underlyings as Contract[]
     const balancesOfRes = balancesOfsRes[stakerIdx]
 
-    if (!isSuccess(balancesOfRes)) {
+    if (!balancesOfRes.success) {
       continue
     }
 

--- a/src/adapters/radiant-v2/arbitrum/multifee.ts
+++ b/src/adapters/radiant-v2/arbitrum/multifee.ts
@@ -1,10 +1,10 @@
 import type { Balance, BalancesContext, BaseContext, Contract } from '@lib/adapter'
+import { mapSuccessFilter } from '@lib/array'
 import { call } from '@lib/call'
 import { abi as erc20Abi } from '@lib/erc20'
 import { BN_ZERO, sumBN } from '@lib/math'
 import { multicall } from '@lib/multicall'
 import type { Token } from '@lib/token'
-import { isSuccess } from '@lib/type'
 import { BigNumber } from 'ethers'
 
 const abi = {
@@ -141,7 +141,7 @@ export async function getMultiFeeDistributionContracts(
     ...stakingToken,
     address: multiFeeDistribution.address,
     token: stakingToken.address,
-    rewards: underlyingsTokensRes.filter(isSuccess).map((token) => token.output),
+    rewards: mapSuccessFilter(underlyingsTokensRes, (token) => token.output),
   }
 }
 
@@ -164,7 +164,7 @@ export async function getMultiFeeDistributionBalances(
     call({ ctx, target: params.multiFeeDistribution.address, params: [ctx.address], abi: abi.lockedBalances }),
     call({ ctx, target: params.multiFeeDistribution.address, params: [ctx.address], abi: abi.earnedBalances }),
     call({ ctx, target: params.multiFeeDistribution.address, abi: abi.rewardConverter }),
-    call({ ctx, target: contract.token as string, abi: erc20Abi.totalSupply }),
+    call({ ctx, target: contract.token!, abi: erc20Abi.totalSupply }),
     call({ ctx, target: contract.vault, params: [contract.poolId], abi: abi.getPoolTokens }),
   ])
   const [total, _unlockable, _locked, _lockedWithMultiplier, lockData] = lockedBalances

--- a/src/adapters/redacted/ethereum/vest.ts
+++ b/src/adapters/redacted/ethereum/vest.ts
@@ -3,7 +3,6 @@ import { BN_ZERO } from '@lib/math'
 import { multicall } from '@lib/multicall'
 import { providers } from '@lib/providers'
 import type { Token } from '@lib/token'
-import { isSuccess } from '@lib/type'
 import { BigNumber } from 'ethers'
 
 const abi = {
@@ -19,7 +18,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 const BTRFLY: Token = {
   chain: 'ethereum',
@@ -34,7 +33,7 @@ export async function getRedactedVesterBalances(ctx: BalancesContext, vesters: C
 
   const bondInfosRes = await multicall({
     ctx,
-    calls: vesters.map((vester) => ({ target: vester.address, params: [ctx.address] })),
+    calls: vesters.map((vester) => ({ target: vester.address, params: [ctx.address] } as const)),
     abi: abi.bondInfo,
   })
 
@@ -42,17 +41,19 @@ export async function getRedactedVesterBalances(ctx: BalancesContext, vesters: C
     const vester = vesters[vesterIdx]
     const bondInfoRes = bondInfosRes[vesterIdx]
 
-    if (!isSuccess(bondInfoRes)) {
+    if (!bondInfoRes.success) {
       continue
     }
 
+    const [payout, _vesting, lastBlock] = bondInfoRes.output
+
     const provider = providers[ctx.chain]
-    const unlockAt = (await provider.getBlock(parseInt(bondInfoRes.output.lastBlock))).timestamp
+    const unlockAt = Number((await provider.getBlock({ blockNumber: lastBlock })).timestamp)
 
     balances.push({
       ...vester,
-      amount: BigNumber.from(bondInfoRes.output.payout),
-      claimable: now > unlockAt ? BigNumber.from(bondInfoRes.output.payout) : BN_ZERO,
+      amount: BigNumber.from(payout),
+      claimable: now > unlockAt ? BigNumber.from(payout) : BN_ZERO,
       unlockAt,
       underlyings: [BTRFLY],
       rewards: undefined,

--- a/src/adapters/rook/ethereum/stake.ts
+++ b/src/adapters/rook/ethereum/stake.ts
@@ -16,7 +16,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getRookStakeBalances(
   ctx: BalancesContext,
@@ -26,7 +26,7 @@ export async function getRookStakeBalances(
   const userBalancesRes = await multicall({
     ctx,
     calls: stakers.flatMap((staker) =>
-      tokenLists.map((underlying) => ({ target: staker.address, params: [underlying.address, ctx.address] })),
+      tokenLists.map((underlying) => ({ target: staker.address, params: [underlying.address, ctx.address] } as const)),
     ),
     abi: abi.underlyingBalance,
   })

--- a/src/adapters/set-protocol/ethereum/contract.ts
+++ b/src/adapters/set-protocol/ethereum/contract.ts
@@ -1,7 +1,6 @@
 import type { BaseContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 
 const abi = {
   getSets: {
@@ -33,7 +32,7 @@ export async function getSetProtocolPools(ctx: BaseContext, controller: Contract
 
   for (let idx = 0; idx < setsContractsRes.length; idx++) {
     const underlyingsRes = setsUnderlyingsRes[idx]
-    if (!isSuccess(underlyingsRes)) {
+    if (!underlyingsRes.success) {
       continue
     }
 

--- a/src/adapters/smoothy/common/stake.ts
+++ b/src/adapters/smoothy/common/stake.ts
@@ -30,7 +30,7 @@ const getSmoothyUnderlyingsBalances = async (ctx: BalancesContext, staker: Balan
   const [tokensBalancesRes, totalSupply] = await Promise.all([
     multicall({
       ctx,
-      calls: underlyings.map((_, idx) => ({ target: staker.address, params: [idx] })),
+      calls: underlyings.map((_, idx) => ({ target: staker.address, params: [BigInt(idx)] } as const)),
       abi: abi.getBalance,
     }),
     call({ ctx, target: staker.address, abi: erc20Abi.totalSupply }),

--- a/src/adapters/solidlizard/arbitrum/pair.ts
+++ b/src/adapters/solidlizard/arbitrum/pair.ts
@@ -151,9 +151,9 @@ export interface Token0Class {
 }
 
 export interface GaugeContract extends Contract {
-  token: string
-  bribeAddress?: string
-  feesAddress?: string
+  token: `0x${string}`
+  bribeAddress?: `0x${string}`
+  feesAddress?: `0x${string}`
 }
 
 export async function getPairsContracts(ctx: BaseContext) {

--- a/src/adapters/sommelier/ethereum/contract.ts
+++ b/src/adapters/sommelier/ethereum/contract.ts
@@ -10,12 +10,12 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
-export async function getSommelierContracts(ctx: BaseContext, pools: Contract[]): Promise<Contract[]> {
+export async function getSommelierContracts(ctx: BaseContext, pools: Contract[]) {
   const underlyings = await multicall({ ctx, calls: pools.map((pool) => ({ target: pool.address })), abi: abi.asset })
 
-  const contracts: Contract[] = mapSuccessFilter(underlyings, (res, idx: number) => ({
+  const contracts: Contract[] = mapSuccessFilter(underlyings, (res, idx) => ({
     ...pools[idx],
     underlyings: [res.output],
   }))

--- a/src/adapters/spool/ethereum/genesis.ts
+++ b/src/adapters/spool/ethereum/genesis.ts
@@ -1,7 +1,33 @@
-import type { Balance, BalancesContext, Contract } from '@lib/adapter'
+import type { Balance, BalancesContext, BaseBalance, Contract } from '@lib/adapter'
 import { multicall } from '@lib/multicall'
 import type { Token } from '@lib/token'
 import { BigNumber } from 'ethers'
+
+const abi = {
+  earned: {
+    inputs: [
+      { internalType: 'contract IERC20', name: 'token', type: 'address' },
+      { internalType: 'address', name: 'account', type: 'address' },
+    ],
+    name: 'earned',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  users: {
+    inputs: [{ internalType: 'address', name: '', type: 'address' }],
+    name: 'users',
+    outputs: [
+      { internalType: 'uint128', name: 'instantDeposit', type: 'uint128' },
+      { internalType: 'uint128', name: 'activeDeposit', type: 'uint128' },
+      { internalType: 'uint128', name: 'owed', type: 'uint128' },
+      { internalType: 'uint128', name: 'withdrawnDeposits', type: 'uint128' },
+      { internalType: 'uint128', name: 'shares', type: 'uint128' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
 
 const Spool: Token = {
   chain: 'ethereum',
@@ -16,55 +42,27 @@ export async function getYieldBalances(ctx: BalancesContext, pools: Contract[]) 
   const [getDeposit, getEarned] = await Promise.all([
     multicall({
       ctx,
-      calls: pools.map((pool) => ({
-        target: pool.address,
-        params: [ctx.address],
-      })),
-      abi: {
-        inputs: [{ internalType: 'address', name: '', type: 'address' }],
-        name: 'users',
-        outputs: [
-          { internalType: 'uint128', name: 'instantDeposit', type: 'uint128' },
-          { internalType: 'uint128', name: 'activeDeposit', type: 'uint128' },
-          { internalType: 'uint128', name: 'owed', type: 'uint128' },
-          { internalType: 'uint128', name: 'withdrawnDeposits', type: 'uint128' },
-          { internalType: 'uint128', name: 'shares', type: 'uint128' },
-        ],
-        stateMutability: 'view',
-        type: 'function',
-      },
+      calls: pools.map((pool) => ({ target: pool.address, params: [ctx.address] } as const)),
+      abi: abi.users,
     }),
 
     multicall({
       ctx,
-      calls: pools.map((pool) => ({
-        target: pool.address,
-        params: [Spool.address, ctx.address],
-      })),
-      abi: {
-        inputs: [
-          { internalType: 'contract IERC20', name: 'token', type: 'address' },
-          { internalType: 'address', name: 'account', type: 'address' },
-        ],
-        name: 'earned',
-        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-        stateMutability: 'view',
-        type: 'function',
-      },
+      calls: pools.map((pool) => ({ target: pool.address, params: [Spool.address, ctx.address] } as const)),
+      abi: abi.earned,
     }),
   ])
 
-  const deposits = getDeposit.filter((res) => res.success).map((res) => BigNumber.from(res.output.instantDeposit))
-  const earneds = getEarned.filter((res) => res.success).map((res) => BigNumber.from(res.output))
-
   for (let i = 0; i < pools.length; i++) {
     const pool = pools[i]
-    const deposit = deposits[i]
-    const earned = earneds[i]
-    const underlying = pool.underlyings?.[0]
-    if (!underlying) {
+    const depositRes = getDeposit[i]
+    const earnedRes = getEarned[i]
+    const underlying = pool.underlyings?.[0] as BaseBalance
+    if (!underlying || !depositRes.success || !earnedRes.success) {
       continue
     }
+
+    const [instantDeposit] = depositRes.output
 
     balances.push({
       chain: ctx.chain,
@@ -72,9 +70,9 @@ export async function getYieldBalances(ctx: BalancesContext, pools: Contract[]) 
       address: pool.address,
       symbol: underlying.symbol,
       decimals: underlying.decimals,
-      amount: deposit,
-      underlyings: [{ ...underlying, amount: deposit }],
-      rewards: [{ ...Spool, amount: earned }],
+      amount: BigNumber.from(instantDeposit),
+      underlyings: [{ ...underlying, amount: BigNumber.from(instantDeposit) }],
+      rewards: [{ ...Spool, amount: BigNumber.from(earnedRes.output) }],
       category: 'farm',
     })
   }

--- a/src/adapters/stargate/common/contract.ts
+++ b/src/adapters/stargate/common/contract.ts
@@ -1,6 +1,5 @@
 import type { BaseContext, Contract } from '@lib/adapter'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 
 const abi = {
   token: {
@@ -10,7 +9,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getStargateLpContracts(ctx: BaseContext, lpStakers: Contract[]): Promise<Contract[]> {
   const contracts: Contract[] = []
@@ -25,7 +24,7 @@ export async function getStargateLpContracts(ctx: BaseContext, lpStakers: Contra
     const lpStaker = lpStakers[stakerIdx]
     const underlyingRes = underlyingsRes[stakerIdx]
 
-    if (!isSuccess(underlyingRes)) {
+    if (!underlyingRes.success) {
       continue
     }
 

--- a/src/adapters/thena/bsc/pair.ts
+++ b/src/adapters/thena/bsc/pair.ts
@@ -7,7 +7,7 @@ export interface PairsResponse {
 }
 
 export interface Pair {
-  address: string
+  address: `0x${string}`
   symbol: string
   totalSupply: number
   tvl: number
@@ -24,9 +24,9 @@ export interface Gauge {
   projectedApr: number
   voteApr: number
   totalSupply: number
-  address: string
-  fee: string
-  bribe: string
+  address: `0x${string}`
+  fee: `0x${string}`
+  bribe: `0x${string}`
   weight: number
   weightPercent: number
   bribesInUsd: number
@@ -46,7 +46,7 @@ export interface Bribe {
 }
 
 export interface Token {
-  address: string
+  address: `0x${string}`
   symbol: string
   decimals: number
   reserve: number
@@ -60,9 +60,9 @@ export interface Meta {
 }
 
 export interface GaugeContract extends Contract {
-  token: string
-  bribeAddress?: string
-  feesAddress?: string
+  token: `0x${string}`
+  bribeAddress?: `0x${string}`
+  feesAddress?: `0x${string}`
 }
 
 export async function getPairsContracts(ctx: BaseContext) {

--- a/src/adapters/tokemak/ethereum/contract.ts
+++ b/src/adapters/tokemak/ethereum/contract.ts
@@ -1,7 +1,6 @@
 import type { BaseContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 
 const abi = {
   getPools: {
@@ -35,7 +34,7 @@ export async function getTokemakContracts(ctx: BaseContext, manager: Contract): 
     const getPoolsAddress = getPoolsAddresses[poolIdx]
     const underlyingsAddress = underlyingsAddresses[poolIdx]
 
-    if (!isSuccess(underlyingsAddress)) {
+    if (!underlyingsAddress.success) {
       continue
     }
 

--- a/src/adapters/vector/avalanche/locker.ts
+++ b/src/adapters/vector/avalanche/locker.ts
@@ -1,11 +1,62 @@
 import type { Balance, BalancesContext, Contract } from '@lib/adapter'
-import { range } from '@lib/array'
+import { mapSuccessFilter, range } from '@lib/array'
 import { call } from '@lib/call'
-import { abi } from '@lib/erc20'
+import { abi as erc20Abi } from '@lib/erc20'
 import { getERC20Details } from '@lib/erc20'
 import { multicall } from '@lib/multicall'
 import type { Token } from '@lib/token'
 import { BigNumber } from 'ethers'
+
+const abi = {
+  earned: {
+    inputs: [
+      { internalType: 'address', name: '_account', type: 'address' },
+      { internalType: 'address', name: '_rewardToken', type: 'address' },
+    ],
+    name: 'earned',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  getUserNthSlot: {
+    inputs: [
+      { internalType: 'address', name: '_user', type: 'address' },
+      { internalType: 'uint256', name: 'n', type: 'uint256' },
+    ],
+    name: 'getUserNthSlot',
+    outputs: [
+      { internalType: 'uint256', name: 'startTime', type: 'uint256' },
+      { internalType: 'uint256', name: 'endTime', type: 'uint256' },
+      { internalType: 'uint256', name: 'amount', type: 'uint256' },
+      { internalType: 'uint256', name: 'unlockingStrategy', type: 'uint256' },
+      { internalType: 'uint256', name: 'alreadyUnstaked', type: 'uint256' },
+      { internalType: 'uint256', name: 'alreadyWithdrawn', type: 'uint256' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  getUserSlotLength: {
+    inputs: [{ internalType: 'address', name: '_user', type: 'address' }],
+    name: 'getUserSlotLength',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  rewarder: {
+    inputs: [],
+    name: 'rewarder',
+    outputs: [{ internalType: 'contract IBaseRewardPoolLocker', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  rewardTokens: {
+    inputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    name: 'rewardTokens',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
 
 const VTX: Token = {
   chain: 'avalanche',
@@ -17,37 +68,9 @@ const VTX: Token = {
 export async function getLockerBalances(ctx: BalancesContext, contract: Contract): Promise<Balance[]> {
   const balances: Balance[] = []
   const [userTotalDepositRes, rewarderAddressRes, userExtraLockedSlots] = await Promise.all([
-    call({
-      ctx,
-      target: contract.address,
-      params: [ctx.address],
-      abi: abi.balanceOf,
-    }),
-
-    call({
-      ctx,
-      target: contract.address,
-      abi: {
-        inputs: [],
-        name: 'rewarder',
-        outputs: [{ internalType: 'contract IBaseRewardPoolLocker', name: '', type: 'address' }],
-        stateMutability: 'view',
-        type: 'function',
-      },
-    }),
-
-    call({
-      ctx,
-      target: contract.address,
-      params: [ctx.address],
-      abi: {
-        inputs: [{ internalType: 'address', name: '_user', type: 'address' }],
-        name: 'getUserSlotLength',
-        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-        stateMutability: 'view',
-        type: 'function',
-      },
-    }),
+    call({ ctx, target: contract.address, params: [ctx.address], abi: erc20Abi.balanceOf }),
+    call({ ctx, target: contract.address, abi: abi.rewarder }),
+    call({ ctx, target: contract.address, params: [ctx.address], abi: abi.getUserSlotLength }),
   ])
 
   const userTotalDeposit = BigNumber.from(userTotalDepositRes)
@@ -68,33 +91,20 @@ export async function getLockerBalances(ctx: BalancesContext, contract: Contract
 
   const extraUserLockedBySlotsRes = await multicall({
     ctx,
-    calls: range(0, Number(userExtraLockedSlots)).map((i) => ({
-      target: contract.address,
-      params: [ctx.address, i],
-    })),
-    abi: {
-      inputs: [
-        { internalType: 'address', name: '_user', type: 'address' },
-        { internalType: 'uint256', name: 'n', type: 'uint256' },
-      ],
-      name: 'getUserNthSlot',
-      outputs: [
-        { internalType: 'uint256', name: 'startTime', type: 'uint256' },
-        { internalType: 'uint256', name: 'endTime', type: 'uint256' },
-        { internalType: 'uint256', name: 'amount', type: 'uint256' },
-        { internalType: 'uint256', name: 'unlockingStrategy', type: 'uint256' },
-        { internalType: 'uint256', name: 'alreadyUnstaked', type: 'uint256' },
-        { internalType: 'uint256', name: 'alreadyWithdrawn', type: 'uint256' },
-      ],
-      stateMutability: 'view',
-      type: 'function',
-    },
+    calls: range(0, Number(userExtraLockedSlots)).map(
+      (i) => ({ target: contract.address, params: [ctx.address, BigInt(i)] } as const),
+    ),
+    abi: abi.getUserNthSlot,
   })
 
-  const extraUserLockedBySlots = extraUserLockedBySlotsRes
-    .filter((res) => res.success)
-    .map((res) => ({ amount: BigNumber.from(res.output.amount), endTime: res.output.endTime }))
-    .filter((res) => res.amount.gt(0))
+  const extraUserLockedBySlots = mapSuccessFilter(extraUserLockedBySlotsRes, (res) => {
+    const [_startTime, endTime, amount] = res.output
+    if (amount === 0n) {
+      return null
+    }
+
+    return { amount, endTime }
+  })
 
   for (const extraUserLockedBySlot of extraUserLockedBySlots) {
     balances.push({
@@ -102,9 +112,9 @@ export async function getLockerBalances(ctx: BalancesContext, contract: Contract
       address: contract.address,
       decimals: contract.decimals,
       symbol: contract.symbol,
-      amount: extraUserLockedBySlot.amount,
-      underlyings: [{ ...VTX, amount: extraUserLockedBySlot.amount }],
-      unlockAt: extraUserLockedBySlot.endTime,
+      amount: BigNumber.from(extraUserLockedBySlot.amount),
+      underlyings: [{ ...VTX, amount: BigNumber.from(extraUserLockedBySlot.amount) }],
+      unlockAt: Number(extraUserLockedBySlot.endTime),
       category: 'lock',
     })
   }
@@ -116,42 +126,21 @@ const lockedRewardsBalances = async (ctx: BalancesContext, rewarder: `0x${string
   const pendingRewardsTokensRes = await multicall({
     ctx,
     // There is no logic in the contracts to know the number of tokens in advance. Among all the contracts checked, 7 seems to be the maximum number of extra tokens used.
-    calls: range(0, 7).map((i) => ({
-      target: rewarder,
-      params: [i],
-    })),
-    abi: {
-      inputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-      name: 'rewardTokens',
-      outputs: [{ internalType: 'address', name: '', type: 'address' }],
-      stateMutability: 'view',
-      type: 'function',
-    },
+    calls: range(0, 7).map((i) => ({ target: rewarder, params: [BigInt(i)] } as const)),
+    abi: abi.rewardTokens,
   })
 
-  const pendingRewardsTokens = pendingRewardsTokensRes.filter((res) => res.success).map((res) => res.output)
+  const pendingRewardsTokens = mapSuccessFilter(pendingRewardsTokensRes, (res) => res.output)
   const rewardsTokens = await getERC20Details(ctx, pendingRewardsTokens)
 
   const pendingRewardsBalancesRes = await multicall({
     ctx,
-    calls: pendingRewardsTokens.map((token) => ({
-      target: rewarder,
-      params: [ctx.address, token],
-    })),
-    abi: {
-      inputs: [
-        { internalType: 'address', name: '_account', type: 'address' },
-        { internalType: 'address', name: '_rewardToken', type: 'address' },
-      ],
-      name: 'earned',
-      outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-      stateMutability: 'view',
-      type: 'function',
-    },
+    calls: pendingRewardsTokens.map((token) => ({ target: rewarder, params: [ctx.address, token] } as const)),
+    abi: abi.earned,
   })
-  const pendingRewardsBalances = pendingRewardsBalancesRes
-    .filter((res) => res.success)
-    .map((res) => BigNumber.from(res.output))
 
-  return rewardsTokens.map((token, i) => ({ ...token, amount: pendingRewardsBalances[i] }))
+  return mapSuccessFilter(pendingRewardsBalancesRes, (pendingRewardRes, idx) => ({
+    ...rewardsTokens[idx],
+    amount: BigNumber.from(pendingRewardRes.output),
+  }))
 }

--- a/src/adapters/velodrome/optimism/factory.ts
+++ b/src/adapters/velodrome/optimism/factory.ts
@@ -1,5 +1,4 @@
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 import type { getPairsContractsParams as getUniswapPairsContractsParams } from '@lib/uniswap/v2/factory'
 import { getPairsContracts as getUniswapPairsContracts } from '@lib/uniswap/v2/factory'
 
@@ -11,7 +10,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getPairsContracts({
   ctx,
@@ -26,7 +25,7 @@ export async function getPairsContracts({
   for (let pid = 0; pid < pairs.length; pid++) {
     const stableRes = stablesRes[pid]
 
-    if (isSuccess(stableRes)) {
+    if (stableRes.success) {
       pairs[pid].stable = stableRes.output
     }
   }

--- a/src/adapters/velodrome/optimism/gauge.ts
+++ b/src/adapters/velodrome/optimism/gauge.ts
@@ -2,7 +2,6 @@ import type { BalancesContext, BaseContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { multicall } from '@lib/multicall'
 import { getStakingPoolsBalances } from '@lib/pools'
-import { isSuccess } from '@lib/type'
 import { BigNumber } from 'ethers'
 
 import type { GaugeContract } from './pair'
@@ -44,7 +43,9 @@ export async function getGaugesBalances(ctx: BalancesContext, gauges: GaugeContr
     ctx,
     calls: stakingBalances.flatMap(
       (balance) =>
-        balance.rewards?.map((reward) => ({ target: balance.address, params: [reward.address, ctx.address] })) ?? [],
+        balance.rewards?.map(
+          (reward) => ({ target: balance.address, params: [reward.address, ctx.address] } as const),
+        ) ?? [],
     ),
     abi: abi.earned,
   })
@@ -59,7 +60,7 @@ export async function getGaugesBalances(ctx: BalancesContext, gauges: GaugeContr
     for (const reward of rewards) {
       const rewardRes = rewardsRes[rewardIdx]
 
-      if (isSuccess(rewardRes)) {
+      if (rewardRes.success) {
         reward.amount = BigNumber.from(rewardRes.output)
       }
 

--- a/src/adapters/verse/ethereum/contract.ts
+++ b/src/adapters/verse/ethereum/contract.ts
@@ -1,6 +1,5 @@
 import type { BaseContext, Contract } from '@lib/adapter'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 import { getPairsDetails } from '@lib/uniswap/v2/factory'
 
 const abi = {
@@ -11,7 +10,7 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-}
+} as const
 
 export async function getVerseContracts(ctx: BaseContext, pools: Contract[]): Promise<Contract[]> {
   const contracts: Contract[] = []
@@ -26,7 +25,7 @@ export async function getVerseContracts(ctx: BaseContext, pools: Contract[]): Pr
     const pool = pools[poolIdx]
     const tokenRes = tokensRes[poolIdx]
 
-    if (!isSuccess(tokenRes)) {
+    if (!tokenRes.success) {
       continue
     }
 

--- a/src/adapters/wonderland/avalanche/rewards.ts
+++ b/src/adapters/wonderland/avalanche/rewards.ts
@@ -1,8 +1,7 @@
 import type { BaseContext, Contract } from '@lib/adapter'
-import { range } from '@lib/array'
+import { mapSuccessFilter, range } from '@lib/array'
 import { call } from '@lib/call'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 
 const abiWonderland = {
   rewardTokenLength: {
@@ -45,14 +44,11 @@ export async function getRewardsMEMOFarmTokens(ctx: BaseContext, wMEMOFarm: Cont
 
   const rewardTokensRes = await multicall({
     ctx,
-    calls: range(0, rewardTokenLength).map((i) => ({
-      target: wMEMOFarm.address,
-      params: [i],
-    })),
+    calls: range(0, rewardTokenLength).map((i) => ({ target: wMEMOFarm.address, params: [BigInt(i)] } as const)),
     abi: abiWonderland.rewardTokens,
   })
 
-  const rewardTokens = rewardTokensRes.filter(isSuccess).map((res) => res.output)
+  const rewardTokens = mapSuccessFilter(rewardTokensRes, (res) => res.output)
 
   return {
     chain: ctx.chain,

--- a/src/adapters/zyberswap/arbitrum/balance.ts
+++ b/src/adapters/zyberswap/arbitrum/balance.ts
@@ -5,7 +5,6 @@ import { getMasterChefPoolsBalances } from '@lib/masterchef/masterchef'
 import type { Call } from '@lib/multicall'
 import { multicall } from '@lib/multicall'
 import type { Token } from '@lib/token'
-import { isSuccess } from '@lib/type'
 import type { Pair } from '@lib/uniswap/v2/factory'
 import { BigNumber } from 'ethers'
 
@@ -73,7 +72,7 @@ export async function getZyberFarmBalances(
     lpTokenAbi,
   )
 
-  const calls: Call[] = pairBalances.map((pair) => ({
+  const calls: Call<typeof abi.pendingTokens>[] = pairBalances.map((pair) => ({
     target: masterchef.address,
     params: [(pair as Contract).pid, ctx.address],
   }))
@@ -82,8 +81,9 @@ export async function getZyberFarmBalances(
 
   pairBalances.forEach((pair, idx) => {
     const pendingRewardRes = pendingRewardsRes[idx]
-    if (isSuccess(pendingRewardRes)) {
-      pair.rewards = [{ ...zyber, amount: BigNumber.from(pendingRewardRes.output.amounts[0]) }]
+    if (pendingRewardRes.success) {
+      const [_addresses, _symbols, _decimals, amounts] = pendingRewardRes.output
+      pair.rewards = [{ ...zyber, amount: BigNumber.from(amounts[0]) }]
     }
   })
 

--- a/src/handlers/updateBalances.ts
+++ b/src/handlers/updateBalances.ts
@@ -36,7 +36,7 @@ interface ExtendedBalancesConfig extends BalancesConfig {
 export const handler: APIGatewayProxyHandler = async (event, context) => {
   context.callbackWaitsForEmptyEventLoop = false // !important to reuse pool
 
-  const { address } = event as APIGatewayProxyEvent & { address?: string }
+  const { address } = event as APIGatewayProxyEvent & { address?: `0x${string}` }
 
   if (!address) {
     return badRequest('Missing address parameter')

--- a/src/lib/aave/v2/lending.ts
+++ b/src/lib/aave/v2/lending.ts
@@ -3,7 +3,6 @@ import { call } from '@lib/call'
 import { getERC20BalanceOf } from '@lib/erc20'
 import { multicall } from '@lib/multicall'
 import type { Token } from '@lib/token'
-import { isSuccess } from '@lib/type'
 import { BigNumber, ethers } from 'ethers'
 
 const abi = {
@@ -125,16 +124,15 @@ export async function getLendingPoolContracts(ctx: BaseContext, lendingPool: Con
 
   const reservesDataRes = await multicall({
     ctx,
-    calls: reservesList.map((reserveTokenAddress) => ({
-      target: lendingPool.address,
-      params: [reserveTokenAddress],
-    })),
+    calls: reservesList.map(
+      (reserveTokenAddress) => ({ target: lendingPool.address, params: [reserveTokenAddress] } as const),
+    ),
     abi: abi.getReserveData,
   })
 
   for (let i = 0; i < reservesDataRes.length; i++) {
     const reserveDataRes = reservesDataRes[i]
-    if (!isSuccess(reserveDataRes)) {
+    if (!reserveDataRes.success) {
       continue
     }
 

--- a/src/lib/adapter.ts
+++ b/src/lib/adapter.ts
@@ -9,7 +9,7 @@ export interface BaseContext {
 }
 
 export interface BalancesContext extends BaseContext {
-  address: `0x${string}`
+  readonly address: `0x${string}`
 }
 
 export type ContractStandard = 'erc20' | 'erc721'
@@ -22,7 +22,7 @@ export interface BaseContract {
   name?: string
   displayName?: string
   chain: Chain
-  address: `0x${string}`
+  readonly address: `0x${string}`
   // if specified, used to retrieve token details: symbol / decimals
   token?: `0x${string}`
   symbol?: string
@@ -34,14 +34,14 @@ export interface BaseContract {
 }
 
 export interface RawContract extends BaseContract {
-  rewards?: string[]
-  underlyings?: string[]
+  rewards?: `0x${string}`[]
+  underlyings?: `0x${string}`[]
   [key: string | number]: any
 }
 
 export interface Contract extends BaseContract {
-  rewards?: BaseContract[] | string[]
-  underlyings?: BaseContract[] | string[]
+  rewards?: BaseContract[] | `0x${string}`[]
+  underlyings?: BaseContract[] | `0x${string}`[]
   [key: string | number]: any
 }
 

--- a/src/lib/array.ts
+++ b/src/lib/array.ts
@@ -1,5 +1,5 @@
 import type { MultiCallResult } from '@lib/multicall'
-import { isNotNullish, isSuccess } from '@lib/type'
+import { isNotNullish } from '@lib/type'
 
 export function range(start: number, end: number, step = 1) {
   const nums: number[] = []
@@ -11,7 +11,7 @@ export function range(start: number, end: number, step = 1) {
 }
 
 export function sliceIntoChunks<T>(arr: T[], chunkSize: number) {
-  const res = []
+  const res: T[][] = []
   for (let i = 0; i < arr.length; i += chunkSize) {
     const chunk = arr.slice(i, i + chunkSize)
     res.push(chunk)
@@ -118,8 +118,12 @@ export function groupBy2<T extends Record<string, any>>(
  * @param results
  * @param mapFn
  */
-export function mapSuccess<T>(results: MultiCallResult[], mapFn: (res: MultiCallResult, index: number) => T | null) {
-  return results.map((res, index) => (isSuccess(res) ? mapFn(res, index) : null))
+export function mapSuccess<T extends MultiCallResult<never>, S>(
+  results: T[],
+  mapFn: (res: { success: true; input: T['input']; output: NonNullable<T['output']> }, index: number) => S | null,
+) {
+  // @ts-ignore
+  return results.map((res, index) => (res.success ? mapFn(res, index) : null))
 }
 
 /**
@@ -127,11 +131,12 @@ export function mapSuccess<T>(results: MultiCallResult[], mapFn: (res: MultiCall
  * @param results
  * @param mapFn
  */
-export function flatMapSuccess<T>(
-  results: MultiCallResult[],
-  mapFn: (res: MultiCallResult, index: number) => T[] | null,
+export function flatMapSuccess<T extends MultiCallResult<never>, S>(
+  results: T[],
+  mapFn: (res: { success: true; input: T['input']; output: NonNullable<T['output']> }, index: number) => S[] | null,
 ) {
-  return results.flatMap((res, index) => (isSuccess(res) ? mapFn(res, index) : []))
+  // @ts-ignore
+  return results.flatMap((res, index) => (res.success ? mapFn(res, index) : []))
 }
 
 /**
@@ -139,9 +144,9 @@ export function flatMapSuccess<T>(
  * @param results
  * @param mapFn
  */
-export function mapSuccessFilter<T>(
-  results: MultiCallResult[],
-  mapFn: (res: MultiCallResult, index: number) => T | null,
+export function mapSuccessFilter<T extends MultiCallResult<never>, S>(
+  results: T[],
+  mapFn: (res: { success: true; input: T['input']; output: NonNullable<T['output']> }, index: number) => S | null,
 ) {
   return mapSuccess(results, mapFn).filter(isNotNullish)
 }

--- a/src/lib/balance.ts
+++ b/src/lib/balance.ts
@@ -11,7 +11,6 @@ import type { Category } from '@lib/category'
 import { ADDRESS_ZERO } from '@lib/contract'
 import { getERC20BalanceOf } from '@lib/erc20'
 import { BN_TEN, BN_ZERO } from '@lib/math'
-import type { Call, MultiCallOptions, MultiCallResult } from '@lib/multicall'
 import { multicall } from '@lib/multicall'
 import { providers } from '@lib/providers'
 import type { Token } from '@lib/token'
@@ -58,11 +57,11 @@ export async function getBalances(ctx: BalancesContext, contracts: BaseContract[
   return coinsBalances.concat(tokensBalances)
 }
 
-export async function multicallBalances(params: MultiCallOptions) {
+export async function multicallBalances(params: any) {
   const chain = params.ctx.chain
   const coinsCallsAddresses: string[] = []
-  const tokensCalls: Call[] = []
-  const res: MultiCallResult[] = []
+  const tokensCalls = []
+  const res = []
 
   for (const call of params.calls) {
     if (call.target === ADDRESS_ZERO) {
@@ -185,6 +184,7 @@ export async function resolveBalances<C extends GetContractsHandler>(
           const balances = await resolver(ctx, contracts[contractKey]!)
           return balances
         } catch (error) {
+          // Catch execution errors in adapters getBalances
           console.error(`[${ctx.adapterId}][${ctx.chain}] resolver ${contractKey} failed`, error)
           return null
         }

--- a/src/lib/call.ts
+++ b/src/lib/call.ts
@@ -7,7 +7,7 @@ import type { DecodeFunctionResultParameters, DecodeFunctionResultReturnType } f
 
 export async function call<TAbi extends Abi[number] | readonly unknown[]>(options: {
   ctx: BaseContext
-  target: string
+  target: `0x${string}`
   abi: DecodeFunctionResultParameters<TAbi[]>['abi'][number]
   params?: DecodeFunctionResultParameters<TAbi[]>['args']
 }): Promise<DecodeFunctionResultReturnType<TAbi[]>> {

--- a/src/lib/chains.ts
+++ b/src/lib/chains.ts
@@ -2,7 +2,7 @@ import environment from '@environment'
 
 import { isNotNullish } from './type'
 
-const { LLAMANODES_API_KEY } = environment
+const { ARBITRUM_RPC, LLAMANODES_API_KEY, OPTIMISM_RPC } = environment
 
 export declare type Chain =
   | 'arbitrum'
@@ -31,7 +31,7 @@ export const chains: IChainInfo[] = [
     id: 'arbitrum',
     chainId: 42161,
     name: 'Arbitrum',
-    rpcUrls: ['https://arb1.arbitrum.io/rpc', 'https://rpc.ankr.com/arbitrum'],
+    rpcUrls: [ARBITRUM_RPC, 'https://arb1.arbitrum.io/rpc', 'https://rpc.ankr.com/arbitrum'].filter(isNotNullish),
   },
   {
     id: 'avalanche',
@@ -105,7 +105,7 @@ export const chains: IChainInfo[] = [
     id: 'optimism',
     chainId: 10,
     name: 'Optimism',
-    rpcUrls: ['https://mainnet.optimism.io/', 'https://rpc.ankr.com/optimism'],
+    rpcUrls: [OPTIMISM_RPC, 'https://mainnet.optimism.io/', 'https://rpc.ankr.com/optimism'].filter(isNotNullish),
   },
   {
     id: 'gnosis',

--- a/src/lib/geist/lending.ts
+++ b/src/lib/geist/lending.ts
@@ -7,7 +7,6 @@ import { keyBy, range } from '@lib/array'
 import { call } from '@lib/call'
 import { multicall } from '@lib/multicall'
 import type { Token } from '@lib/token'
-import { isSuccess } from '@lib/type'
 import { BigNumber } from 'ethers'
 
 const abi = {
@@ -62,15 +61,14 @@ export async function getLendingPoolContracts(
 
   const registeredTokensRes = await multicall({
     ctx,
-    calls: range(0, Number(lmRewardsCount)).map((_, idx) => ({
-      target: chefIncentivesController.address,
-      params: [idx],
-    })),
+    calls: range(0, Number(lmRewardsCount)).map(
+      (_, idx) => ({ target: chefIncentivesController.address, params: [BigInt(idx)] } as const),
+    ),
     abi: abi.registeredTokens,
   })
 
   for (const registeredTokenRes of registeredTokensRes) {
-    if (!isSuccess(registeredTokenRes)) {
+    if (!registeredTokenRes.success) {
       continue
     }
     const contract = aaveLendingPoolContractsByAddress[registeredTokenRes.output]
@@ -109,7 +107,7 @@ export async function getLendingPoolBalances(
   for (let rewardIdx = 0; rewardIdx < claimableRewards.length; rewardIdx++) {
     const claimableReward = claimableRewards[rewardIdx]
 
-    if (!isSuccess(claimableReward)) {
+    if (!claimableReward.success) {
       continue
     }
 

--- a/src/lib/gmx/underlying.ts
+++ b/src/lib/gmx/underlying.ts
@@ -20,17 +20,18 @@ export const get_xLP_UnderlyingsBalances = async (
       call({ ctx, target: balance.address, abi: erc20Abi.totalSupply }),
       multicall({
         ctx,
-        calls: underlyings.map((underlying) => ({
-          target: (underlying as Contract).address,
-          params: [vault.address],
-        })),
+        calls: underlyings.map(
+          (underlying) => ({ target: (underlying as Contract).address, params: [vault.address] } as const),
+        ),
         abi: erc20Abi.balanceOf,
       }),
     ])
 
     const fmtUnderlyings: Contract[] = underlyings.map((underlying, idx) => {
       const underlyingsBalancesOfRes = underlyingsBalancesOfsRes[idx]
-      const underlyingsAmount = balance.amount.mul(underlyingsBalancesOfRes.output).div(totalSupply)
+      const underlyingsAmount = balance.amount
+        .mul(underlyingsBalancesOfRes.success ? underlyingsBalancesOfRes.output : 0)
+        .div(totalSupply)
       return { ...(underlying as Contract), amount: underlyingsAmount }
     })
 

--- a/src/lib/gmx/vault.ts
+++ b/src/lib/gmx/vault.ts
@@ -1,8 +1,7 @@
 import type { BaseContext, Contract } from '@lib/adapter'
-import { range } from '@lib/array'
+import { mapSuccessFilter, range } from '@lib/array'
 import { call } from '@lib/call'
 import { multicall } from '@lib/multicall'
-import { isSuccess } from '@lib/type'
 
 const abi = {
   allWhitelistedTokensLength: {
@@ -34,14 +33,13 @@ export async function getVaultTokens(ctx: BaseContext, vault: Contract) {
 
   const allWhitelistedTokensLength = Number(allWhitelistedTokensLengthRes)
 
-  const allWhitelistedTokensRes = await multicall<string, [number], string>({
+  const allWhitelistedTokensRes = await multicall({
     ctx,
-    calls: range(0, allWhitelistedTokensLength).map((idx) => ({
-      target: vault.address,
-      params: [idx],
-    })),
+    calls: range(0, allWhitelistedTokensLength).map(
+      (idx) => ({ target: vault.address, params: [BigInt(idx)] } as const),
+    ),
     abi: abi.allWhitelistedTokens,
   })
 
-  return allWhitelistedTokensRes.filter(isSuccess).map((res) => res.output)
+  return mapSuccessFilter(allWhitelistedTokensRes, (res) => res.output)
 }

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -27,7 +27,7 @@ export function mulPrice(amountBN: BigNumber, decimals: number, price: number) {
   try {
     const priceBN = utils.parseUnits(price.toFixed(decimals), decimals)
 
-    const mulBN = amountBN.mul(priceBN)
+    const mulBN = BigNumber.from(amountBN).mul(priceBN)
 
     return parseFloat(utils.formatUnits(mulBN, 2 * decimals))
   } catch (err) {

--- a/src/lib/price.ts
+++ b/src/lib/price.ts
@@ -128,7 +128,7 @@ export async function getPricedBalances(balances: Balance[]): Promise<(Balance |
       ...price,
       ...balance,
       priceTimestamp: price.timestamp ? new Date(price.timestamp * 1000) : undefined,
-      balanceUSD: mulPrice(balance.amount, decimals, price.price),
+      balanceUSD: mulPrice(balance.amount, Number(decimals), price.price),
       claimableUSD: balance.claimable ? mulPrice(balance.claimable || BN_ZERO, decimals, price.price) : undefined,
     }
   }

--- a/src/lib/type.ts
+++ b/src/lib/type.ts
@@ -1,11 +1,5 @@
-import type { MultiCallResult } from '@lib/multicall'
-
 export function isNotNullish<T>(param: T | undefined | null): param is T {
   return param != null
-}
-
-export function isSuccess<T, P, O>(param: MultiCallResult<T, P, O>): param is MultiCallResult<T, P, NonNullable<O>> {
-  return param.success
 }
 
 export type TUnixTimestamp = number


### PR DESCRIPTION
<!-- 🦙🦙 Thanks for contributing ! 🦙🦙 -->

<!-- Please specify the adapter id in the title -->

<!-- If you're creating a new adapter, please make sure the `links` field is well specified: this info will help us review it -->

## Summary

<!-- Which issues will be closed? (if applicable) -->

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

See: https://github.com/llamafolio/llamafolio-api/pull/607

- remove `lib/multicall` output transformation
- add *real* type definitions for `multicall` (it all used to be `any`)

This should now be easier to remove BigNumber without breaking all the adapters (as types are correct)

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
