### PR TITLE
Fix: Incentive rewards on Aave

### DIFF
--- a/src/adapters/aave-v3/arbitrum/index.ts
+++ b/src/adapters/aave-v3/arbitrum/index.ts
@@ -27,10 +27,14 @@ const incentiveController: Contract = {
   address: '0x929EC64c34a17401F460460D4B9390518E5B473e',
   name: 'Incentive Controller',
   displayName: 'Aave: Incentives V3',
+  pools: [],
+  rewards: [],
 }
 
 export const getContracts = async (ctx: BaseContext) => {
   const pools = await getLendingPoolContracts(ctx, lendingPool, poolDataProvider)
+
+  incentiveController.pools = pools
 
   return {
     contracts: {
@@ -44,7 +48,7 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const [balances, healthFactor] = await Promise.all([
     resolveBalances<typeof getContracts>(ctx, contracts, {
       pools: getLendingPoolBalances,
-      incentiveController: (...args) => getLendingRewardsBalances(...args, contracts.pools || []),
+      incentiveController: getLendingRewardsBalances,
     }),
     getLendingPoolHealthFactor(ctx, lendingPool),
   ])

--- a/src/adapters/aave-v3/avalanche/index.ts
+++ b/src/adapters/aave-v3/avalanche/index.ts
@@ -27,10 +27,14 @@ const incentiveController: Contract = {
   address: '0x929EC64c34a17401F460460D4B9390518E5B473e',
   name: 'Incentive Controller',
   displayName: 'Aave: Incentives V3',
+  pools: [],
+  rewards: ['0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7'],
 }
 
 export const getContracts = async (ctx: BaseContext) => {
   const pools = await getLendingPoolContracts(ctx, lendingPool, poolDataProvider)
+
+  incentiveController.pools = pools
 
   return {
     contracts: {
@@ -44,7 +48,7 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const [balances, healthFactor] = await Promise.all([
     resolveBalances<typeof getContracts>(ctx, contracts, {
       pools: getLendingPoolBalances,
-      incentiveController: (...args) => getLendingRewardsBalances(...args, contracts.pools || []),
+      incentiveController: getLendingRewardsBalances,
     }),
     getLendingPoolHealthFactor(ctx, lendingPool),
   ])

--- a/src/adapters/aave-v3/fantom/index.ts
+++ b/src/adapters/aave-v3/fantom/index.ts
@@ -27,10 +27,14 @@ const incentiveController: Contract = {
   address: '0x929EC64c34a17401F460460D4B9390518E5B473e',
   name: 'Incentive Controller',
   displayName: 'Aave: Incentives V3',
+  pools: [],
+  rewards: [],
 }
 
 export const getContracts = async (ctx: BaseContext) => {
   const pools = await getLendingPoolContracts(ctx, lendingPool, poolDataProvider)
+
+  incentiveController.pools = pools
 
   return {
     contracts: {
@@ -44,7 +48,7 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const [balances, healthFactor] = await Promise.all([
     resolveBalances<typeof getContracts>(ctx, contracts, {
       pools: getLendingPoolBalances,
-      incentiveController: (...args) => getLendingRewardsBalances(...args, contracts.pools || []),
+      incentiveController: getLendingRewardsBalances,
     }),
     getLendingPoolHealthFactor(ctx, lendingPool),
   ])

--- a/src/adapters/aave-v3/optimism/index.ts
+++ b/src/adapters/aave-v3/optimism/index.ts
@@ -27,10 +27,14 @@ const incentiveController: Contract = {
   address: '0x929EC64c34a17401F460460D4B9390518E5B473e',
   name: 'Incentive Controller',
   displayName: 'Aave: Incentives V3',
+  pools: [],
+  rewards: ['0x4200000000000000000000000000000000000042'],
 }
 
 export const getContracts = async (ctx: BaseContext) => {
   const pools = await getLendingPoolContracts(ctx, lendingPool, poolDataProvider)
+
+  incentiveController.pools = pools
 
   return {
     contracts: {
@@ -44,7 +48,7 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const [balances, healthFactor] = await Promise.all([
     resolveBalances<typeof getContracts>(ctx, contracts, {
       pools: getLendingPoolBalances,
-      incentiveController: (...args) => getLendingRewardsBalances(...args, contracts.pools || []),
+      incentiveController: getLendingRewardsBalances,
     }),
     getLendingPoolHealthFactor(ctx, lendingPool),
   ])

--- a/src/adapters/aave-v3/polygon/index.ts
+++ b/src/adapters/aave-v3/polygon/index.ts
@@ -27,10 +27,19 @@ const incentiveController: Contract = {
   address: '0x929EC64c34a17401F460460D4B9390518E5B473e',
   name: 'Incentive Controller',
   displayName: 'Aave: Incentives V3',
+  pools: [],
+  rewards: [
+    '0x1d734A02eF1e1f5886e66b0673b71Af5B53ffA94',
+    '0xC3C7d422809852031b44ab29EEC9F1EfF2A58756',
+    '0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4',
+    '0xfa68FB4628DFF1028CFEc22b4162FCcd0d45efb6',
+  ],
 }
 
 export const getContracts = async (ctx: BaseContext) => {
   const pools = await getLendingPoolContracts(ctx, lendingPool, poolDataProvider)
+
+  incentiveController.pools = pools
 
   return {
     contracts: {
@@ -44,7 +53,7 @@ export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, 
   const [balances, healthFactor] = await Promise.all([
     resolveBalances<typeof getContracts>(ctx, contracts, {
       pools: getLendingPoolBalances,
-      incentiveController: (...args) => getLendingRewardsBalances(...args, contracts.pools || []),
+      incentiveController: getLendingRewardsBalances,
     }),
     getLendingPoolHealthFactor(ctx, lendingPool),
   ])


### PR DESCRIPTION
AVALANCHE
`pnpm run adapter aave-v3 avalanche 0x5a2d0e3d6f862ee155f52ab65b6b22e1d80f5716`

BEFORE
![before-0x5a2d0e3d6f862ee155f52ab65b6b22e1d80f5716](https://github.com/llamafolio/llamafolio-api/assets/110820448/4dbc6e74-be53-4f96-8d05-3fb5ef1b8c44)


AFTER
![now-aave-0x5a2d0e3d6f862ee155f52ab65b6b22e1d80f5716](https://github.com/llamafolio/llamafolio-api/assets/110820448/13cfd7a5-5321-4b1e-89c2-f26860bf88d5)


POLYGON
`pnpm run adapter aave-v3 polygon 0x31e411356d89f8a4149149bbd7beb7d12f863670`

BEFORE
![before-0x31e411356d89f8a4149149bbd7beb7d12f863670](https://github.com/llamafolio/llamafolio-api/assets/110820448/2afaee18-507f-42aa-952c-1b212fc3ddc0)


AFTER
![polygon-aave-0x31e411356d89f8a4149149bbd7beb7d12f863670](https://github.com/llamafolio/llamafolio-api/assets/110820448/0cb2b760-9233-4740-a488-92fa95431a85)
