### PR TITLE
Feat: Adapter, Uniswap-v3

### DIFF
--- a/src/adapters/uniswap-v3/common/pools.ts
+++ b/src/adapters/uniswap-v3/common/pools.ts
@@ -203,7 +203,8 @@ export async function getTokenIdsBalances(
     .map((slot0Res, idx) => {
       const pool = poolsRes[idx].output
       const positionRes = positionsRes[idx]
-      if (!pool || !positionRes.success) {
+      // Uniswap rewarder address doesnt need to be display on llamafolio 'Claim Rewards/Uniswap-LP.org'
+      if (!pool || pool === '0x6e5db687c2f089fb68232B08B3b669659C7c836C' || !positionRes.success) {
         return null
       }
 
@@ -287,6 +288,11 @@ export async function getTokenIdsBalances(
           { ...token0, amount: rewardAmounts[0] },
           { ...token1, amount: rewardAmounts[1] },
         ]
+      }
+
+      const underlyings = balance.underlyings as Balance[]
+      if (!underlyings || underlyings[0].amount === 0n || underlyings[1].amount === 0n) {
+        return null
       }
 
       return balance


### PR DESCRIPTION
Logic to prevent to display all uniswap LPs on llamafolio

`pnpm run adapter-balances uniswap-v3 ethereum 0xbdfa4f4492dd7b7cf211209c4791af8d52bf5c50`


BEFORE
![uniswap_list](https://github.com/llamafolio/llamafolio-api/assets/110820448/65a9d31d-bcd8-4db7-b97b-e07ecee9ba2b)

WITH CLAIM ADDRESS
![rewarder](https://github.com/llamafolio/llamafolio-api/assets/110820448/45dac440-ed24-4da3-a4e4-a284afd3d1cf)

NOW
![rm_rewarder](https://github.com/llamafolio/llamafolio-api/assets/110820448/4556f317-7417-4dd3-b400-a2811637dc4e)
