### PR TITLE
Fix: Aura underlyings using Balancer logic

### DIFF
--- a/src/adapters/balancer/common/balance.ts
+++ b/src/adapters/balancer/common/balance.ts
@@ -29,6 +29,7 @@ const abi = {
 export type getBalancerPoolsBalancesParams = Balance & {
   totalSupply: bigint
   actualSupply?: bigint
+  lpToken?: `0x${string}`
 }
 
 export async function getBalancerPoolsBalances(ctx: BalancesContext, pools: Contract[], vault: Contract) {
@@ -86,6 +87,11 @@ export async function getBalancerPoolsBalances(ctx: BalancesContext, pools: Cont
 
     for (let underlyingIdx = 0; underlyingIdx < balance.underlyings!.length; underlyingIdx++) {
       const underlying = balance.underlyings![underlyingIdx]
+
+      if (underlying.address.toLowerCase() === balance.lpToken?.toLowerCase()) {
+        continue
+      }
+
       const [_tokens, balances] = poolTokenBalanceRes.output
       const underlyingsBalanceOf = balances[underlyingIdx]
 


### PR DESCRIPTION
> Fixed Aura underlyings, sometimes there were still lpTokens in the underlyings which tended to add abnormal amounts

### **BEFORE**
`pnpm run adapter-balances aura ethereum 0x35e3564c86bc0b5548a3be3a9a1e71eb1455fad2`

![aura-bug-0x35e3564c86bc0b5548a3be3a9a1e71eb1455fad2](https://github.com/llamafolio/llamafolio-api/assets/110820448/703a5323-09c0-400e-95cc-ba2da6f58f71)

### **NOW**
`pnpm run adapter-balances aura ethereum 0x35e3564c86bc0b5548a3be3a9a1e71eb1455fad2`

![fix_aura_0x35e3564c86bc0b5548a3be3a9a1e71eb1455fad2](https://github.com/llamafolio/llamafolio-api/assets/110820448/c569263e-10e8-4350-b961-06a13c416c12)

