### PR TITLE
Feat: Fix abracadabra contracts

### DIFF
--- a/src/adapters/abracadabra/ethereum/farm.ts
+++ b/src/adapters/abracadabra/ethereum/farm.ts
@@ -69,9 +69,9 @@ export async function getFarmBalances(ctx: BalancesContext, pools: Contract[], c
   const sushiPools: Balance[] = []
   const curvePools: Balance[] = []
 
-  const calls: Call<typeof abi.userInfo>[] = pools.map((_, idx) => ({
+  const calls: Call<typeof abi.userInfo>[] = pools.map((pool) => ({
     target: contract.address,
-    params: [BigInt(idx), ctx.address],
+    params: [pool.pid, ctx.address],
   }))
 
   const [poolBalances, poolRewards] = await Promise.all([

--- a/src/adapters/abracadabra/ethereum/index.ts
+++ b/src/adapters/abracadabra/ethereum/index.ts
@@ -40,6 +40,7 @@ const abracadabra_SPELL_WETH: Contract = {
   symbol: 'SLP',
   provider: 'sushi',
   underlyings: ['0x090185f2135308BaD17527004364eBcC2D37e5F6', '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'],
+  pid: 0,
 }
 
 const abracadabra_MIM3LP3CRV: Contract = {
@@ -57,6 +58,7 @@ const abracadabra_MIM3LP3CRV: Contract = {
     '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
     '0xdAC17F958D2ee523a2206206994597C13D831ec7',
   ],
+  pid: 1,
 }
 
 const abracadabra_MIM_WETH: Contract = {
@@ -66,6 +68,7 @@ const abracadabra_MIM_WETH: Contract = {
   symbol: 'SLP',
   provider: 'sushi',
   underlyings: ['0x99D8a9C45b2ecA8864373A26D1459e3Dff1e17F3', '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'],
+  pid: 2,
 }
 
 const abracadabraFarm: Contract = {


### PR DESCRIPTION
Abracadabra farming contracts had wrong pid

`pnpm run adapter-balances abracadabra ethereum 0xbdfa4f4492dd7b7cf211209c4791af8d52bf5c50`

### BEFORE
![abracadabra](https://github.com/llamafolio/llamafolio-api/assets/110820448/bbf257f1-0cc6-4b8e-b539-5ca995a90681)


### NOW
![abracadabra-now](https://github.com/llamafolio/llamafolio-api/assets/110820448/0edd6a3d-9c37-4898-b372-46f6a7e32994)
