### PR TITLE
Feat: Adapter, SNX (Ethereum-Optimism)

### DIFF
--- a/src/adapters/synthetix/common/farm.ts
+++ b/src/adapters/synthetix/common/farm.ts
@@ -1,0 +1,115 @@
+import type { ProviderBalancesParams } from '@adapters/badger-dao/common/provider'
+import { getArrakisProvider } from '@adapters/synthetix/common/provider/arrakis'
+import { getBalancerProvider } from '@adapters/synthetix/common/provider/balancer'
+import { getCurveProvider } from '@adapters/synthetix/common/provider/curve'
+import { getSnxProvider } from '@adapters/synthetix/common/provider/snx'
+import { getUniswapProvider } from '@adapters/synthetix/common/provider/uniswap'
+import type { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { groupBy } from '@lib/array'
+import { abi as erc20Abi } from '@lib/erc20'
+import type { Call } from '@lib/multicall'
+import { multicall } from '@lib/multicall'
+
+const abi = {
+  earned: {
+    constant: true,
+    inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
+    name: 'earned',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+const SNX: { [key: string]: Contract } = {
+  ethereum: {
+    chain: 'ethereum',
+    address: '0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f',
+    decimals: 18,
+    symbol: 'SNX',
+  },
+  optimism: {
+    chain: 'optimism',
+    address: '0x8700daec35af8ff88c16bdf0418774cb3d7599b4',
+    decimals: 18,
+    symbol: 'SNX',
+  },
+}
+
+export async function getSNXFarmBalances(ctx: BalancesContext, pools: Contract[]): Promise<Balance[]> {
+  const balances: Balance[] = []
+
+  const calls: Call<typeof abi.earned>[] = pools.map((pool) => ({
+    target: pool.address,
+    params: [ctx.address],
+  }))
+
+  const [balanceOfsRes, earnedsRes] = await Promise.all([
+    multicall({ ctx, calls, abi: erc20Abi.balanceOf }),
+    multicall({ ctx, calls, abi: abi.earned }),
+  ])
+
+  for (let poolIdx = 0; poolIdx < pools.length; poolIdx++) {
+    const pool = pools[poolIdx]
+    const balanceOfRes = balanceOfsRes[poolIdx]
+    const earnedRes = earnedsRes[poolIdx]
+
+    if (!balanceOfRes.success || balanceOfRes.output === 0n || !earnedRes.success) {
+      continue
+    }
+
+    balances.push({
+      ...pool,
+      address: pool.token!,
+      amount: balanceOfRes.output,
+      underlyings: pool.underlyings as Contract[],
+      rewards: [{ ...SNX[ctx.chain], amount: earnedRes.output }],
+      category: 'farm',
+    })
+  }
+
+  return getUnderlyingsBadgerBalances(ctx, balances)
+}
+
+type Provider = (ctx: BalancesContext, pools: ProviderBalancesParams[]) => Promise<(ProviderBalancesParams | Balance)[]>
+
+const providers: Record<string, Provider | undefined> = {
+  snx: getSnxProvider,
+  arrakis: getArrakisProvider,
+  balancer: getBalancerProvider,
+  curve: getCurveProvider,
+  uniswap: getUniswapProvider,
+}
+
+const getUnderlyingsBadgerBalances = async (ctx: BalancesContext, pools: Contract[]): Promise<Balance[]> => {
+  // add totalSupply, required to get some formatted underlyings balances
+  const totalSuppliesRes = await multicall({
+    ctx,
+    calls: pools.map((pool) => ({ target: pool.token! })),
+    abi: erc20Abi.totalSupply,
+  })
+
+  for (let poolIdx = 0; poolIdx < pools.length; poolIdx++) {
+    const totalSupplyRes = totalSuppliesRes[poolIdx]
+    if (totalSupplyRes.success) {
+      pools[poolIdx].totalSupply = totalSupplyRes.output
+    }
+  }
+
+  // resolve underlyings
+  const poolsByProvider = groupBy(pools, 'provider')
+
+  return (
+    await Promise.all(
+      Object.keys(poolsByProvider).map((providerId) => {
+        const providerFn = providers[providerId]
+        if (!providerFn) {
+          return poolsByProvider[providerId] as Balance[]
+        }
+
+        return providerFn(ctx, poolsByProvider[providerId] as ProviderBalancesParams[])
+      }),
+    )
+  ).flat()
+}

--- a/src/adapters/synthetix/common/provider/arrakis.ts
+++ b/src/adapters/synthetix/common/provider/arrakis.ts
@@ -1,0 +1,53 @@
+import type { ProviderBalancesParams } from '@adapters/badger-dao/common/provider'
+import type { Balance, BalancesContext } from '@lib/adapter'
+import { multicall } from '@lib/multicall'
+
+const abi = {
+  getUnderlyingBalances: {
+    inputs: [],
+    name: 'getUnderlyingBalances',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'amount0Current',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount1Current',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+export async function getArrakisProvider(
+  ctx: BalancesContext,
+  pools: ProviderBalancesParams[],
+): Promise<ProviderBalancesParams[]> {
+  const underlyingBalancesRes = await multicall({
+    ctx,
+    calls: pools.map((pool) => ({ target: pool.token! } as const)),
+    abi: abi.getUnderlyingBalances,
+  })
+
+  for (let i = 0; i < pools.length; i++) {
+    const pool = pools[i]
+    const underlyings = pool.underlyings
+    const underlyingBalances = underlyingBalancesRes[i]
+    if (!underlyingBalances.success) {
+      continue
+    }
+
+    const [amount0Current, amount1Current] = underlyingBalances.output
+
+    ;(underlyings![0] as Balance).amount = (pool.amount * amount0Current) / pool.totalSupply
+    ;(underlyings![1] as Balance).amount = (pool.amount * amount1Current) / pool.totalSupply
+
+    pool.underlyings = [underlyings![0], underlyings![1]]
+  }
+
+  return pools
+}

--- a/src/adapters/synthetix/common/provider/balancer.ts
+++ b/src/adapters/synthetix/common/provider/balancer.ts
@@ -1,0 +1,63 @@
+import type { ProviderBalancesParams } from '@adapters/badger-dao/common/provider'
+import type { BalancesContext, Contract } from '@lib/adapter'
+import { multicall } from '@lib/multicall'
+
+const abi = {
+  getBalance: {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'token',
+        type: 'address',
+      },
+    ],
+    name: 'getBalance',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+export async function getBalancerProvider(
+  ctx: BalancesContext,
+  pools: ProviderBalancesParams[],
+): Promise<ProviderBalancesParams[]> {
+  const underlyingsBalancesRes = await multicall({
+    ctx,
+    calls: pools.flatMap((pool) =>
+      pool.underlyings!.map((underlying) => ({ target: pool.address, params: [underlying.address] } as const)),
+    ),
+    abi: abi.getBalance,
+  })
+
+  let balanceOfIdx = 0
+  for (let poolIdx = 0; poolIdx < pools.length; poolIdx++) {
+    const pool = pools[poolIdx]
+    const { amount, totalSupply } = pool
+    const underlyings = pool.underlyings as Contract[]
+
+    if (!underlyings) {
+      continue
+    }
+
+    underlyings.forEach((underlying) => {
+      const underlyingsBalanceRes = underlyingsBalancesRes[balanceOfIdx].success
+        ? underlyingsBalancesRes[balanceOfIdx].output
+        : 0n
+
+      underlying.amount = (underlyingsBalanceRes! * amount) / totalSupply
+
+      balanceOfIdx++
+    })
+  }
+
+  return pools
+}

--- a/src/adapters/synthetix/common/provider/curve.ts
+++ b/src/adapters/synthetix/common/provider/curve.ts
@@ -1,0 +1,56 @@
+import type { ProviderBalancesParams } from '@adapters/badger-dao/common/provider'
+import type { Balance, BalancesContext } from '@lib/adapter'
+import { mapSuccess } from '@lib/array'
+import { multicall } from '@lib/multicall'
+
+const abi = {
+  get_pool_from_lp_token: {
+    stateMutability: 'view',
+    type: 'function',
+    name: 'get_pool_from_lp_token',
+    inputs: [{ name: '_token', type: 'address' }],
+    outputs: [{ name: '', type: 'address' }],
+  },
+  get_underlying_balances: {
+    stateMutability: 'view',
+    type: 'function',
+    name: 'get_underlying_balances',
+    inputs: [{ name: '_pool', type: 'address' }],
+    outputs: [{ name: '', type: 'uint256[8]' }],
+  },
+} as const
+
+export async function getCurveProvider(
+  ctx: BalancesContext,
+  pools: ProviderBalancesParams[],
+): Promise<ProviderBalancesParams[]> {
+  const CURVE_REGISTRY_ADDRESS = '0xF98B45FA17DE75FB1aD0e7aFD971b0ca00e379fC'
+
+  const poolAddressesRes = await multicall({
+    ctx,
+    calls: pools.map((pool) => ({ target: CURVE_REGISTRY_ADDRESS, params: [pool.address] } as const)),
+    abi: abi.get_pool_from_lp_token,
+  })
+
+  const underlyingsBalancesRes = await multicall({
+    ctx,
+    calls: mapSuccess(poolAddressesRes, (pool) => ({ target: CURVE_REGISTRY_ADDRESS, params: [pool.output] } as const)),
+    abi: abi.get_underlying_balances,
+  })
+
+  for (let poolIdx = 0; poolIdx < pools.length; poolIdx++) {
+    const pool = pools[poolIdx]
+    const { underlyings, amount, totalSupply } = pool
+    const underlyingsBalanceRes = underlyingsBalancesRes[poolIdx]
+
+    if (!underlyings || !underlyingsBalanceRes.success) {
+      continue
+    }
+
+    underlyings.forEach((underlying, underlyingIdx) => {
+      const underlyingBalance = underlyingsBalanceRes.output[underlyingIdx]
+      ;(underlying as Balance).amount = (underlyingBalance * amount) / totalSupply
+    })
+  }
+  return pools
+}

--- a/src/adapters/synthetix/common/provider/snx.ts
+++ b/src/adapters/synthetix/common/provider/snx.ts
@@ -1,0 +1,16 @@
+import type { ProviderBalancesParams } from '@adapters/badger-dao/common/provider'
+import type { Balance, BalancesContext } from '@lib/adapter'
+
+export const getSnxProvider = async (
+  _ctx: BalancesContext,
+  pools: ProviderBalancesParams[],
+): Promise<ProviderBalancesParams[]> => {
+  for (const pool of pools) {
+    const { amount, underlyings } = pool
+    if (underlyings && underlyings.length < 2) {
+      ;(pool.underlyings![0] as Balance).amount = amount
+    }
+  }
+
+  return pools
+}

--- a/src/adapters/synthetix/common/provider/uniswap.ts
+++ b/src/adapters/synthetix/common/provider/uniswap.ts
@@ -1,0 +1,6 @@
+import type { Balance, BalancesContext } from '@lib/adapter'
+import { getUnderlyingBalances } from '@lib/uniswap/v2/pair'
+
+export async function getUniswapProvider(ctx: BalancesContext, pools: Balance[]): Promise<Balance[]> {
+  return getUnderlyingBalances(ctx, pools)
+}

--- a/src/adapters/synthetix/ethereum/index.ts
+++ b/src/adapters/synthetix/ethereum/index.ts
@@ -1,4 +1,5 @@
 import { getSNXBalances } from '@adapters/synthetix/common/balance'
+import { getSNXFarmBalances } from '@adapters/synthetix/common/farm'
 import type { Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
 
@@ -10,15 +11,79 @@ const SNX: Contract = {
   rewarder: '0x83105D7CDd2fd9b8185BFF1cb56bB1595a618618',
 }
 
+const farmers: Contract[] = [
+  {
+    chain: 'ethereum',
+    address: '0x13c1542a468319688b89e323fe9a3be3a90ebb27',
+    token: '0x075b1bb99792c9E1041bA13afEf80C91a1e70fB3',
+    underlyings: [
+      '0xeb4c2781e4eba804ce9a9803c67d0893436bb27d',
+      '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
+      '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6',
+    ],
+    provider: 'curve',
+  },
+  {
+    chain: 'ethereum',
+    address: '0xf0de877f2f9e7a60767f9ba662f10751566ad01c',
+    token: '0x055dB9AFF4311788264798356bbF3a733AE181c6',
+    underlyings: ['0x57Ab1ec28D129707052df4dF418D58a2D46d5f51', '0x918dA91Ccbc32B7a6A0cc4eCd5987bbab6E31e6D'],
+    provider: 'balancer',
+  },
+  {
+    chain: 'ethereum',
+    address: '0xfbaedde70732540ce2b11a8ac58eb2dc0d69de10',
+    token: '0x815F8eF4863451f4Faf34FBc860034812E7377d9',
+    underlyings: ['0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F', '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'],
+    provider: 'balancer',
+  },
+  {
+    chain: 'ethereum',
+    address: '0x167009dcda2e49930a71712d956f02cc980dcc1b',
+    token: '0xD6014EA05BDe904448B743833dDF07c3C7837481',
+    underlyings: ['0x2260fac5e5542a773aa44fbcfedf7c193bc2c599'],
+    provider: 'snx',
+  },
+  {
+    chain: 'ethereum',
+    address: '0x8302fe9f0c509a996573d3cc5b0d5d51e4fdd5ec',
+    token: '0x34a0216C5057bC18e5d34D4405284564eFd759b2',
+    underlyings: ['0x261EfCdD24CeA98652B9700800a13DfBca4103fF', '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'],
+    provider: 'uniswap',
+  },
+  {
+    chain: 'ethereum',
+    address: '0x3f27c540adae3a9e8c875c61e3b970b559d7f65d',
+    token: '0xA9859874e1743A32409f75bB11549892138BBA1E',
+    underlyings: ['0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'],
+    provider: 'snx',
+  },
+  {
+    chain: 'ethereum',
+    address: '0xc0d8994cd78ee1980885df1a0c5470fc977b5cfe',
+    token: '0x194eBd173F6cDacE046C53eACcE9B953F28411d1',
+    underlyings: ['0xdb25f211ab05b1c97d595516f45794528a807ad8', '0xd71ecff9342a5ced620049e616c5035f1db98620'],
+    provider: 'curve',
+  },
+  {
+    chain: 'ethereum',
+    address: '0xdc338c7544654c7dadfeb7e44076e457963113b0',
+    token: '0x74821343b5b969c0D4b31aFF3931E00a40990CfD',
+    underlyings: ['0x57Ab1ec28D129707052df4dF418D58a2D46d5f51', '0x9CF7E61853ea30A41b02169391b393B901eac457'],
+    provider: 'balancer',
+  },
+]
+
 export const getContracts = async () => {
   return {
-    contracts: { SNX },
+    contracts: { SNX, farmers },
   }
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
   const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     SNX: getSNXBalances,
+    farmers: getSNXFarmBalances,
   })
 
   return {

--- a/src/adapters/synthetix/index.ts
+++ b/src/adapters/synthetix/index.ts
@@ -1,15 +1,12 @@
 import type { Adapter } from '@lib/adapter'
 
 import * as ethereum from './ethereum'
-// import * as optimism from './optimism'
+import * as optimism from './optimism'
 
 const adapter: Adapter = {
   id: 'synthetix',
   ethereum,
-  // optimism,
+  optimism,
 }
-
-// TODO: Farm parts using Curve logic, HealthFactor
-// https://docs.synthetix.io/
 
 export default adapter

--- a/src/adapters/synthetix/optimism/index.ts
+++ b/src/adapters/synthetix/optimism/index.ts
@@ -1,4 +1,5 @@
 import { getSNXBalances } from '@adapters/synthetix/common/balance'
+import { getSNXFarmBalances } from '@adapters/synthetix/common/farm'
 import type { Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
 
@@ -10,15 +11,26 @@ const SNX: Contract = {
   rewarder: '0xf9FE3607e6d19D8dC690DD976061a91D4A0db30B',
 }
 
+const farmers: Contract[] = [
+  {
+    chain: 'optimism',
+    address: '0xfd49c7ee330fe060ca66fee33d49206eb96f146d',
+    token: '0x83beefb4ca39af649d03969b442c0e9f4e1732d8',
+    underlyings: ['0x4200000000000000000000000000000000000006', '0x8700daec35af8ff88c16bdf0418774cb3d7599b4'],
+    provider: 'arrakis',
+  },
+]
+
 export const getContracts = async () => {
   return {
-    contracts: { SNX },
+    contracts: { SNX, farmers },
   }
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
   const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     SNX: getSNXBalances,
+    farmers: getSNXFarmBalances,
   })
 
   return {


### PR DESCRIPTION
Add different farm providers on SNX (Ethereum + Optimism)

- [x] Store contracts
- [x] farm logics

### Optimism
`pnpm run adapter-balances synthetix optimism 0xd09583bbf77d0da34cd02612fe41af4ae37ebc95`

![snx_op_farm-arrakis-0xd09583bbf77d0da34cd02612fe41af4ae37ebc95](https://github.com/llamafolio/llamafolio-api/assets/110820448/f9d20814-8066-4924-9a98-d09cb7e7d9a6)


### Ethereum
`pnpm run adapter-balances synthetix ethereum 0xdcabc755fb10931e6d8059113f762cd8a6813deb`

![snx-balancer-farm-0xdcabc755fb10931e6d8059113f762cd8a6813deb](https://github.com/llamafolio/llamafolio-api/assets/110820448/93f2da5c-1abb-4760-8140-c9c857888ad6)

`pnpm run adapter synthetix ethereum 0xb9fc7a5e4147e013e20348d94ad2badadf4d2045`

![snx-curve-farm-adapter-0xb9fc7a5e4147e013e20348d94ad2badadf4d2045](https://github.com/llamafolio/llamafolio-api/assets/110820448/e7aa1c8f-9323-48b4-95a6-02cdcc618d82)

