### PR TITLE
Fix: Aura rewards were negative and wrong since we switch BN to BigInt

### DIFF
--- a/src/adapters/aura/ethereum/balance.ts
+++ b/src/adapters/aura/ethereum/balance.ts
@@ -162,7 +162,7 @@ export const getAuraMintAmount = async (
     // e.g. (new) reduction = (500 - 250) * 2.5 + 700 = 1325;
     // e.g. (new) reduction = (500 - 400) * 2.5 + 700 = 950;
 
-    const reduction = absBigInt(totalCliffs - (cliff * 5n * 2n + 700n))
+    const reduction = ((totalCliffs - cliff) * 5n) / 2n + 700n
     // e.g. (new) amount = 1e19 * 1700 / 500 =  34e18;
     // e.g. (new) amount = 1e19 * 1325 / 500 =  26.5e18;
     // e.g. (new) amount = 1e19 * 950 / 500  =  19e17;
@@ -189,8 +189,4 @@ export const getAuraMintAmount = async (
   }
 
   return balancesWithExtraRewards
-}
-
-function absBigInt(num: bigint): bigint {
-  return num < 0 ? -num : num
 }

--- a/src/adapters/aura/ethereum/balance.ts
+++ b/src/adapters/aura/ethereum/balance.ts
@@ -161,7 +161,8 @@ export const getAuraMintAmount = async (
     // e.g. (new) reduction = (500 - 100) * 2.5 + 700 = 1700;
     // e.g. (new) reduction = (500 - 250) * 2.5 + 700 = 1325;
     // e.g. (new) reduction = (500 - 400) * 2.5 + 700 = 950;
-    const reduction = totalCliffs - cliff * 5n * 2n + 700n
+
+    const reduction = absBigInt(totalCliffs - (cliff * 5n * 2n + 700n))
     // e.g. (new) amount = 1e19 * 1700 / 500 =  34e18;
     // e.g. (new) amount = 1e19 * 1325 / 500 =  26.5e18;
     // e.g. (new) amount = 1e19 * 950 / 500  =  19e17;
@@ -188,4 +189,8 @@ export const getAuraMintAmount = async (
   }
 
   return balancesWithExtraRewards
+}
+
+function absBigInt(num: bigint): bigint {
+  return num < 0 ? -num : num
 }


### PR DESCRIPTION
> Aura rewards were negative and wrong since we switch BN to BigInt

`pnpm run adapter aura ethereum 0x9026a229b535ecf0162dfe48fdeb3c75f7b2a7ae`

BEFORE
![before-aura-rewards-0x9026a229b535ecf0162dfe48fdeb3c75f7b2a7ae](https://github.com/llamafolio/llamafolio-api/assets/110820448/3b6a4b13-05ac-4096-8fee-244a0aaf11b5)

AFTER
![now](https://github.com/llamafolio/llamafolio-api/assets/110820448/8a2966bf-d2cc-42c9-bc75-e3b73237d887)


dAPP values
![aura-true](https://github.com/llamafolio/llamafolio-api/assets/110820448/fe9db33f-1d1d-479a-979e-8467e0d06866)

![aura-true-2](https://github.com/llamafolio/llamafolio-api/assets/110820448/98ee8914-1870-45b5-961f-4851f164c6d2)

