### PR TITLE
Feat: Adapter, Lido (moonbeam)

### DIFF
--- a/src/adapters/lido/index.ts
+++ b/src/adapters/lido/index.ts
@@ -1,10 +1,12 @@
 import type { Adapter } from '@lib/adapter'
 
 import * as ethereum from './ethereum'
+import * as moonbeam from './moonbeam'
 
 const adapter: Adapter = {
   id: 'lido',
   ethereum,
+  moonbeam,
 }
 
 export default adapter

--- a/src/adapters/lido/moonbeam/index.ts
+++ b/src/adapters/lido/moonbeam/index.ts
@@ -1,0 +1,30 @@
+import type { Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+import { getSingleStakeBalance } from '@lib/stake'
+
+const stDOT: Contract = {
+  chain: 'moonbeam',
+  address: '0xfa36fe1da08c89ec72ea1f0143a35bfd5daea108',
+  name: 'Liquid staked DOT',
+  symbol: 'stDOT',
+  decimals: 10,
+  underlyings: ['0xFfFFfFff1FcaCBd218EDc0EbA20Fc2308C778080'],
+}
+
+export const getContracts = () => {
+  return {
+    contracts: {
+      stDOT,
+    },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    stDOT: getSingleStakeBalance,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}


### PR DESCRIPTION
Add Lido on moonbeam chain

- [x] store contracts
- [x] stake

`pnpm run adapter-balances lido moonbeam 0x16674814ea6a7aac3decb877ea8fd01deb5c333d`

![lido-moon-0x16674814ea6a7aac3decb877ea8fd01deb5c333d](https://github.com/llamafolio/llamafolio-api/assets/110820448/cf225fb7-ac01-4400-af15-fd48fee88ff9)
