### PR TITLE
Feat: Adapter, Elephant-money

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -118,6 +118,7 @@
         "curve-dex",
         "definix",
         "dydx",
+        "elephant-money",
         "ellipsis-finance",
         "equalizer-exchange",
         "ether.fi",

--- a/src/adapters/elephant-money/bsc/farmer.ts
+++ b/src/adapters/elephant-money/bsc/farmer.ts
@@ -1,0 +1,80 @@
+import type { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { mapSuccessFilter } from '@lib/array'
+import { multicall } from '@lib/multicall'
+import type { Token } from '@lib/token'
+
+const abi = {
+  users: {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    name: 'users',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'assetBalance',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'balance',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'payouts',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'last_time',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+const TRUNK: Token = {
+  chain: 'bsc',
+  address: '0xdd325c38b12903b727d16961e61333f4871a70e0',
+  decimals: 18,
+  symbol: 'TRUNK',
+}
+
+export async function getElephantFarmBalances(ctx: BalancesContext, farmer: Contract): Promise<Balance[] | undefined> {
+  const tokens = farmer.underlyings as Contract[]
+  if (!tokens) {
+    return
+  }
+
+  const userBalancesRes = await multicall({
+    ctx,
+    calls: tokens.map((token) => ({ target: farmer.address, params: [token.address, ctx.address] } as const)),
+    abi: abi.users,
+  })
+
+  const balances: Balance[] = mapSuccessFilter(userBalancesRes, (res, idx) => {
+    const [assetBalance, balance, _payouts, _last_time] = res.output
+
+    return {
+      ...tokens[idx],
+      amount: assetBalance,
+      underlyings: undefined,
+      rewards: [{ ...TRUNK, amount: balance }],
+      category: 'farm',
+    }
+  })
+
+  return balances
+}

--- a/src/adapters/elephant-money/bsc/index.ts
+++ b/src/adapters/elephant-money/bsc/index.ts
@@ -1,0 +1,90 @@
+import { getElephantFarmBalances } from '@adapters/elephant-money/bsc/farmer'
+import {
+  getElephantStakeBalances,
+  getElephantTrumpetBalance,
+  getElephantTrunkBalance,
+} from '@adapters/elephant-money/bsc/stake'
+import type { BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+const trunkStaker: Contract = {
+  chain: 'bsc',
+  address: '0x7c4dad1b249efdc998f3569c8537866639b914b7',
+  token: '0xdd325c38b12903b727d16961e61333f4871a70e0',
+}
+
+const trumpetStaker: Contract = {
+  chain: 'bsc',
+  address: '0x574a691d05eee825299024b2de584b208647e073',
+  token: '0xdd325c38b12903b727d16961e61333f4871a70e0',
+}
+
+const stakers: Contract[] = [
+  {
+    chain: 'bsc',
+    address: '0x564d4126af2b195ffaa7fb470ed658b1d9d07a54',
+    token: '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c',
+    rewards: ['0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c'],
+  },
+  {
+    chain: 'bsc',
+    address: '0xec10059ba900883ed6154883e9f3a1c24fce1eb7',
+    token: '0xdd325c38b12903b727d16961e61333f4871a70e0',
+    rewards: ['0xdd325c38b12903b727d16961e61333f4871a70e0'],
+  },
+  {
+    chain: 'bsc',
+    address: '0x83ad16274c8bdd547582de02db25a81a7a33759f',
+    token: '0x7130d2a12b9bcbfae4f2634d864a1ee1ce3ead9c',
+    rewards: ['0x7130d2a12b9bcbfae4f2634d864a1ee1ce3ead9c'],
+  },
+  {
+    chain: 'bsc',
+    address: '0x599640ddacb546b1446fa149f4a9ceecd3fcc87a',
+    token: '0xe9e7cea3dedca5984780bafc599bd69add087d56',
+    rewards: ['0xe9e7cea3dedca5984780bafc599bd69add087d56'],
+  },
+  {
+    chain: 'bsc',
+    address: '0xd397f06eecd4eb9af0492874be0d24d67560ff69',
+    token: '0x190b589cf9fb8ddeabbfeae36a813ffb2a702454',
+    rewards: ['0x190b589cf9fb8ddeabbfeae36a813ffb2a702454'],
+  },
+]
+
+const farmer: Contract = {
+  chain: 'bsc',
+  address: '0x71b00a9c9cc1902efddd6ba28850f6f34f5938ed',
+  underlyings: [
+    '0x7130d2a12b9bcbfae4f2634d864a1ee1ce3ead9c',
+    '0x2170ed0880ac9a755fd29b2688956bd959f933f8',
+    '0x55d398326f99059ff775485246999027b3197955',
+    '0xe9e7cea3dedca5984780bafc599bd69add087d56',
+    '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d',
+    '0x0e09fabb73bd3ade0a17ecc321fd13a19e81ce82',
+    '0xba2ae424d960c26247dd6c32edc70b295c744c43',
+    '0xcc42724c6683b7e57334c4e856f4c9965ed682bd',
+    '0x1d2f0da169ceb9fc7b3144628db156f3f6c60dbe',
+    '0x1af3f329e8be154074d8769d1ffa4ee058b1dbc3',
+    '0x3ee2200efb3400fabb9aacf31297cbdd1d435d47',
+  ],
+}
+
+export const getContracts = async (_ctx: BaseContext) => {
+  return {
+    contracts: { stakers, trunkStaker, trumpetStaker, farmer },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    stakers: getElephantStakeBalances,
+    trunkStaker: getElephantTrunkBalance,
+    trumpetStaker: getElephantTrumpetBalance,
+    farmer: getElephantFarmBalances,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/elephant-money/bsc/stake.ts
+++ b/src/adapters/elephant-money/bsc/stake.ts
@@ -1,0 +1,192 @@
+import type { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { call } from '@lib/call'
+import { multicall } from '@lib/multicall'
+import { parseEther } from 'viem'
+
+const abi = {
+  balanceOf: {
+    constant: true,
+    inputs: [
+      {
+        name: '_customerAddress',
+        type: 'address',
+      },
+    ],
+    name: 'balanceOf',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  dividendsOf: {
+    constant: true,
+    inputs: [
+      {
+        name: '_customerAddress',
+        type: 'address',
+      },
+    ],
+    name: 'dividendsOf',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  getUser: {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_user',
+        type: 'address',
+      },
+    ],
+    name: 'getUser',
+    outputs: [
+      {
+        components: [
+          {
+            internalType: 'bool',
+            name: 'exists',
+            type: 'bool',
+          },
+          {
+            internalType: 'uint256',
+            name: 'deposits',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'compound_deposits',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'current_balance',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'payouts',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'rewards',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'last_time',
+            type: 'uint256',
+          },
+        ],
+        internalType: 'struct StampedeUser',
+        name: '',
+        type: 'tuple',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  calculatePrice: {
+    inputs: [],
+    name: 'calculatePrice',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+export async function getElephantStakeBalances(ctx: BalancesContext, stakers: Contract[]): Promise<Balance[]> {
+  const balances: Balance[] = []
+
+  const [userBalancesRes, userRewardsRes] = await Promise.all([
+    multicall({
+      ctx,
+      calls: stakers.map((staker) => ({ target: staker.address, params: [ctx.address] } as const)),
+      abi: abi.balanceOf,
+    }),
+    multicall({
+      ctx,
+      calls: stakers.map((staker) => ({ target: staker.address, params: [ctx.address] } as const)),
+      abi: abi.dividendsOf,
+    }),
+  ])
+
+  for (let stakeIdx = 0; stakeIdx < stakers.length; stakeIdx++) {
+    const staker = stakers[stakeIdx]
+    const reward = staker.rewards?.[0] as Contract
+    const userBalanceRes = userBalancesRes[stakeIdx]
+    const userRewardRes = userRewardsRes[stakeIdx]
+
+    if (!userBalanceRes.success) {
+      continue
+    }
+
+    const fmtRewards = userRewardRes.success ? [{ ...reward, amount: userRewardRes.output }] : undefined
+
+    balances.push({
+      ...staker,
+      amount: userBalanceRes.output,
+      underlyings: undefined,
+      rewards: fmtRewards,
+      category: 'stake',
+    })
+  }
+
+  return balances
+}
+
+export async function getElephantTrunkBalance(ctx: BalancesContext, staker: Contract): Promise<Balance> {
+  const userBalance = await call({ ctx, target: staker.address, params: [ctx.address], abi: abi.getUser })
+
+  return {
+    ...staker,
+    amount: userBalance.current_balance,
+    underlyings: undefined,
+    rewards: undefined,
+    category: 'stake',
+  }
+}
+
+export async function getElephantTrumpetBalance(ctx: BalancesContext, staker: Contract): Promise<Balance> {
+  const [userBalancesRes, exchangeRate] = await Promise.all([
+    call({
+      ctx,
+      target: staker.address,
+      params: [ctx.address],
+      abi: abi.balanceOf,
+    }),
+    call({
+      ctx,
+      target: staker.address,
+      abi: abi.calculatePrice,
+    }),
+  ])
+
+  const fmtAmount = (userBalancesRes * exchangeRate) / parseEther('1.0')
+
+  return {
+    ...staker,
+    amount: fmtAmount,
+    underlyings: undefined,
+    rewards: undefined,
+    category: 'stake',
+  }
+}

--- a/src/adapters/elephant-money/index.ts
+++ b/src/adapters/elephant-money/index.ts
@@ -1,0 +1,10 @@
+import type { Adapter } from '@lib/adapter'
+
+import * as bsc from './bsc'
+
+const adapter: Adapter = {
+  id: 'elephant-money',
+  bsc,
+}
+
+export default adapter

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -49,6 +49,7 @@ import crvusd from '@adapters/crvusd'
 import curveDex from '@adapters/curve-dex'
 import definix from '@adapters/definix'
 import dydx from '@adapters/dydx'
+import elephantMoney from '@adapters/elephant-money'
 import ellipsisFinance from '@adapters/ellipsis-finance'
 import equalizerExchange from '@adapters/equalizer-exchange'
 import etherFi from '@adapters/ether.fi'
@@ -257,6 +258,7 @@ export const adapters: Adapter[] = [
   curveDex,
   definix,
   dydx,
+  elephantMoney,
   ellipsisFinance,
   equalizerExchange,
   etherFi,


### PR DESCRIPTION
Add Elephant-money adapter on bsc chain

- [x] store contracts
- [x] farm
- [x] stake


/!\ - Unfortunately, price of TRUNK token is not supported by Defillama API - /!\

`pnpm run adapter-balances elephant-money bsc scan 0xcb71eb21f53a2f4de0f26dc90518df10be13d1ec`

![elephant-stake-0xcb71eb21f53a2f4de0f26dc90518df10be13d1ec](https://github.com/llamafolio/llamafolio-api/assets/110820448/ee0233dd-3fc4-4b4d-bf99-f88914e94fad)
