### PR TITLE
Feat: Adapter, Across

### DIFF
--- a/src/adapters/across/ethereum/v1/balance.ts
+++ b/src/adapters/across/ethereum/v1/balance.ts
@@ -40,11 +40,13 @@ export async function getAcrossLPBalances(ctx: BalancesContext, pools: Contract[
 
     const fmtUnderlyings = {
       ...underlying,
+      decimals: 18,
       amount: (userBalanceOfRes.output * underlyingsBalanceRes.output) / totalSupplyRes.output,
     }
 
     balances.push({
       ...pool,
+      decimals: 18,
       amount: userBalanceOfRes.output,
       underlyings: [fmtUnderlyings],
       rewards: undefined,


### PR DESCRIPTION
Fix decimals on underlyings used by Across to fit with real values on dApp

`pnpm run adapter-balances across ethereum 0xbdfa4f4492dd7b7cf211209c4791af8d52bf5c50`

BEFORE
![across_now](https://github.com/llamafolio/llamafolio-api/assets/110820448/22ce8ce8-9b82-4e42-b6cd-4f75185290c4)

NOW
![fmtUnderlyingsAcross](https://github.com/llamafolio/llamafolio-api/assets/110820448/e80669a8-d33c-4d41-b96f-d93eb1d6b0d9)
