### PR TITLE
Fix: Adapter, Ether.fi

### DIFF
--- a/src/adapters/ether.fi/ethereum/index.ts
+++ b/src/adapters/ether.fi/ethereum/index.ts
@@ -6,7 +6,6 @@ import { getEtherBalances } from './stake'
 const staker: Contract = {
   chain: 'ethereum',
   address: '0x7623e9dc0da6ff821ddb9ebaba794054e078f8c4',
-  token: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
 }
 
 export const getContracts = () => {

--- a/src/adapters/ether.fi/ethereum/stake.ts
+++ b/src/adapters/ether.fi/ethereum/stake.ts
@@ -1,5 +1,7 @@
 import type { Balance, BalancesContext, Contract } from '@lib/adapter'
-import { call } from '@lib/call'
+import { mapSuccessFilter } from '@lib/array'
+import { multicall } from '@lib/multicall'
+import type { Token } from '@lib/token'
 
 const abi = {
   depositInfo: {
@@ -13,23 +15,58 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
+  userToErc20Balance: {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    name: 'userToErc20Balance',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
 } as const
 
-export async function getEtherBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
-  const depositInfo = await call({
+const assets: Token[] = [
+  { chain: 'ethereum', address: '0xae78736cd615f374d3085123a210448e74fc6393', decimals: 18, symbol: 'rETH' },
+  { chain: 'ethereum', address: '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0', decimals: 18, symbol: 'wstETH' },
+  { chain: 'ethereum', address: '0xac3e018457b222d93114458476f3e3416abbe38f', decimals: 18, symbol: 'sfrxETH' },
+  { chain: 'ethereum', address: '0xBe9895146f7AF43049ca1c1AE358B0541Ea49704', decimals: 18, symbol: 'cbETH' },
+  { chain: 'ethereum', address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', decimals: 18, symbol: 'WETH' },
+]
+
+const assetByAddress: { [key: string]: Token } = {}
+assets.forEach((asset) => {
+  assetByAddress[asset.address] = asset
+})
+
+export async function getEtherBalances(ctx: BalancesContext, staker: Contract): Promise<Balance[]> {
+  const userEthBalances = await multicall({
     ctx,
-    target: staker.address,
-    params: [ctx.address],
-    abi: abi.depositInfo,
+    calls: assets.map((asset) => ({ target: staker.address, params: [ctx.address, asset.address] } as const)),
+    abi: abi.userToErc20Balance,
   })
 
-  const [_depositTime, etherBalance, _totalERC20Balance] = depositInfo
-
-  return {
+  return mapSuccessFilter(userEthBalances, (res) => ({
     ...staker,
-    amount: etherBalance,
-    underlyings: undefined,
+    decimals: 18,
+    amount: res.output,
+    underlyings: [assetByAddress[res.input.params[1]]],
     rewards: undefined,
     category: 'stake',
-  }
+  }))
 }


### PR DESCRIPTION
Ether.fi now fit with more liquid eth staking (it was working only with WETH until now)

### **wstETH**
`pnpm run adapter-balances ether.fi ethereum 0x9026a229b535ecf0162dfe48fdeb3c75f7b2a7ae`

![ether_wsteth_0x9026a229b535ecf0162dfe48fdeb3c75f7b2a7ae](https://github.com/llamafolio/llamafolio-api/assets/110820448/e5551272-5b94-43a3-ad05-9ba222fc098e)

### **cbETH**
`pnpm run adapter-balances ether.fi ethereum 0xcfd727653c3d5a1b943f675781d3245b884f1d34`

![ether_cbeth_0xcfd727653c3d5a1b943f675781d3245b884f1d34](https://github.com/llamafolio/llamafolio-api/assets/110820448/0eb1d4fb-2787-43da-98b2-c3541ad0aa81)

### **sfrxETH**
`pnpm run adapter-balances ether.fi ethereum 0x857ab110153ad57240ab920e93bfb549c045af55`

![ether_sfreth_0x857ab110153ad57240ab920e93bfb549c045af55](https://github.com/llamafolio/llamafolio-api/assets/110820448/3fa617ff-1544-4ccd-a527-660be42b7739)
