### PR TITLE
Fix: Adapter Uniswap-v3

### DIFF
--- a/src/adapters/uniswap-v3/common/pools.ts
+++ b/src/adapters/uniswap-v3/common/pools.ts
@@ -291,7 +291,7 @@ export async function getTokenIdsBalances(
       }
 
       const underlyings = balance.underlyings as Balance[]
-      if (!underlyings || underlyings[0].amount === 0n || underlyings[1].amount === 0n) {
+      if (!underlyings || (underlyings[0].amount === 0n && underlyings[1].amount === 0n)) {
         return null
       }
 


### PR DESCRIPTION
Small fix on uniswap-v3 since there may be an underlying at 0 if user is out of range

pnpm run adapter-balances uniswap-v3 ethereum 0x26fcbd3afebbe28d0a8684f790c48368d21665b5

BEFORE
![BEFORE-0x26fcbd3afebbe28d0a8684f790c48368d21665b5](https://github.com/llamafolio/llamafolio-api/assets/110820448/ad9e2595-81e8-4638-9f09-7cbfc1c06481)

AFTER
![Now-0x26fcbd3afebbe28d0a8684f790c48368d21665b5](https://github.com/llamafolio/llamafolio-api/assets/110820448/a274633a-2612-4c71-a73b-89de64a2bf49)
