### PR TITLE
Fix: Curve  

### DIFF
--- a/src/adapters/curve-dex/common/balance.ts
+++ b/src/adapters/curve-dex/common/balance.ts
@@ -100,6 +100,22 @@ const stableRegistry: { [key: string]: `0x${string}` } = {
   polygon: '0x094d12e5b541784701FD8d65F11fc0598FBC6332',
 }
 
+const blacklist = [
+  { chain: 'avalanche', registryId: 'stableSwap' },
+  { chain: 'fantom', registryId: 'stableSwap' },
+  { chain: 'polygon', registryId: 'stableSwap' },
+  { chain: 'ethereum', address: '0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8' },
+  { chain: 'ethereum', address: '0x3b3ac5386837dc563660fb6a0937dfaa5924333b' },
+  { chain: 'ethereum', address: '0x05ca5c01629a8e5845f12ea3a03ff7331932233a' },
+  { chain: 'ethereum', address: '0xf5194c3325202f456c95c1cf0ca36f8475c1949f' },
+]
+
+function isInBlacklist(item: any) {
+  return blacklist.some((blacklistedItem) =>
+    Object.entries(blacklistedItem).every(([key, value]) => item[key] === value),
+  )
+}
+
 export async function getPoolsBalances(
   ctx: BalancesContext,
   pools: Contract[],
@@ -190,9 +206,8 @@ export const getUnderlyingsPoolsBalances = async (
         ...underlyings[underlyingIdx],
         // on Avalanche & Fantom & Polygon, stablePool uses fixed decimals as 18 even if tokens are USDC or USDT
         decimals:
-          (ctx.chain === 'avalanche' && poolBalance.registryId === 'stableSwap') ||
-          (ctx.chain === 'fantom' && poolBalance.registryId === 'stableSwap') ||
-          (ctx.chain === 'polygon' && poolBalance.registryId === 'stableSwap')
+          isInBlacklist({ chain: ctx.chain, registryId: poolBalance.registryId }) ||
+          isInBlacklist({ chain: ctx.chain, address: poolBalance.address })
             ? 18
             : underlyings[underlyingIdx].decimals,
         amount: (underlyingsBalance * poolBalance.amount) / totalSupply,

--- a/src/adapters/curve-dex/common/balance.ts
+++ b/src/adapters/curve-dex/common/balance.ts
@@ -135,10 +135,11 @@ export async function getPoolsBalances(
       return null
     }
 
-    return {
-      ...pool,
-      amount: res.output,
-    }
+    if (res.output > 0n)
+      return {
+        ...pool,
+        amount: res.output,
+      }
   }).filter(isNotNullish) as Balance[]
 
   return getUnderlyingsPoolsBalances(ctx, poolBalances, registry)
@@ -182,6 +183,8 @@ export const getUnderlyingsPoolsBalances = async (
 
     const totalSupply = totalSupplyRes.output
 
+    console.log(totalSupply)
+
     const poolBalance: PoolBalance = {
       ...pools[poolIdx],
       registry: pools[poolIdx].registry,
@@ -193,9 +196,10 @@ export const getUnderlyingsPoolsBalances = async (
     }
 
     for (let underlyingIdx = 0; underlyingIdx < underlyings.length; underlyingIdx++) {
-      const underlyingBalanceOfRes = get_underlying_balancesOfRes[balanceOfIdx].success
-        ? get_underlying_balancesOfRes[balanceOfIdx]
-        : get_balancesOfRes[balanceOfIdx]
+      const underlyingBalanceOfRes =
+        get_underlying_balancesOfRes[balanceOfIdx] && get_underlying_balancesOfRes[balanceOfIdx].success
+          ? get_underlying_balancesOfRes[balanceOfIdx]
+          : get_balancesOfRes[balanceOfIdx]
 
       const underlyingsBalance =
         underlyingBalanceOfRes && underlyingBalanceOfRes.output?.filter(isNotNullish) != undefined

--- a/src/adapters/curve-dex/common/balance.ts
+++ b/src/adapters/curve-dex/common/balance.ts
@@ -183,8 +183,6 @@ export const getUnderlyingsPoolsBalances = async (
 
     const totalSupply = totalSupplyRes.output
 
-    console.log(totalSupply)
-
     const poolBalance: PoolBalance = {
       ...pools[poolIdx],
       registry: pools[poolIdx].registry,


### PR DESCRIPTION
Small-Fix decimals for some underlyings were too low -> blacklist logic to prevent these exceptions

`pnpm run adapter-balances curve-dex ethereum 0x50664ede715e131f584d3e7eaabd7818bb20a068`

### **BEFORE**
![curveFix-0x50664ede715e131f584d3e7eaabd7818bb20a068-BEFORE](https://github.com/llamafolio/llamafolio-api/assets/110820448/48726063-86a9-43b7-b6f2-7995c7ebbdfd)

### **AFTER**
![curveFix-0x50664ede715e131f584d3e7eaabd7818bb20a068-AFTER](https://github.com/llamafolio/llamafolio-api/assets/110820448/6a76ded8-8894-482a-b82b-e14f5d8e806a)

==================================================================================

`pnpm run adapter-balances curve-dex ethereum 0x7a16ff8270133f063aab6c9977183d9e72835428`

### **BEFORE**
![curve-before-0x7a16ff8270133f063aab6c9977183d9e72835428](https://github.com/llamafolio/llamafolio-api/assets/110820448/2c082cd6-3ede-4ab6-a4f7-a28ff8194cc3)

### **AFTER**
![curve-after-0x7a16ff8270133f063aab6c9977183d9e72835428](https://github.com/llamafolio/llamafolio-api/assets/110820448/506af336-1141-411f-affc-cf98ef4c4cf2)

