### PR TITLE
Feat: Adapter, Fractional-art

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -129,6 +129,7 @@
         "floor-dao",
         "flux-finance",
         "fortress-loans",
+        "fractional-art",
         "frax-finance",
         "fraxlend",
         "gains-network",

--- a/src/adapters/fractional-art/ethereum/index.ts
+++ b/src/adapters/fractional-art/ethereum/index.ts
@@ -1,0 +1,26 @@
+import { getFractionalVaults, getFractionalVaultsBalances } from '@adapters/fractional-art/ethereum/vault'
+import type { BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+const factory: Contract = {
+  chain: 'ethereum',
+  address: '0x85aa7f78bdb2de8f3e0c0010d99ad5853ffcfc63',
+}
+
+export const getContracts = async (ctx: BaseContext) => {
+  const vaults = await getFractionalVaults(ctx, factory)
+
+  return {
+    contracts: { factory, vaults },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    vaults: getFractionalVaultsBalances,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/fractional-art/ethereum/vault.ts
+++ b/src/adapters/fractional-art/ethereum/vault.ts
@@ -1,0 +1,89 @@
+import type { Balance, BalancesContext, BaseContext, Contract } from '@lib/adapter'
+import { mapSuccessFilter, rangeBI } from '@lib/array'
+import { call } from '@lib/call'
+import { abi as erc20Abi } from '@lib/erc20'
+import { multicall } from '@lib/multicall'
+
+const abi = {
+  vaultCount: {
+    inputs: [],
+    name: 'vaultCount',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  vaults: {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    name: 'vaults',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  token: {
+    inputs: [],
+    name: 'token',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+export async function getFractionalVaults(ctx: BaseContext, factory: Contract): Promise<Contract[]> {
+  const vaultCount = await call({ ctx, target: factory.address, abi: abi.vaultCount })
+
+  const vaultsRes = await multicall({
+    ctx,
+    calls: rangeBI(0n, vaultCount).map((idx) => ({ target: factory.address, params: [idx] } as const)),
+    abi: abi.vaults,
+  })
+
+  const contracts: Contract[] = mapSuccessFilter(vaultsRes, (res) => ({
+    chain: ctx.chain,
+    address: res.output,
+  }))
+
+  return contracts
+}
+
+export async function getFractionalVaultsBalances(ctx: BalancesContext, vaults: Contract[]): Promise<Balance[]> {
+  const userPricesRes = await multicall({
+    ctx,
+    calls: vaults.map((vault) => ({ target: vault.address, params: [ctx.address] } as const)),
+    abi: erc20Abi.balanceOf,
+  })
+
+  const balances: Balance[] = mapSuccessFilter(userPricesRes, (res, idx) => ({
+    ...vaults[idx],
+    decimals: 18,
+    amount: res.output,
+    underlyings: undefined,
+    rewards: undefined,
+    category: 'stake',
+  }))
+
+  return balances
+}

--- a/src/adapters/fractional-art/index.ts
+++ b/src/adapters/fractional-art/index.ts
@@ -1,0 +1,10 @@
+import type { Adapter } from '@lib/adapter'
+
+import * as ethereum from './ethereum'
+
+const adapter: Adapter = {
+  id: 'fractional-art',
+  ethereum,
+}
+
+export default adapter

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -60,6 +60,7 @@ import flamincome from '@adapters/flamincome'
 import floorDao from '@adapters/floor-dao'
 import fluxFinance from '@adapters/flux-finance'
 import fortressLoans from '@adapters/fortress-loans'
+import fractionalArt from '@adapters/fractional-art'
 import fraxFinance from '@adapters/frax-finance'
 import fraxlend from '@adapters/fraxlend'
 import gainsNetwork from '@adapters/gains-network'
@@ -269,6 +270,7 @@ export const adapters: Adapter[] = [
   floorDao,
   fluxFinance,
   fortressLoans,
+  fractionalArt,
   fraxFinance,
   fraxlend,
   gainsNetwork,


### PR DESCRIPTION
Add Fractional-art adapter, (nft stake)

- [x] store contracts
- [x] stake logic

`pnpm run adapterfractional-art ethereum 0x50664ede715e131f584d3e7eaabd7818bb20a068`

![fractional-stake-0x50664ede715e131f584d3e7eaabd7818bb20a068](https://github.com/llamafolio/llamafolio-api/assets/110820448/46b44922-04eb-415e-9eda-5766d89f6e30)

`pnpm run adapter-balances fractional-art ethereum 0x5dc58f812b2e244daba2fabd33f399cd699d7ddc`

![fractional-stake-0x5dc58f812b2e244daba2fabd33f399cd699d7ddc](https://github.com/llamafolio/llamafolio-api/assets/110820448/1512dc1c-8c64-458e-a612-6ed5912a8b49)


