### PR TITLE
Fix:  Balance filter + Aura extra rewards

### DIFF
--- a/src/adapters/balancer/common/balance.ts
+++ b/src/adapters/balancer/common/balance.ts
@@ -57,6 +57,7 @@ export async function getBalancerPoolsBalances(ctx: BalancesContext, pools: Cont
   for (let idx = 0; idx < pools.length; idx++) {
     const pool = pools[idx]
     const underlyings = pool.underlyings as Contract[]
+    const rewards = pool.rewards as Balance[]
     const balanceOfRes = balanceOfsRes[idx]
     const totalSupplyRes = totalSuppliesRes[idx]
     const actualSupplyRes = actualSuppliesRes[idx]
@@ -76,7 +77,7 @@ export async function getBalancerPoolsBalances(ctx: BalancesContext, pools: Cont
       ...pool,
       amount: balanceOfRes.output,
       underlyings,
-      rewards: undefined,
+      rewards,
       totalSupply: totalSupplyRes.output,
       // actualSupply is only available for stablepools abi
       actualSupply: actualSupplyRes.output ? actualSupplyRes.output : undefined,

--- a/src/lib/price.ts
+++ b/src/lib/price.ts
@@ -1,6 +1,6 @@
 import type { Balance, BaseBalance, PricedBalance } from '@lib/adapter'
 import { sliceIntoChunks } from '@lib/array'
-import { type Chain, toDefiLlamaChain } from '@lib/chains'
+import { toDefiLlamaChain, type Chain } from '@lib/chains'
 import { mulPrice, sum } from '@lib/math'
 import type { Token } from '@lib/token'
 import { isNotNullish } from '@lib/type'
@@ -67,7 +67,12 @@ export async function getTokenPrice(token: Token) {
 
 export async function getPricedBalances(balances: Balance[]): Promise<(Balance | PricedBalance)[]> {
   // Filter empty balances
-  balances = balances.filter((balance) => balance.amount > 0n || (balance.claimable && balance.claimable > 0n))
+  balances = balances.filter(
+    (balance) =>
+      balance.amount > 0n ||
+      (balance.claimable && balance.claimable > 0n) ||
+      (balance.rewards && balance.rewards.some((reward) => reward.amount > 0n)),
+  )
 
   const priced: BaseBalance[] = balances.slice()
 


### PR DESCRIPTION
Add a fix on balance filter now allowing to display rewards left by a user if he has ever withdrawn his principal

`pnpm run adapter aura ethereum 0x9026a229b535ecf0162dfe48fdeb3c75f7b2a7ae`

BEFORE
![Before-0x9026a229b535ecf0162dfe48fdeb3c75f7b2a7ae](https://github.com/llamafolio/llamafolio-api/assets/110820448/395d0aea-82ef-4588-8a1b-897731eb18d6)

NOW
![NOW-0x9026a229b535ecf0162dfe48fdeb3c75f7b2a7ae](https://github.com/llamafolio/llamafolio-api/assets/110820448/772ad3c9-5337-46bc-983c-268e407071ae)

AURA EXTRA REWARDS
_(LDO on this test address)_

![ExtraRewards-Aura](https://github.com/llamafolio/llamafolio-api/assets/110820448/b288483e-7bb0-4b85-8aed-31efe6754b66)

