### PR TITLE
Fix: Chainlink, interaction

### DIFF
--- a/src/adapters/chainlink/ethereum/balance.ts
+++ b/src/adapters/chainlink/ethereum/balance.ts
@@ -26,10 +26,10 @@ const link: Token = {
   symbol: 'LINK',
 }
 
-export async function getChainlinkStakerBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
+export async function getChainlinkStakerBalance(ctx: BalancesContext, staker: Contract): Promise<Balance> {
   const [balanceOf, rewardsOf] = await Promise.all([
-    call({ ctx, target: staker.address, params: [ctx.address], abi: abi.getStake }),
-    call({ ctx, target: staker.address, params: [ctx.address], abi: abi.getBaseReward }),
+    call({ ctx, target: staker.staker, params: [ctx.address], abi: abi.getStake }),
+    call({ ctx, target: staker.staker, params: [ctx.address], abi: abi.getBaseReward }),
   ])
 
   return {

--- a/src/adapters/chainlink/ethereum/index.ts
+++ b/src/adapters/chainlink/ethereum/index.ts
@@ -1,33 +1,25 @@
 import type { Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
-import type { Token } from '@lib/token'
 
-import { getChainlinkStakerBalances } from './balance'
+import { getChainlinkStakerBalance } from './balance'
 
-const link: Token = {
+const link: Contract = {
   chain: 'ethereum',
   address: '0x514910771AF9Ca656af840dff83E8264EcF986CA',
+  staker: '0x3feb1e09b4bb0e7f0387cee092a52e85797ab889',
   decimals: 18,
   symbol: 'LINK',
 }
 
-const staker: Contract = {
-  chain: 'ethereum',
-  address: '0x3feb1e09b4bb0e7f0387cee092a52e85797ab889',
-  underlyings: [link],
-}
-
 export const getContracts = async () => {
   return {
-    contracts: { staker },
-    // TODO: check contract interaction
-    props: { staker },
+    contracts: { link },
   }
 }
 
-export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, _contracts, props) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, props, {
-    staker: getChainlinkStakerBalances,
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    link: getChainlinkStakerBalance,
   })
 
   return {


### PR DESCRIPTION
Now working without using props in getBalances

`pnpm run adapter-balances chainlink-ethereum 0x92687a7947b34b3fceccbad22c8c0196a8fb3fa9`

![chainlink-0x92687a7947b34b3fceccbad22c8c0196a8fb3fa9](https://github.com/llamafolio/llamafolio-api/assets/110820448/a61db43d-a83b-48c4-86f3-f614e99bb6da)

`pnpm run adapter-balances chainlink-ethereum 0x9828b1b34ce2f6337c47cd29ae3e25dfc2cc6e82`

![chainlink-0x9828b1b34ce2f6337c47cd29ae3e25dfc2cc6e82](https://github.com/llamafolio/llamafolio-api/assets/110820448/041e2a38-b7c9-4f56-bc0c-1912a64bfe73)
