### PR TITLE
Feat: Adapter, Spark (Aave fork)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -226,6 +226,7 @@
         "solidly-v2",
         "sommelier",
         "sonne-finance",
+        "spark",
         "spartacus",
         "spiritswap",
         "spookyswap",

--- a/src/adapters/aave-v2/avalanche/index.ts
+++ b/src/adapters/aave-v2/avalanche/index.ts
@@ -37,12 +37,13 @@ export const getContracts = async (ctx: BaseContext) => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
-    pools: getLendingPoolBalances,
-    incentiveController: (...args) => getLendingRewardsBalances(...args, WAVAX, contracts.pools || []),
-  })
-
-  const healthFactor = await getLendingPoolHealthFactor(ctx, lendingPool)
+  const [balances, healthFactor] = await Promise.all([
+    resolveBalances<typeof getContracts>(ctx, contracts, {
+      pools: getLendingPoolBalances,
+      incentiveController: (...args) => getLendingRewardsBalances(...args, WAVAX, contracts.pools || []),
+    }),
+    getLendingPoolHealthFactor(ctx, lendingPool),
+  ])
 
   return {
     groups: [{ balances, healthFactor }],

--- a/src/adapters/aave-v2/ethereum/index.ts
+++ b/src/adapters/aave-v2/ethereum/index.ts
@@ -66,14 +66,15 @@ export const getContracts = async (ctx: BaseContext) => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
-    pools: getLendingPoolBalances,
-    incentiveController: (...args) => getLendingRewardsBalances(...args, stkAAVE, contracts.pools || []),
-    stkAAVE: getStakeBalances,
-    stkABPT: getStakeBalancerPoolBalances,
-  })
-
-  const healthFactor = await getLendingPoolHealthFactor(ctx, lendingPool)
+  const [balances, healthFactor] = await Promise.all([
+    resolveBalances<typeof getContracts>(ctx, contracts, {
+      pools: getLendingPoolBalances,
+      incentiveController: (...args) => getLendingRewardsBalances(...args, stkAAVE, contracts.pools || []),
+      stkAAVE: getStakeBalances,
+      stkABPT: getStakeBalancerPoolBalances,
+    }),
+    getLendingPoolHealthFactor(ctx, lendingPool),
+  ])
 
   return {
     groups: [{ balances, healthFactor }],

--- a/src/adapters/aave-v2/polygon/index.ts
+++ b/src/adapters/aave-v2/polygon/index.ts
@@ -37,12 +37,13 @@ export const getContracts = async (ctx: BaseContext) => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
-    pools: getLendingPoolBalances,
-    incentiveController: (...args) => getLendingRewardsBalances(...args, WMATIC, contracts.pools || []),
-  })
-
-  const healthFactor = await getLendingPoolHealthFactor(ctx, lendingPool)
+  const [balances, healthFactor] = await Promise.all([
+    resolveBalances<typeof getContracts>(ctx, contracts, {
+      pools: getLendingPoolBalances,
+      incentiveController: (...args) => getLendingRewardsBalances(...args, WMATIC, contracts.pools || []),
+    }),
+    getLendingPoolHealthFactor(ctx, lendingPool),
+  ])
 
   return {
     groups: [{ balances, healthFactor }],

--- a/src/adapters/aave-v3/arbitrum/index.ts
+++ b/src/adapters/aave-v3/arbitrum/index.ts
@@ -41,12 +41,13 @@ export const getContracts = async (ctx: BaseContext) => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
-    pools: getLendingPoolBalances,
-    incentiveController: (...args) => getLendingRewardsBalances(...args, contracts.pools || []),
-  })
-
-  const healthFactor = await getLendingPoolHealthFactor(ctx, lendingPool)
+  const [balances, healthFactor] = await Promise.all([
+    resolveBalances<typeof getContracts>(ctx, contracts, {
+      pools: getLendingPoolBalances,
+      incentiveController: (...args) => getLendingRewardsBalances(...args, contracts.pools || []),
+    }),
+    getLendingPoolHealthFactor(ctx, lendingPool),
+  ])
 
   return {
     groups: [{ balances, healthFactor }],

--- a/src/adapters/aave-v3/avalanche/index.ts
+++ b/src/adapters/aave-v3/avalanche/index.ts
@@ -41,12 +41,13 @@ export const getContracts = async (ctx: BaseContext) => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
-    pools: getLendingPoolBalances,
-    incentiveController: (...args) => getLendingRewardsBalances(...args, contracts.pools || []),
-  })
-
-  const healthFactor = await getLendingPoolHealthFactor(ctx, lendingPool)
+  const [balances, healthFactor] = await Promise.all([
+    resolveBalances<typeof getContracts>(ctx, contracts, {
+      pools: getLendingPoolBalances,
+      incentiveController: (...args) => getLendingRewardsBalances(...args, contracts.pools || []),
+    }),
+    getLendingPoolHealthFactor(ctx, lendingPool),
+  ])
 
   return {
     groups: [{ balances, healthFactor }],

--- a/src/adapters/aave-v3/fantom/index.ts
+++ b/src/adapters/aave-v3/fantom/index.ts
@@ -41,12 +41,13 @@ export const getContracts = async (ctx: BaseContext) => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
-    pools: getLendingPoolBalances,
-    incentiveController: (...args) => getLendingRewardsBalances(...args, contracts.pools || []),
-  })
-
-  const healthFactor = await getLendingPoolHealthFactor(ctx, lendingPool)
+  const [balances, healthFactor] = await Promise.all([
+    resolveBalances<typeof getContracts>(ctx, contracts, {
+      pools: getLendingPoolBalances,
+      incentiveController: (...args) => getLendingRewardsBalances(...args, contracts.pools || []),
+    }),
+    getLendingPoolHealthFactor(ctx, lendingPool),
+  ])
 
   return {
     groups: [{ balances, healthFactor }],

--- a/src/adapters/aave-v3/optimism/index.ts
+++ b/src/adapters/aave-v3/optimism/index.ts
@@ -41,12 +41,13 @@ export const getContracts = async (ctx: BaseContext) => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
-    pools: getLendingPoolBalances,
-    incentiveController: (...args) => getLendingRewardsBalances(...args, contracts.pools || []),
-  })
-
-  const healthFactor = await getLendingPoolHealthFactor(ctx, lendingPool)
+  const [balances, healthFactor] = await Promise.all([
+    resolveBalances<typeof getContracts>(ctx, contracts, {
+      pools: getLendingPoolBalances,
+      incentiveController: (...args) => getLendingRewardsBalances(...args, contracts.pools || []),
+    }),
+    getLendingPoolHealthFactor(ctx, lendingPool),
+  ])
 
   return {
     groups: [{ balances, healthFactor }],

--- a/src/adapters/aave-v3/polygon/index.ts
+++ b/src/adapters/aave-v3/polygon/index.ts
@@ -41,12 +41,13 @@ export const getContracts = async (ctx: BaseContext) => {
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
-    pools: getLendingPoolBalances,
-    incentiveController: (...args) => getLendingRewardsBalances(...args, contracts.pools || []),
-  })
-
-  const healthFactor = await getLendingPoolHealthFactor(ctx, lendingPool)
+  const [balances, healthFactor] = await Promise.all([
+    resolveBalances<typeof getContracts>(ctx, contracts, {
+      pools: getLendingPoolBalances,
+      incentiveController: (...args) => getLendingRewardsBalances(...args, contracts.pools || []),
+    }),
+    getLendingPoolHealthFactor(ctx, lendingPool),
+  ])
 
   return {
     groups: [{ balances, healthFactor }],

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -157,6 +157,7 @@ import solidlizard from '@adapters/solidlizard'
 import solidlyV2 from '@adapters/solidly-v2'
 import sommelier from '@adapters/sommelier'
 import sonneFinance from '@adapters/sonne-finance'
+import spark from '@adapters/spark'
 import spartacus from '@adapters/spartacus'
 import spiritswap from '@adapters/spiritswap'
 import spookyswap from '@adapters/spookyswap'
@@ -369,6 +370,7 @@ export const adapters: Adapter[] = [
   solidlyV2,
   sommelier,
   sonneFinance,
+  spark,
   spartacus,
   spiritswap,
   spookyswap,

--- a/src/adapters/spark/ethereum/contract.ts
+++ b/src/adapters/spark/ethereum/contract.ts
@@ -1,0 +1,203 @@
+import type { BaseContext, Contract } from '@lib/adapter'
+import { call } from '@lib/call'
+import { multicall } from '@lib/multicall'
+
+const abi = {
+  getReservesList: {
+    inputs: [],
+    name: 'getReservesList',
+    outputs: [
+      {
+        internalType: 'address[]',
+        name: '',
+        type: 'address[]',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  getReserveData: {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'asset',
+        type: 'address',
+      },
+    ],
+    name: 'getReserveData',
+    outputs: [
+      {
+        components: [
+          {
+            components: [
+              {
+                internalType: 'uint256',
+                name: 'data',
+                type: 'uint256',
+              },
+            ],
+            internalType: 'struct DataTypes.ReserveConfigurationMap',
+            name: 'configuration',
+            type: 'tuple',
+          },
+          {
+            internalType: 'uint128',
+            name: 'liquidityIndex',
+            type: 'uint128',
+          },
+          {
+            internalType: 'uint128',
+            name: 'currentLiquidityRate',
+            type: 'uint128',
+          },
+          {
+            internalType: 'uint128',
+            name: 'variableBorrowIndex',
+            type: 'uint128',
+          },
+          {
+            internalType: 'uint128',
+            name: 'currentVariableBorrowRate',
+            type: 'uint128',
+          },
+          {
+            internalType: 'uint128',
+            name: 'currentStableBorrowRate',
+            type: 'uint128',
+          },
+          {
+            internalType: 'uint40',
+            name: 'lastUpdateTimestamp',
+            type: 'uint40',
+          },
+          {
+            internalType: 'uint16',
+            name: 'id',
+            type: 'uint16',
+          },
+          {
+            internalType: 'address',
+            name: 'aTokenAddress',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: 'stableDebtTokenAddress',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: 'variableDebtTokenAddress',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: 'interestRateStrategyAddress',
+            type: 'address',
+          },
+          {
+            internalType: 'uint128',
+            name: 'accruedToTreasury',
+            type: 'uint128',
+          },
+          {
+            internalType: 'uint128',
+            name: 'unbacked',
+            type: 'uint128',
+          },
+          {
+            internalType: 'uint128',
+            name: 'isolationModeTotalDebt',
+            type: 'uint128',
+          },
+        ],
+        internalType: 'struct DataTypes.ReserveData',
+        name: '',
+        type: 'tuple',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  getUserAccountData: {
+    inputs: [{ internalType: 'address', name: 'user', type: 'address' }],
+    name: 'getUserAccountData',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'totalCollateralBase',
+        type: 'uint256',
+      },
+      { internalType: 'uint256', name: 'totalDebtBase', type: 'uint256' },
+      {
+        internalType: 'uint256',
+        name: 'availableBorrowsBase',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'currentLiquidationThreshold',
+        type: 'uint256',
+      },
+      { internalType: 'uint256', name: 'ltv', type: 'uint256' },
+      { internalType: 'uint256', name: 'healthFactor', type: 'uint256' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+export async function getLendingPoolContracts(ctx: BaseContext, lendingPool: Contract) {
+  const contracts: Contract[] = []
+
+  const reservesList = await call({
+    ctx,
+    target: lendingPool.address,
+    abi: abi.getReservesList,
+  })
+
+  const reservesDataRes = await multicall({
+    ctx,
+    calls: reservesList.map(
+      (reserveTokenAddress) => ({ target: lendingPool.address, params: [reserveTokenAddress] } as const),
+    ),
+    abi: abi.getReserveData,
+  })
+
+  for (let i = 0; i < reservesDataRes.length; i++) {
+    const reserveDataRes = reservesDataRes[i]
+    if (!reserveDataRes.success) {
+      continue
+    }
+
+    const underlyingToken = reserveDataRes.input.params[0]
+    const aToken = reserveDataRes.output.aTokenAddress
+    const stableDebtToken = reserveDataRes.output.stableDebtTokenAddress
+    const variableDebtToken = reserveDataRes.output.variableDebtTokenAddress
+
+    contracts.push(
+      {
+        chain: ctx.chain,
+        address: aToken,
+        underlyings: [underlyingToken],
+        category: 'lend',
+      },
+      {
+        chain: ctx.chain,
+        address: stableDebtToken,
+        underlyings: [underlyingToken],
+        category: 'borrow',
+        stable: true,
+      },
+      {
+        chain: ctx.chain,
+        address: variableDebtToken,
+        underlyings: [underlyingToken],
+        category: 'borrow',
+        stable: false,
+      },
+    )
+  }
+
+  return contracts
+}

--- a/src/adapters/spark/ethereum/index.ts
+++ b/src/adapters/spark/ethereum/index.ts
@@ -1,24 +1,16 @@
+import { getLendingPoolContracts } from '@adapters/spark/ethereum/contract'
+import { getLendingPoolBalances, getLendingPoolHealthFactor } from '@lib/aave/v2/lending'
 import type { BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
 
-import { getLendingPoolBalances, getLendingPoolContracts, getLendingPoolHealthFactor } from '../common/lending'
-
 const lendingPool: Contract = {
-  name: 'Pool',
-  displayName: 'Pool',
+  name: 'Lending Pool',
+  address: '0xC13e21B648A5Ee794902342038FF3aDAB66BE987',
   chain: 'ethereum',
-  address: '0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2',
-}
-
-const poolDataProvider: Contract = {
-  chain: 'ethereum',
-  address: '0x7B4EB56E7CD4b454BA8ff71E4518426369a138a3',
-  name: 'Pool Data Provider',
-  displayName: 'Aave: Pool Data Provider V3',
 }
 
 export const getContracts = async (ctx: BaseContext) => {
-  const pools = await getLendingPoolContracts(ctx, lendingPool, poolDataProvider)
+  const pools = await getLendingPoolContracts(ctx, lendingPool)
 
   return {
     contracts: {

--- a/src/adapters/spark/index.ts
+++ b/src/adapters/spark/index.ts
@@ -1,0 +1,10 @@
+import type { Adapter } from '@lib/adapter'
+
+import * as ethereum from './ethereum'
+
+const adapter: Adapter = {
+  id: 'spark',
+  ethereum,
+}
+
+export default adapter


### PR DESCRIPTION
Add Spark Adapter

- [x] store contracts
- [x] Lending/Borrowing 

> (There were small differences in the abi preventing us from reusing the function to retrieve the contracts)

- [x] Promise healthfactor

> Using promises to retrieve healthfactors on Aave to launch calls in parallel


### **SPARK**

`pnpm run adapter spark ethereum 0xfe13988736d95d052c2e45e5b4e1ef2e2750b7f4`

![lend-spark-0xfe13988736d95d052c2e45e5b4e1ef2e2750b7f4](https://github.com/llamafolio/llamafolio-api/assets/110820448/885d131a-fec5-4fa3-befd-943365c57999)

`pnpm run adapter spark ethereum 0x9026a229b535ecf0162dfe48fdeb3c75f7b2a7ae`

![lend-spark-0x9026a229b535ecf0162dfe48fdeb3c75f7b2a7ae](https://github.com/llamafolio/llamafolio-api/assets/110820448/a83b0305-d883-441c-8fad-877921e3f75f)
