### PR TITLE
Fix: Lib Lock

### DIFF
--- a/src/adapters/aura/ethereum/index.ts
+++ b/src/adapters/aura/ethereum/index.ts
@@ -57,7 +57,7 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pools: (...args) => getAuraPoolsBalances(...args, vaultBAL),
     auraStaker: getAuraBalStakerBalances,
-    auraLocker: (...args) => getMultipleLockerBalances(...args, AURA, [auraBal]),
+    auraLocker: (...args) => getMultipleLockerBalances(...args, AURA, [auraBal], false),
   })
 
   return {

--- a/src/adapters/convex-finance/ethereum/index.ts
+++ b/src/adapters/convex-finance/ethereum/index.ts
@@ -94,7 +94,7 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
     pools: (...args) => getConvexGaugesBalances(...args, metaRegistry),
     cvxRewardPool: getCVXStakeBalance,
     cvxCRVStaker: getCvxCrvStakeBalance,
-    locker: (...args) => getMultipleLockerBalances(...args, CVX, [cvxCRV, cvxFXS, FXS]),
+    locker: (...args) => getMultipleLockerBalances(...args, CVX, [cvxCRV, cvxFXS, FXS], true),
   })
 
   return {


### PR DESCRIPTION
There was an invalid Date on Convex.
Added a condition allowing the abi to be more flexible

`pnpm run adapter-balances convex-finance ethereum 0xa0f75491720835b36edc92d06ddc468d201e9b73`

### BEFORE
![invalida-date-convex-0xa0f75491720835b36edc92d06ddc468d201e9b73](https://github.com/llamafolio/llamafolio-api/assets/110820448/9f9f9b45-b5ef-470d-af5a-54f298f356ce)

### AFTER
![NOW-convex-0xa0f75491720835b36edc92d06ddc468d201e9b73](https://github.com/llamafolio/llamafolio-api/assets/110820448/49e1bf9f-bc98-4420-8772-327eadd77e85)
