### PR TITLE
Fix: Aave_v2 rewards (stkAave)

### DIFF
--- a/src/adapters/aave-v2/common/rewards.ts
+++ b/src/adapters/aave-v2/common/rewards.ts
@@ -1,6 +1,19 @@
 import type { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 
+const abi = {
+  getRewardsBalance: {
+    inputs: [
+      { internalType: 'address[]', name: 'assets', type: 'address[]' },
+      { internalType: 'address', name: 'user', type: 'address' },
+    ],
+    name: 'getRewardsBalance',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
 export async function getLendingRewardsBalances(
   ctx: BalancesContext,
   incentiveController: Contract,
@@ -17,16 +30,7 @@ export async function getLendingRewardsBalances(
     ctx,
     target: incentiveController.address,
     params: [assetsAddressesList, ctx.address],
-    abi: {
-      inputs: [
-        { internalType: 'address[]', name: 'assets', type: 'address[]' },
-        { internalType: 'address', name: 'user', type: 'address' },
-      ],
-      name: 'getRewardsBalance',
-      outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-      stateMutability: 'view',
-      type: 'function',
-    },
+    abi: abi.getRewardsBalance,
   })
 
   rewards.push({

--- a/src/adapters/aave-v2/common/rewards.ts
+++ b/src/adapters/aave-v2/common/rewards.ts
@@ -35,6 +35,7 @@ export async function getLendingRewardsBalances(
     decimals: rewardToken.decimals,
     symbol: rewardToken.symbol,
     amount: userRewardsRes,
+    underlyings: rewardToken.underlyings as Contract[],
     category: 'reward',
   })
 


### PR DESCRIPTION
Fix Aave_v2 rewards on ethereum with `1 stkAave = 1Aave`

`pnpm run adapter-balances aave-v2 ethereum 0x50664ede715e131f584d3e7eaabd7818bb20a068`

### BEFORE
![AAVE-rewards-price-before-0x50664ede715e131f584d3e7eaabd7818bb20a068](https://github.com/llamafolio/llamafolio-api/assets/110820448/de9d6504-82e3-46ce-b805-b591321db500)


### AFTER
![AAVE-rewards-price-after-0x50664ede715e131f584d3e7eaabd7818bb20a068](https://github.com/llamafolio/llamafolio-api/assets/110820448/1c9815a4-a86b-4e31-b1f1-fd765732dbd2)

