### PR TITLE
feat: Adapter Exactly

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -126,6 +126,7 @@
         "ether.fi",
         "euler",
         "everrise",
+        "exactly",
         "fantohm",
         "flamincome",
         "floor-dao",

--- a/src/adapters/exactly/common/balance.ts
+++ b/src/adapters/exactly/common/balance.ts
@@ -1,0 +1,83 @@
+import type { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { mapSuccessFilter } from '@lib/array'
+import { call } from '@lib/call'
+import { multicall } from '@lib/multicall'
+import type { Token } from '@lib/token'
+
+const abi = {
+  accountSnapshot: {
+    inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
+    name: 'accountSnapshot',
+    outputs: [
+      { internalType: 'uint256', name: '', type: 'uint256' },
+      { internalType: 'uint256', name: '', type: 'uint256' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  allClaimable: {
+    inputs: [
+      { internalType: 'address', name: 'account', type: 'address' },
+      { internalType: 'contract ERC20', name: 'reward', type: 'address' },
+    ],
+    name: 'allClaimable',
+    outputs: [{ internalType: 'uint256', name: 'unclaimedRewards', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+const OP: Token = {
+  chain: 'optimism',
+  address: '0x4200000000000000000000000000000000000042',
+  decimals: 18,
+  symbol: 'OP',
+}
+
+export async function getExactlyBalances(ctx: BalancesContext, pools: Contract[]) {
+  const userInfos = await multicall({
+    ctx,
+    calls: pools.map((pool) => ({ target: pool.address, params: [ctx.address] } as const)),
+    abi: abi.accountSnapshot,
+  })
+
+  return mapSuccessFilter(userInfos, (res, idx) => {
+    const pool = pools[idx]
+    const [lend, borrow] = res.output
+
+    const lendPool: Balance = {
+      ...pool,
+      amount: lend,
+      underlyings: undefined,
+      rewards: undefined,
+      category: 'lend',
+    }
+
+    const borrowPool: Balance = {
+      ...pool,
+      amount: borrow,
+      underlyings: undefined,
+      rewards: undefined,
+      category: 'borrow',
+    }
+
+    return [lendPool, borrowPool]
+  })
+}
+
+export async function getExactlyIncentive(ctx: BalancesContext, rewardPool: Contract): Promise<Balance> {
+  const userReward = await call({
+    ctx,
+    target: rewardPool.address,
+    params: [ctx.address, OP.address],
+    abi: abi.allClaimable,
+  })
+
+  return {
+    ...rewardPool,
+    amount: userReward,
+    underlyings: [OP],
+    rewards: undefined,
+    category: 'reward',
+  }
+}

--- a/src/adapters/exactly/common/market.ts
+++ b/src/adapters/exactly/common/market.ts
@@ -1,0 +1,38 @@
+import type { BaseContext, Contract } from '@lib/adapter'
+import { mapSuccessFilter } from '@lib/array'
+import { call } from '@lib/call'
+import { multicall } from '@lib/multicall'
+
+const abi = {
+  allMarkets: {
+    inputs: [],
+    name: 'allMarkets',
+    outputs: [{ internalType: 'contract Market[]', name: '', type: 'address[]' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  asset: {
+    inputs: [],
+    name: 'asset',
+    outputs: [{ internalType: 'contract ERC20', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+export async function getExactlyMarkets(ctx: BaseContext, lendingPool: Contract): Promise<Contract[]> {
+  const marketsRes = await call({ ctx, target: lendingPool.address, abi: abi.allMarkets })
+
+  const assetsRes = await multicall({
+    ctx,
+    calls: marketsRes.map((market) => ({ target: market })),
+    abi: abi.asset,
+  })
+
+  return mapSuccessFilter(assetsRes, (res) => ({
+    chain: ctx.chain,
+    address: res.input.target,
+    token: res.output,
+    lendingPool,
+  }))
+}

--- a/src/adapters/exactly/ethereum/index.ts
+++ b/src/adapters/exactly/ethereum/index.ts
@@ -1,0 +1,24 @@
+import { getExactlyBalances } from '@adapters/exactly/common/balance'
+import { getExactlyMarkets } from '@adapters/exactly/common/market'
+import type { BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+const lendingPool: Contract = { chain: 'ethereum', address: '0x310a2694521f75c7b2b64b5937c16ce65c3efe01' }
+
+export const getContracts = async (ctx: BaseContext) => {
+  const markets = await getExactlyMarkets(ctx, lendingPool)
+
+  return {
+    contracts: { markets },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    markets: getExactlyBalances,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/exactly/index.ts
+++ b/src/adapters/exactly/index.ts
@@ -1,0 +1,12 @@
+import type { Adapter } from '@lib/adapter'
+
+import * as ethereum from './ethereum'
+import * as optimism from './optimism'
+
+const adapter: Adapter = {
+  id: 'exactly',
+  optimism,
+  ethereum,
+}
+
+export default adapter

--- a/src/adapters/exactly/optimism/index.ts
+++ b/src/adapters/exactly/optimism/index.ts
@@ -1,0 +1,30 @@
+import { getExactlyBalances, getExactlyIncentive } from '@adapters/exactly/common/balance'
+import { getExactlyMarkets } from '@adapters/exactly/common/market'
+import type { BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+const lendingPool: Contract = { chain: 'optimism', address: '0xaeb62e6f27bc103702e7bc879ae98bcea56f027e' }
+const rewardPool: Contract = {
+  chain: 'optimism',
+  address: '0xbd1ba78a3976cab420a9203e6ef14d18c2b2e031',
+  token: '0x4200000000000000000000000000000000000042',
+}
+
+export const getContracts = async (ctx: BaseContext) => {
+  const markets = await getExactlyMarkets(ctx, lendingPool)
+
+  return {
+    contracts: { markets, rewardPool },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    markets: getExactlyBalances,
+    rewardPool: getExactlyIncentive,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -57,6 +57,7 @@ import equalizerExchange from '@adapters/equalizer-exchange'
 import etherFi from '@adapters/ether.fi'
 import euler from '@adapters/euler'
 import everrise from '@adapters/everrise'
+import exactly from '@adapters/exactly'
 import fantohm from '@adapters/fantohm'
 import flamincome from '@adapters/flamincome'
 import floorDao from '@adapters/floor-dao'
@@ -276,6 +277,7 @@ export const adapters: Adapter[] = [
   etherFi,
   euler,
   everrise,
+  exactly,
   fantohm,
   flamincome,
   floorDao,


### PR DESCRIPTION
Add Exactly adapter on both Ethereum + Optimism

- [x] store contracts
- [x] Lend/borrow
- [x] Incentive on OP

### **Optimism**
`pnpm run adapter exactly optimism 0xb5a9621b0397bfc5b45896cae5998b6111bcdce6`

![exactly-op-0xb5a9621b0397bfc5b45896cae5998b6111bcdce6](https://github.com/llamafolio/llamafolio-api/assets/110820448/0df710e7-aef3-4b5e-9089-2ed40745df19)

`pnpm run adapter exactly optimism 0xf567361ff0bcdcad1252c8e2fb8e5d4a9bb4e266`

![exactly-op-0xf567361ff0bcdcad1252c8e2fb8e5d4a9bb4e266](https://github.com/llamafolio/llamafolio-api/assets/110820448/4a497a9c-8aa1-4fba-ba8c-cb19a489386f)

### **Ethereum**
`pnpm run adapter exactly ethereum 0x8a6134ecba73d51f64794f93c6d0c057893d328d`

![exactly-eth-0x8a6134ecba73d51f64794f93c6d0c057893d328d](https://github.com/llamafolio/llamafolio-api/assets/110820448/d46ead08-c82f-4d12-a03d-3dad368c70be)

`pnpm run adapter exactly ethereum 0x5d1124fb77c539ec92e3ef853053bbce1e98271b`

![exactly-eth-0x5d1124fb77c539ec92e3ef853053bbce1e98271b](https://github.com/llamafolio/llamafolio-api/assets/110820448/fd986642-e1b4-479d-8d52-d59ee0aed46d)
