### PR TITLE
Feat: Adapter, Definix

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -104,6 +104,7 @@
         "conic-finance",
         "convex-finance",
         "curve-dex",
+        "definix",
         "dydx",
         "equalizer-exchange",
         "ether.fi",

--- a/src/adapters/definix/bsc/index.ts
+++ b/src/adapters/definix/bsc/index.ts
@@ -1,0 +1,68 @@
+import type { BalancesContext, BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+import { getMasterChefPoolsBalances } from '@lib/masterchef/masterchef'
+import type { Token } from '@lib/token'
+import type { Pair } from '@lib/uniswap/v2/factory'
+import { getPairsContracts } from '@lib/uniswap/v2/factory'
+import { getPairsBalances } from '@lib/uniswap/v2/pair'
+
+const masterChef: Contract = {
+  name: 'masterChef',
+  displayName: 'MasterChef',
+  chain: 'bsc',
+  address: '0x6b51e8fdc32ead0b837deb334fcb79e24f3b105a',
+}
+
+const FINIX: Token = {
+  chain: 'bsc',
+  address: '0x0f02b1f5af54e04fb6dd6550f009ac2429c4e30d',
+  symbol: 'FINIX',
+  decimals: 18,
+}
+
+export const getContracts = async (ctx: BaseContext, props: any) => {
+  const offset = props.pairOffset || 0
+  const limit = 100
+
+  const { pairs, allPairsLength } = await getPairsContracts({
+    ctx,
+    factoryAddress: '0x43eBb0cb9bD53A3Ed928Dd662095aCE1cef92D19',
+    offset,
+    limit,
+  })
+
+  return {
+    contracts: {
+      masterChef,
+      pairs,
+    },
+    revalidate: 60 * 60,
+    revalidateProps: {
+      pairOffset: Math.min(offset + limit, allPairsLength),
+    },
+  }
+}
+
+function getSushiswapPairsBalances(
+  ctx: BalancesContext,
+  pairs: Pair[],
+  masterchef: Contract,
+  rewardToken: Token,
+  rewardTokenName?: string,
+  lpTokenAbi?: boolean,
+) {
+  return Promise.all([
+    getPairsBalances(ctx, pairs),
+    getMasterChefPoolsBalances(ctx, pairs, masterchef, rewardToken, rewardTokenName, lpTokenAbi),
+  ])
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx: BalancesContext, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    pairs: (...args) => getSushiswapPairsBalances(...args, masterChef, FINIX, 'Finix'),
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/definix/index.ts
+++ b/src/adapters/definix/index.ts
@@ -1,0 +1,10 @@
+import type { Adapter } from '@lib/adapter'
+
+import * as bsc from './bsc'
+
+const adapter: Adapter = {
+  id: 'definix',
+  bsc,
+}
+
+export default adapter

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -43,6 +43,7 @@ import concentrator from '@adapters/concentrator'
 import conicFinance from '@adapters/conic-finance'
 import convexFinance from '@adapters/convex-finance'
 import curveDex from '@adapters/curve-dex'
+import definix from '@adapters/definix'
 import dydx from '@adapters/dydx'
 import equalizerExchange from '@adapters/equalizer-exchange'
 import etherFi from '@adapters/ether.fi'
@@ -240,6 +241,7 @@ export const adapters: Adapter[] = [
   conicFinance,
   convexFinance,
   curveDex,
+  definix,
   dydx,
   equalizerExchange,
   etherFi,


### PR DESCRIPTION
Add Definix adapter (dexes)

- [x]  store contracts
- [x] lp + farm using masterchef lib

### LP
`pnpm run adapter-balances definix bsc 0x6b51e8fdc32ead0b837deb334fcb79e24f3b105a`

![definix-lp-0x6b51e8fdc32ead0b837deb334fcb79e24f3b105a](https://github.com/llamafolio/llamafolio-api/assets/110820448/54c0b36e-75b6-4425-b013-98307b11fbf3)

### FARM
`pnpm run adapter-balances definix bsc 0x80d619b7ed458668cbe718e865f38e73cfe9c7bc`

![definix-farm-0x80d619b7ed458668cbe718e865f38e73cfe9c7bc](https://github.com/llamafolio/llamafolio-api/assets/110820448/77884c6c-3a01-4e31-b26a-337f40eea0f5)
