### PR TITLE
Feat: Adapter,  Annex

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -70,6 +70,7 @@
         "alpaca-finance",
         "ambire-wallet",
         "angle",
+        "annex",
         "apeswap-amm",
         "apeswap-lending",
         "api3",

--- a/src/adapters/annex/bsc/balance.ts
+++ b/src/adapters/annex/bsc/balance.ts
@@ -1,0 +1,105 @@
+import type { Balance, BalancesContext, Contract } from '@lib/adapter'
+import type { Call } from '@lib/multicall'
+import { multicall } from '@lib/multicall'
+import type { Token } from '@lib/token'
+import { getUnderlyingBalances } from '@lib/uniswap/v2/pair'
+
+const abi = {
+  userInfo: {
+    inputs: [
+      { internalType: 'uint256', name: '', type: 'uint256' },
+      { internalType: 'address', name: '', type: 'address' },
+    ],
+    name: 'userInfo',
+    outputs: [
+      { internalType: 'uint256', name: 'amount', type: 'uint256' },
+      { internalType: 'uint256', name: 'rewardDebt', type: 'uint256' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  pendingReward: {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_pid',
+        type: 'uint256',
+      },
+      {
+        internalType: 'address',
+        name: '_user',
+        type: 'address',
+      },
+    ],
+    name: 'pending',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'pending',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+const ANN: Token = {
+  chain: 'bsc',
+  address: '0x98936bde1cf1bff1e7a8012cee5e2583851f2067',
+  decimals: 18,
+  symbol: 'ANN',
+}
+
+export async function getAnnexFarmBalances(ctx: BalancesContext, masterchefPools: Contract[]): Promise<Balance[]> {
+  const poolsBalances: Balance[] = []
+  const singleBalances: Balance[] = []
+
+  const rewardTokenName = masterchefPools.map((master) =>
+    master.masterchef === '0x95660cc9fdf5e55c579101f5867b89f24f254ea1' ? 'Reward' : 'Annex',
+  )
+
+  const pendingReward: typeof abi.pendingReward = JSON.parse(
+    JSON.stringify(abi.pendingReward).replace(
+      'pending',
+      rewardTokenName.length === 0 ? `pending` : `pending${rewardTokenName[0]}`,
+    ),
+  )
+
+  const calls: Call<typeof abi.userInfo>[] = []
+  for (let poolIdx = 0; poolIdx < masterchefPools.length; poolIdx++) {
+    const masterchefPool = masterchefPools[poolIdx]
+    calls.push({ target: masterchefPool.masterchef, params: [masterchefPool.pid, ctx.address] })
+  }
+
+  const [poolsBalancesRes, pendingRewardsRes] = await Promise.all([
+    multicall({ ctx, calls, abi: abi.userInfo }),
+    multicall({ ctx, calls, abi: pendingReward }),
+  ])
+
+  for (let userIdx = 0; userIdx < poolsBalancesRes.length; userIdx++) {
+    const masterchefPool = masterchefPools[userIdx]
+    const poolBalanceRes = poolsBalancesRes[userIdx]
+    const pendingRewardRes = pendingRewardsRes[userIdx]
+
+    if (!poolBalanceRes.success || !pendingRewardRes.success) {
+      continue
+    }
+
+    const balance: Balance = {
+      ...masterchefPool,
+      underlyings: masterchefPool.underlyings as Contract[],
+      category: 'farm',
+      amount: poolBalanceRes.output[0],
+      rewards: [{ ...ANN, amount: pendingRewardRes.output }],
+    }
+
+    if (!balance.underlyings) {
+      singleBalances.push(balance)
+    } else {
+      poolsBalances.push(balance)
+    }
+  }
+
+  return (await Promise.all([singleBalances, getUnderlyingBalances(ctx, poolsBalances)])).flat()
+}

--- a/src/adapters/annex/bsc/contract.ts
+++ b/src/adapters/annex/bsc/contract.ts
@@ -1,0 +1,51 @@
+import type { BaseContext, Contract } from '@lib/adapter'
+import { mapSuccessFilter } from '@lib/array'
+import { multicall } from '@lib/multicall'
+import { getPairsDetails } from '@lib/uniswap/v2/factory'
+
+const abi = {
+  poolLength: {
+    inputs: [],
+    name: 'poolLength',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  getPoolInfo: {
+    inputs: [{ internalType: 'uint256', name: '_pid', type: 'uint256' }],
+    name: 'getPoolInfo',
+    outputs: [
+      { internalType: 'contract IERC20', name: 'lpToken', type: 'address' },
+      { internalType: 'uint256', name: 'lpSupply', type: 'uint256' },
+      { internalType: 'uint256', name: 'allocPoint', type: 'uint256' },
+      { internalType: 'uint256', name: 'lastRewardBlock', type: 'uint256' },
+      { internalType: 'uint256', name: 'accAnnexperShare', type: 'uint256' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+export async function getAnnexContracts(ctx: BaseContext, masterchefs: Contract[]): Promise<Contract[]> {
+  const poolLength = await multicall({
+    ctx,
+    calls: masterchefs.map((master) => ({ target: master.address })),
+    abi: abi.poolLength,
+  })
+
+  const poolInfosRes = await multicall({
+    ctx,
+    calls: poolLength.map((pool, idx) => ({ target: pool.input.target, params: [BigInt(idx)] } as const)),
+    abi: abi.getPoolInfo,
+  })
+
+  const contracts: Contract[] = mapSuccessFilter(poolInfosRes, (res, idx) => ({
+    chain: ctx.chain,
+    address: res.output[0],
+    lpToken: res.output[0],
+    masterchef: res.input.target,
+    pid: idx,
+  }))
+
+  return getPairsDetails(ctx, contracts)
+}

--- a/src/adapters/annex/bsc/index.ts
+++ b/src/adapters/annex/bsc/index.ts
@@ -1,0 +1,59 @@
+import { getAnnexFarmBalances } from '@adapters/annex/bsc/balance'
+import { getAnnexContracts } from '@adapters/annex/bsc/contract'
+import type { BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+import type { BalanceWithExtraProps } from '@lib/compound/v2/lending'
+import { getHealthFactor, getMarketsBalances, getMarketsContracts } from '@lib/compound/v2/lending'
+
+const Comptroller: Contract = {
+  chain: 'bsc',
+  address: '0xb13026db8aafa2fd6d23355533dccccbd4442f4c',
+}
+
+const annSingleFarm: Contract = {
+  chain: 'bsc',
+  address: '0x98936Bde1CF1BFf1e7a8012Cee5e2583851f2067',
+  lpToken: '0x98936Bde1CF1BFf1e7a8012Cee5e2583851f2067',
+  masterchef: '0x9c821500eaba9f9737fdaadf7984dff03edc74d1',
+  pid: 2,
+}
+
+const masterchef: Contract = {
+  chain: 'bsc',
+  address: '0x9c821500eaba9f9737fdaadf7984dff03edc74d1',
+}
+
+const masterchef_v2: Contract = {
+  chain: 'bsc',
+  address: '0x9c821500eaba9f9737fdaadf7984dff03edc74d1',
+}
+
+export const getContracts = async (ctx: BaseContext) => {
+  const [markets, pools] = await Promise.all([
+    getMarketsContracts(ctx, {
+      comptrollerAddress: Comptroller.address,
+      underlyingAddressByMarketAddress: {
+        // cBNB -> wBNB
+        '0xc5a83ad9f3586e143d2c718e8999206887ef9ddc': '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c',
+      },
+    }),
+    getAnnexContracts(ctx, [masterchef, masterchef_v2]),
+  ])
+
+  return {
+    contracts: { markets, Comptroller, masterchef, masterchef_v2, pools: [...pools, annSingleFarm] },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    markets: getMarketsBalances,
+    pools: getAnnexFarmBalances,
+  })
+
+  const healthFactor = await getHealthFactor(balances as BalanceWithExtraProps[])
+
+  return {
+    groups: [{ balances, healthFactor }],
+  }
+}

--- a/src/adapters/annex/index.ts
+++ b/src/adapters/annex/index.ts
@@ -1,0 +1,10 @@
+import type { Adapter } from '@lib/adapter'
+
+import * as bsc from './bsc'
+
+const adapter: Adapter = {
+  id: 'annex',
+  bsc,
+}
+
+export default adapter

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -9,6 +9,7 @@ import alchemix from '@adapters/alchemix'
 import alpacaFinance from '@adapters/alpaca-finance'
 import ambireWallet from '@adapters/ambire-wallet'
 import angle from '@adapters/angle'
+import annex from '@adapters/annex'
 import apeswapAmm from '@adapters/apeswap-amm'
 import apeswapLending from '@adapters/apeswap-lending'
 import api3 from '@adapters/api3'
@@ -205,6 +206,7 @@ export const adapters: Adapter[] = [
   alpacaFinance,
   ambireWallet,
   angle,
+  annex,
   apeswapAmm,
   apeswapLending,
   api3,


### PR DESCRIPTION
Add Annex adapter on bsc chain

- [x] store contracts
- [x] Lend/borrow (compound forks)
- [x] Farm

`pnpm run adapter-balances annex bsc 0x6eb1ec23d6dcdd987936658b1b2f0db5c5a87e0f`

![annex-0x6eb1ec23d6dcdd987936658b1b2f0db5c5a87e0f](https://github.com/llamafolio/llamafolio-api/assets/110820448/5c571555-a44f-47c4-8676-e4bd7816f4ec)
