### PR TITLE
Ellipsis, lp, farm, lock

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -105,6 +105,7 @@
         "convex-finance",
         "curve-dex",
         "dydx",
+        "ellipsis-finance",
         "equalizer-exchange",
         "ether.fi",
         "euler",

--- a/src/adapters/ellipsis-finance/bsc/contract.ts
+++ b/src/adapters/ellipsis-finance/bsc/contract.ts
@@ -1,0 +1,21 @@
+import type { BaseContext, Contract } from '@lib/adapter'
+
+const API_URL = 'https://api.ellipsis.finance/api/getPoolsCrypto'
+
+export async function getEllipsisContracts(ctx: BaseContext): Promise<Contract[]> {
+  const response = await fetch(API_URL)
+  const res: any = await response.json()
+
+  return res.data.allPools.map((d: any) => ({
+    chain: ctx.chain,
+    name: d.name,
+    address: d.lpToken.address,
+    lpToken: d.lpToken.address,
+    symbol: d.lpToken.symbol,
+    decimals: d.lpToken.decimals,
+    pool: d.address,
+    pid: d.poolIndex,
+    tokens: d.tokens,
+    underlyings: d.underlying,
+  }))
+}

--- a/src/adapters/ellipsis-finance/bsc/farm.ts
+++ b/src/adapters/ellipsis-finance/bsc/farm.ts
@@ -1,0 +1,132 @@
+import type { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { range } from '@lib/array'
+import { multicall } from '@lib/multicall'
+import type { Token } from '@lib/token'
+
+const abi = {
+  userInfo: {
+    inputs: [
+      { internalType: 'address', name: '', type: 'address' },
+      { internalType: 'address', name: '', type: 'address' },
+    ],
+    name: 'userInfo',
+    outputs: [
+      { internalType: 'uint256', name: 'depositAmount', type: 'uint256' },
+      { internalType: 'uint256', name: 'adjustedAmount', type: 'uint256' },
+      { internalType: 'uint256', name: 'rewardDebt', type: 'uint256' },
+      { internalType: 'uint256', name: 'claimable', type: 'uint256' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  claimableReward: {
+    inputs: [
+      { internalType: 'address', name: '_user', type: 'address' },
+      { internalType: 'address[]', name: '_tokens', type: 'address[]' },
+    ],
+    name: 'claimableReward',
+    outputs: [{ internalType: 'uint256[]', name: '', type: 'uint256[]' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  balances: {
+    stateMutability: 'view',
+    type: 'function',
+    name: 'balances',
+    inputs: [{ name: 'arg0', type: 'uint256' }],
+    outputs: [{ name: '', type: 'uint256' }],
+    gas: 3201,
+  },
+  totalSupply: {
+    inputs: [],
+    name: 'totalSupply',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+const EPX: Token = {
+  chain: 'bsc',
+  address: '0xaf41054c1487b0e5e2b9250c0332ecbce6ce9d71',
+  decimals: 18,
+  symbol: 'EPX',
+}
+
+export async function getEllipsisFarmingBalances(
+  ctx: BalancesContext,
+  pools: Contract[],
+  masterchef: Contract,
+): Promise<Balance[]> {
+  const balances: Balance[] = []
+
+  const [userBalancesRes, userPendingsRewardsRes, totalSuppliesRes, tokenBalancesOfRes] = await Promise.all([
+    multicall({
+      ctx,
+      calls: pools.map((pool) => ({ target: masterchef.address, params: [pool.lpToken, ctx.address] } as const)),
+      abi: abi.userInfo,
+    }),
+    multicall({
+      ctx,
+      calls: pools.map((pool) => ({ target: masterchef.address, params: [ctx.address, [pool.lpToken]] } as const)),
+      abi: abi.claimableReward,
+    }),
+    multicall({ ctx, calls: pools.map((pool) => ({ target: pool.address } as const)), abi: abi.totalSupply }),
+    multicall({
+      ctx,
+      calls: pools.flatMap((pool) =>
+        range(0, pool.tokens.length).map((_, idx) => ({ target: pool.pool, params: [BigInt(idx)] } as const)),
+      ),
+      abi: abi.balances,
+    }),
+  ])
+
+  let balanceOfIdx = 0
+
+  for (let poolIdx = 0; poolIdx < pools.length; poolIdx++) {
+    const underlyings = pools[poolIdx].tokens
+    const userPendingRewardsRes = userPendingsRewardsRes[poolIdx]
+    const userBalancesOfRes = userBalancesRes[poolIdx]
+    const totalSupplyRes = totalSuppliesRes[poolIdx]
+
+    if (
+      !underlyings ||
+      !userBalancesOfRes.success ||
+      !userPendingRewardsRes.success ||
+      !totalSupplyRes.success ||
+      totalSupplyRes.output == 0n
+    ) {
+      balanceOfIdx += underlyings.length
+      continue
+    }
+
+    const poolBalance: Balance = {
+      ...pools[poolIdx],
+      amount: userBalancesOfRes.output[0],
+      category: 'farm',
+      underlyings: [],
+      rewards: [{ ...EPX, amount: userPendingRewardsRes.output[0] }],
+    }
+
+    for (let underlyingIdx = 0; underlyingIdx < underlyings.length; underlyingIdx++) {
+      const underlyingBalanceRes = tokenBalancesOfRes[balanceOfIdx]
+
+      const underlyingBalance: bigint = underlyingBalanceRes.success ? underlyingBalanceRes.output : 0n
+
+      const underlyingAmount = (underlyingBalance * poolBalance.amount) / totalSupplyRes.output
+
+      poolBalance.underlyings!.push({
+        ...underlyings[underlyingIdx],
+        address: underlyings[underlyingIdx].erc20address,
+        amount: underlyingAmount,
+        chain: ctx.chain,
+      })
+
+      balanceOfIdx++
+    }
+
+    balances.push(poolBalance)
+  }
+
+  return balances
+}

--- a/src/adapters/ellipsis-finance/bsc/index.ts
+++ b/src/adapters/ellipsis-finance/bsc/index.ts
@@ -1,0 +1,40 @@
+import { getEllipsisContracts } from '@adapters/ellipsis-finance/bsc/contract'
+import { getEllipsisFarmingBalances } from '@adapters/ellipsis-finance/bsc/farm'
+import { getEllipsisLockerBalance } from '@adapters/ellipsis-finance/bsc/locker'
+import { getEllipsisLpBalances } from '@adapters/ellipsis-finance/bsc/lp'
+import type { BalancesContext, BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+const masterChef: Contract = {
+  chain: 'bsc',
+  address: '0x5B74C99AA2356B4eAa7B85dC486843eDff8Dfdbe',
+}
+
+const locker: Contract = {
+  chain: 'bsc',
+  address: '0x22a93f53a0a3e6847d05dd504283e8e296a49aae',
+  token: '0xaf41054c1487b0e5e2b9250c0332ecbce6ce9d71',
+}
+
+export const getContracts = async (ctx: BaseContext) => {
+  const pools = await getEllipsisContracts(ctx)
+
+  return {
+    contracts: { pools, masterChef, locker },
+  }
+}
+
+const ellipsisBalances = async (ctx: BalancesContext, pools: Contract[]) => {
+  return Promise.all([getEllipsisLpBalances(ctx, pools), getEllipsisFarmingBalances(ctx, pools, masterChef)])
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    pools: ellipsisBalances,
+    locker: getEllipsisLockerBalance,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/ellipsis-finance/bsc/locker.ts
+++ b/src/adapters/ellipsis-finance/bsc/locker.ts
@@ -1,0 +1,24 @@
+import type { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { call } from '@lib/call'
+
+const abi = {
+  userBalance: {
+    inputs: [{ internalType: 'address', name: '_user', type: 'address' }],
+    name: 'userBalance',
+    outputs: [{ internalType: 'uint256', name: 'balance', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+export async function getEllipsisLockerBalance(ctx: BalancesContext, locker: Contract): Promise<Balance> {
+  const userLockBalance = await call({ ctx, target: locker.address, params: [ctx.address], abi: abi.userBalance })
+
+  return {
+    ...locker,
+    amount: userLockBalance,
+    underlyings: undefined,
+    rewards: undefined,
+    category: 'lock',
+  }
+}

--- a/src/adapters/ellipsis-finance/bsc/lp.ts
+++ b/src/adapters/ellipsis-finance/bsc/lp.ts
@@ -1,0 +1,90 @@
+import type { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { range } from '@lib/array'
+import { multicall } from '@lib/multicall'
+
+const abi = {
+  balanceOf: {
+    inputs: [{ internalType: 'address', name: '', type: 'address' }],
+    name: 'balanceOf',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  balances: {
+    stateMutability: 'view',
+    type: 'function',
+    name: 'balances',
+    inputs: [{ name: 'arg0', type: 'uint256' }],
+    outputs: [{ name: '', type: 'uint256' }],
+    gas: 3201,
+  },
+  totalSupply: {
+    inputs: [],
+    name: 'totalSupply',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+export async function getEllipsisLpBalances(ctx: BalancesContext, pools: Contract[]): Promise<Balance[]> {
+  const balances: Balance[] = []
+
+  const [userBalancesOfsRes, totalSuppliesRes, tokenBalancesOfRes] = await Promise.all([
+    multicall({
+      ctx,
+      calls: pools.map((pool) => ({ target: pool.address, params: [ctx.address] } as const)),
+      abi: abi.balanceOf,
+    }),
+    multicall({ ctx, calls: pools.map((pool) => ({ target: pool.address } as const)), abi: abi.totalSupply }),
+    multicall({
+      ctx,
+      calls: pools.flatMap((pool) =>
+        range(0, pool.tokens.length).map((_, idx) => ({ target: pool.pool, params: [BigInt(idx)] } as const)),
+      ),
+      abi: abi.balances,
+    }),
+  ])
+
+  let balanceOfIdx = 0
+
+  for (let poolIdx = 0; poolIdx < pools.length; poolIdx++) {
+    const underlyings = pools[poolIdx].tokens
+    const userBalancesOfRes = userBalancesOfsRes[poolIdx]
+    const totalSupplyRes = totalSuppliesRes[poolIdx]
+
+    if (!underlyings || !userBalancesOfRes.success || !totalSupplyRes.success || totalSupplyRes.output == 0n) {
+      balanceOfIdx += underlyings.length
+      continue
+    }
+
+    const poolBalance: Balance = {
+      ...pools[poolIdx],
+      amount: userBalancesOfRes.output,
+      category: 'lp',
+      underlyings: [],
+      rewards: undefined,
+    }
+
+    for (let underlyingIdx = 0; underlyingIdx < underlyings.length; underlyingIdx++) {
+      const underlyingBalanceRes = tokenBalancesOfRes[balanceOfIdx]
+
+      const underlyingBalance: bigint = underlyingBalanceRes.success ? underlyingBalanceRes.output : 0n
+
+      const underlyingAmount = (underlyingBalance * poolBalance.amount) / totalSupplyRes.output
+
+      poolBalance.underlyings!.push({
+        ...underlyings[underlyingIdx],
+        address: underlyings[underlyingIdx].erc20address,
+        amount: underlyingAmount,
+        chain: ctx.chain,
+      })
+
+      balanceOfIdx++
+    }
+
+    balances.push(poolBalance)
+  }
+
+  return balances
+}

--- a/src/adapters/ellipsis-finance/index.ts
+++ b/src/adapters/ellipsis-finance/index.ts
@@ -1,0 +1,10 @@
+import type { Adapter } from '@lib/adapter'
+
+import * as bsc from './bsc'
+
+const adapter: Adapter = {
+  id: 'ellipsis-finance',
+  bsc,
+}
+
+export default adapter

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -44,6 +44,7 @@ import conicFinance from '@adapters/conic-finance'
 import convexFinance from '@adapters/convex-finance'
 import curveDex from '@adapters/curve-dex'
 import dydx from '@adapters/dydx'
+import ellipsisFinance from '@adapters/ellipsis-finance'
 import equalizerExchange from '@adapters/equalizer-exchange'
 import etherFi from '@adapters/ether.fi'
 import euler from '@adapters/euler'
@@ -241,6 +242,7 @@ export const adapters: Adapter[] = [
   convexFinance,
   curveDex,
   dydx,
+  ellipsisFinance,
   equalizerExchange,
   etherFi,
   euler,


### PR DESCRIPTION
Add Ellipsis adapter on bsc chain

- [x] Store contracts
- [x] Lp
- [x] Farm
- [x] Lock


### Lock
`pnpm run adapter-balances ellipsis-finance bsc 0x3e47b39cf05511dd666589ea9a5b4cee6c0d1fac`

![ellipsis-lock-0x3e47b39cf05511dd666589ea9a5b4cee6c0d1fac](https://github.com/llamafolio/llamafolio-api/assets/110820448/42f9c138-b9bb-4980-b0d1-30c248cb071c)

### Lp
`pnpm run adapter-balances ellipsis-finance bsc 0x5b74c99aa2356b4eaa7b85dc486843edff8dfdbe`

![ellipsis-lp-0x5b74c99aa2356b4eaa7b85dc486843edff8dfdbe](https://github.com/llamafolio/llamafolio-api/assets/110820448/d614a4b3-4596-4ee1-8eb3-f97569bf0314)

### Farm
`pnpm run adapter-balances ellipsis-finance bsc 0xd4d01c4367ed2d4ab5c2f734d640f7ffe558e8a8`

![ellipsis-farm-0xd4d01c4367ed2d4ab5c2f734d640f7ffe558e8a8](https://github.com/llamafolio/llamafolio-api/assets/110820448/ed2c9e61-8e89-4f51-af35-74c03d8f8240)
