### PR TITLE
Feat: Adapter, Ankr

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -78,6 +78,7 @@
         "alpaca-finance",
         "ambire-wallet",
         "angle",
+        "ankr",
         "annex",
         "apeswap-amm",
         "apeswap-lending",

--- a/src/adapters/ankr/avalanche/index.ts
+++ b/src/adapters/ankr/avalanche/index.ts
@@ -1,0 +1,25 @@
+import { getStakeBalance } from '@adapters/ankr/common/balance'
+import type { Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+const ankrAVAX: Contract = {
+  chain: 'avalanche',
+  address: '0xc3344870d52688874b06d844e0c36cc39fc727f6',
+  underlyings: ['0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7'],
+}
+
+export const getContracts = () => {
+  return {
+    contracts: { ankrAVAX },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    ankrAVAX: getStakeBalance,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/ankr/bsc/index.ts
+++ b/src/adapters/ankr/bsc/index.ts
@@ -1,0 +1,25 @@
+import { getStakeBalance } from '@adapters/ankr/common/balance'
+import type { Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+const ankrBNB: Contract = {
+  chain: 'bsc',
+  address: '0x52f24a5e03aee338da5fd9df68d2b6fae1178827',
+  underlyings: ['0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c'],
+}
+
+export const getContracts = () => {
+  return {
+    contracts: { ankrBNB },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    ankrBNB: getStakeBalance,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/ankr/common/balance.ts
+++ b/src/adapters/ankr/common/balance.ts
@@ -1,0 +1,36 @@
+import type { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { call } from '@lib/call'
+
+const abi = {
+  balanceWithRewardsOf: {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+    ],
+    name: 'balanceWithRewardsOf',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+export async function getStakeBalance(ctx: BalancesContext, staker: Contract): Promise<Balance> {
+  const userBalance = await call({ ctx, target: staker.address, params: [ctx.address], abi: abi.balanceWithRewardsOf })
+
+  return {
+    ...staker,
+    amount: userBalance,
+    underlyings: [{ ...(staker.underlyings?.[0] as Contract), amount: userBalance }],
+    rewards: undefined,
+    category: 'stake',
+  }
+}

--- a/src/adapters/ankr/ethereum/balance.ts
+++ b/src/adapters/ankr/ethereum/balance.ts
@@ -1,0 +1,198 @@
+import type { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { call } from '@lib/call'
+import { abi as erc20Abi } from '@lib/erc20'
+import type { Token } from '@lib/token'
+
+const abi = {
+  getValidatorDelegation: {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'validator',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'delegator',
+        type: 'address',
+      },
+    ],
+    name: 'getValidatorDelegation',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'delegatedAmount',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint64',
+        name: 'atEpoch',
+        type: 'uint64',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  getStakingRewards: {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'validator',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'delegator',
+        type: 'address',
+      },
+    ],
+    name: 'getStakingRewards',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  sharesToBonds: {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'sharesToBonds',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  balanceWithRewardsOf: {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+    ],
+    name: 'balanceWithRewardsOf',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  claimableAETHFRewardOf: {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'staker',
+        type: 'address',
+      },
+    ],
+    name: 'claimableAETHFRewardOf',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  claimableAETHRewardOf: {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'staker',
+        type: 'address',
+      },
+    ],
+    name: 'claimableAETHRewardOf',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+const ANKR: Token = {
+  chain: 'ethereum',
+  address: '0x8290333ceF9e6D528dD5618Fb97a76f268f3EDD4',
+  decimals: 18,
+  symbol: 'ANKR',
+}
+
+export async function getAnkrStakeBalance(ctx: BalancesContext, staker: Contract): Promise<Balance> {
+  const VALIDATOR = '0x0a9bCF1526D39e0CB189215d0380D0b0Fc85B645'
+
+  const [[delegatedAmount, _atEpoch], userPendingRewards] = await Promise.all([
+    call({ ctx, target: staker.address, params: [VALIDATOR, ctx.address], abi: abi.getValidatorDelegation }),
+    call({ ctx, target: staker.address, params: [VALIDATOR, ctx.address], abi: abi.getStakingRewards }),
+  ])
+
+  return {
+    ...staker,
+    amount: delegatedAmount,
+    underlyings: [{ ...(staker.underlyings?.[0] as Contract), amount: delegatedAmount }],
+    rewards: [{ ...ANKR, amount: userPendingRewards }],
+    category: 'stake',
+  }
+}
+
+export async function getAnkrETHv2StakeBalance(ctx: BalancesContext, staker: Contract): Promise<Balance> {
+  const userBalance = await call({ ctx, target: staker.address, params: [ctx.address], abi: erc20Abi.balanceOf })
+  const sharesToBonds = await call({ ctx, target: staker.address, params: [userBalance], abi: abi.sharesToBonds })
+
+  return {
+    ...staker,
+    amount: userBalance,
+    underlyings: [{ ...(staker.underlyings?.[0] as Contract), amount: sharesToBonds }],
+    rewards: undefined,
+    category: 'stake',
+  }
+}
+
+export async function getAnkrETHStakeBalance(ctx: BalancesContext, staker: Contract): Promise<Balance> {
+  const [useraETHBalance, userETHBalance] = await Promise.all([
+    call({
+      ctx,
+      target: staker.address,
+      params: [ctx.address],
+      abi: abi.claimableAETHFRewardOf,
+    }),
+    call({
+      ctx,
+      target: staker.address,
+      params: [ctx.address],
+      abi: abi.claimableAETHRewardOf,
+    }),
+  ])
+
+  return {
+    ...staker,
+    amount: useraETHBalance,
+    underlyings: [{ ...(staker.underlyings?.[0] as Contract), amount: userETHBalance }],
+    rewards: undefined,
+    category: 'stake',
+  }
+}

--- a/src/adapters/ankr/ethereum/index.ts
+++ b/src/adapters/ankr/ethereum/index.ts
@@ -1,0 +1,50 @@
+import { getStakeBalance } from '@adapters/ankr/common/balance'
+import { getAnkrETHStakeBalance, getAnkrETHv2StakeBalance, getAnkrStakeBalance } from '@adapters/ankr/ethereum/balance'
+import type { Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+const ankrStaker: Contract = {
+  chain: 'ethereum',
+  address: '0xab15b0bddc012092cb23f53953149a7f8c1f9e7f',
+  token: '0x8290333ceF9e6D528dD5618Fb97a76f268f3EDD4',
+  underlyings: ['0x8290333ceF9e6D528dD5618Fb97a76f268f3EDD4'],
+  rewards: ['0x8290333ceF9e6D528dD5618Fb97a76f268f3EDD4'],
+}
+
+const ankrETHv2: Contract = {
+  chain: 'ethereum',
+  address: '0xe95a203b1a91a908f9b9ce46459d101078c2c3cb',
+  underlyings: ['0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'],
+}
+
+const ankrETH: Contract = {
+  chain: 'ethereum',
+  decimals: 18,
+  address: '0x84db6ee82b7cf3b47e8f19270abde5718b936670',
+  underlyings: ['0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'],
+}
+
+const ankrMATIC: Contract = {
+  chain: 'ethereum',
+  address: '0x26dcfbfa8bc267b250432c01c982eaf81cc5480c',
+  underlyings: ['0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0'],
+}
+
+export const getContracts = () => {
+  return {
+    contracts: { ankrStaker, ankrETHv2, ankrETH, ankrMATIC },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    ankrStaker: getAnkrStakeBalance,
+    ankrETHv2: getAnkrETHv2StakeBalance,
+    ankrETH: getAnkrETHStakeBalance,
+    ankrMATIC: getStakeBalance,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/ankr/fantom/index.ts
+++ b/src/adapters/ankr/fantom/index.ts
@@ -1,0 +1,25 @@
+import { getStakeBalance } from '@adapters/ankr/common/balance'
+import type { Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+const ankrFTM: Contract = {
+  chain: 'fantom',
+  address: '0xcfc785741dc0e98ad4c9f6394bb9d43cd1ef5179',
+  underlyings: ['0x21be370d5312f44cb42ce377bc9b8a0cef1a4c83'],
+}
+
+export const getContracts = () => {
+  return {
+    contracts: { ankrFTM },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    ankrFTM: getStakeBalance,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/ankr/index.ts
+++ b/src/adapters/ankr/index.ts
@@ -1,0 +1,16 @@
+import type { Adapter } from '@lib/adapter'
+
+import * as avalanche from './avalanche'
+import * as bsc from './bsc'
+import * as ethereum from './ethereum'
+import * as fantom from './fantom'
+
+const adapter: Adapter = {
+  id: 'ankr',
+  ethereum,
+  bsc,
+  fantom,
+  avalanche,
+}
+
+export default adapter

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -9,6 +9,7 @@ import alchemix from '@adapters/alchemix'
 import alpacaFinance from '@adapters/alpaca-finance'
 import ambireWallet from '@adapters/ambire-wallet'
 import angle from '@adapters/angle'
+import ankr from '@adapters/ankr'
 import annex from '@adapters/annex'
 import apeswapAmm from '@adapters/apeswap-amm'
 import apeswapLending from '@adapters/apeswap-lending'
@@ -219,6 +220,7 @@ export const adapters: Adapter[] = [
   alpacaFinance,
   ambireWallet,
   angle,
+  ankr,
   annex,
   apeswapAmm,
   apeswapLending,


### PR DESCRIPTION
Add Ankr Adapter

- [x] Store contracts
- [x] Ethereum
- [x] BSC
- [x] Avalanche
- [x] Fantom

### **Ethereum**
`pnpm run adapter-balances ankr ethereum 0x99534ef705df1fff4e4bd7bbaaf9b0dff038ebfe`

![ANKR-Matic-stake-0x99534ef705df1fff4e4bd7bbaaf9b0dff038ebfe](https://github.com/llamafolio/llamafolio-api/assets/110820448/05b790a2-ea4c-4cd2-8e3d-4ea639cbc5e8)

`pnpm run adapter-balances ankr ethereum 0xf27c965945a7c06fb63be1428bdb84dda50edc6c`

![ANKR-stake-0xf27c965945a7c06fb63be1428bdb84dda50edc6c](https://github.com/llamafolio/llamafolio-api/assets/110820448/296e392a-adff-4ad3-b6f2-f6b56c1471b3)

`pnpm run adapter-balances ankr ethereum 0x8cbee4b481112e44b92817b26f96918221489485`

![ANKR-ETH-stake-0x8cbee4b481112e44b92817b26f96918221489485](https://github.com/llamafolio/llamafolio-api/assets/110820448/822cf38a-0886-4aa0-9120-51056c7a85b8)

`pnpm run adapter-balances ankr ethereum 0xf78d83b4b2228ffeb33a0f999654a52c89c1bc1d`

![ankr-ETH-old-stake-0xf78d83b4b2228ffeb33a0f999654a52c89c1bc1d](https://github.com/llamafolio/llamafolio-api/assets/110820448/1cbd6d23-7aa9-452f-ab59-f0f933557390)

### **BSC**
`pnpm run adapter ankr bsc 0x25b21472c073095bebc681001cbf165f849eee5e`

![ANKR-BSC-stake-0x25b21472c073095bebc681001cbf165f849eee5e](https://github.com/llamafolio/llamafolio-api/assets/110820448/ec6aa370-881a-4814-89fa-a6ce4a9c7c6b)

### **Avalanche**
`pnpm run adapter-balances ankr avalanche 0x542dd5f38fcb3aab28d6418cf3e1d36329a79ac7`

![ANKR-AVAX-stake-0x542dd5f38fcb3aab28d6418cf3e1d36329a79ac7](https://github.com/llamafolio/llamafolio-api/assets/110820448/8cb1edfb-b3af-4fe6-a189-1a6d950d404e)

### **Fantom**
`pnpm run adapter-balances ankr fantom 0x20dd72ed959b6147912c2e529f0a0c651c33c9ce`

![ANKR-FTM-stake-0x20dd72ed959b6147912c2e529f0a0c651c33c9ce](https://github.com/llamafolio/llamafolio-api/assets/110820448/341d2c66-4170-4e36-a550-52e6f4b9d1df)
