### PR TITLE
Fix: Adapter, StakeDao

### DIFF
--- a/src/adapters/stakedao/ethereum/index.ts
+++ b/src/adapters/stakedao/ethereum/index.ts
@@ -79,9 +79,9 @@ const getStakeDaoBalances = async (ctx: BalancesContext, pools: Contract[]) => {
 
   return Promise.all([
     getStakeDaoStakingBalances(ctx, pools),
-    getStakeDaoCurveBalances(ctx, sortedPools['curve']),
-    getStakeDaoBalBalances(ctx, sortedPools['balancer']),
-    getStakeDaoOldBalances(ctx, sortedPools['oldPool']),
+    getStakeDaoCurveBalances(ctx, sortedPools['curve'] || []),
+    getStakeDaoBalBalances(ctx, sortedPools['balancer'] || []),
+    getStakeDaoOldBalances(ctx, sortedPools['oldPool'] || []),
   ])
 }
 


### PR DESCRIPTION
>  small fix, handling error on farming part + conditionnal return on xSDT stake to prevent display if userBalances is null

`pnpm run adapter stakedao ethereum 0xc6625129c9df3314a4dd604845488f4ba62f9db8`

### **BEFORE**
![handling error-0xc6625129c9df3314a4dd604845488f4ba62f9db8](https://github.com/llamafolio/llamafolio-api/assets/110820448/d5a98ab1-9fd5-4416-a804-6b97d7648426)

### **NOW**
![now](https://github.com/llamafolio/llamafolio-api/assets/110820448/aa02c426-92ad-4e8e-b33d-f2d55b321838)

### **FIX_STAKE**
![fix_stake](https://github.com/llamafolio/llamafolio-api/assets/110820448/f28e4ea9-a7c7-485a-9874-b15685732092)


