### PR TITLE
Fix: LBR asset

### DIFF
--- a/src/adapters/lybra-finance/ethereum/vest.ts
+++ b/src/adapters/lybra-finance/ethereum/vest.ts
@@ -1,5 +1,6 @@
 import type { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
+import type { Token } from '@lib/token'
 
 const abi = {
   earned: {
@@ -25,6 +26,13 @@ const abi = {
   },
 } as const
 
+const LBR: Token = {
+  chain: 'ethereum',
+  address: '0xf1182229b71e79e504b1d2bf076c15a277311e05',
+  decimals: 18,
+  symbol: 'LBR',
+}
+
 export async function getLybraVestBalance(ctx: BalancesContext, vester: Contract): Promise<Balance> {
   const [userBalance, userAutoCompoundEarned, userLockTime] = await Promise.all([
     call({ ctx, target: vester.address, params: [ctx.address], abi: abi.getClaimAbleLBR }),
@@ -38,7 +46,7 @@ export async function getLybraVestBalance(ctx: BalancesContext, vester: Contract
   return {
     ...vester,
     amount: userBalance + userAutoCompoundEarned,
-    underlyings: undefined,
+    underlyings: [LBR],
     claimable: now > unlockAt ? userBalance : 0n,
     unlockAt,
     rewards: undefined,


### PR DESCRIPTION
`pnpm run adapter-balances lybra-finance ethereum 0x9026a229b535ecf0162dfe48fdeb3c75f7b2a7ae`

BEFORE
![BEFORE-0x9026a229b535ecf0162dfe48fdeb3c75f7b2a7ae](https://github.com/llamafolio/llamafolio-api/assets/110820448/f98fc4ad-b382-4a74-9a88-661681b6acc6)

AFTER
![LBR icon](https://github.com/llamafolio/llamafolio-api/assets/110820448/91b18be7-0d1e-4696-a947-63c5cd2ca2d8)
