### PR TITLE
feat: Adapter, MorphoAave

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -183,6 +183,7 @@
         "morpheus-swap",
         "morphex",
         "morpho-aave",
+        "morpho-aavev3",
         "morpho-compound",
         "mstable",
         "multichain",

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -114,6 +114,7 @@ import metronome from '@adapters/metronome'
 import morpheusSwap from '@adapters/morpheus-swap'
 import morphex from '@adapters/morphex'
 import morphoAave from '@adapters/morpho-aave'
+import morphoAavev3 from '@adapters/morpho-aavev3'
 import morphoCompound from '@adapters/morpho-compound'
 import mstable from '@adapters/mstable'
 import multichain from '@adapters/multichain'
@@ -336,6 +337,7 @@ export const adapters: Adapter[] = [
   morpheusSwap,
   morphex,
   morphoAave,
+  morphoAavev3,
   morphoCompound,
   mstable,
   multichain,

--- a/src/adapters/morpho-aave/ethereum/balances.ts
+++ b/src/adapters/morpho-aave/ethereum/balances.ts
@@ -1,4 +1,4 @@
-import type { Balance, BalancesContext, BaseContext, Contract } from '@lib/adapter'
+import type { Balance, BalancesContext, Contract } from '@lib/adapter'
 import { call } from '@lib/call'
 import { MAX_UINT_256 } from '@lib/math'
 import type { Call } from '@lib/multicall'
@@ -9,13 +9,6 @@ const abi = {
     inputs: [],
     name: 'getAllMarkets',
     outputs: [{ internalType: 'address[]', name: 'marketsCreated', type: 'address[]' }],
-    stateMutability: 'view',
-    type: 'function',
-  },
-  underlyings_assets: {
-    inputs: [],
-    name: 'UNDERLYING_ASSET_ADDRESS',
-    outputs: [{ internalType: 'address', name: '', type: 'address' }],
     stateMutability: 'view',
     type: 'function',
   },
@@ -54,40 +47,45 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
+  collateralBalance: {
+    inputs: [
+      { internalType: 'address', name: 'underlying', type: 'address' },
+      { internalType: 'address', name: 'user', type: 'address' },
+    ],
+    name: 'collateralBalance',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  borrowBalance: {
+    inputs: [
+      { internalType: 'address', name: 'underlying', type: 'address' },
+      { internalType: 'address', name: 'user', type: 'address' },
+    ],
+    name: 'borrowBalance',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  liquidityData: {
+    inputs: [{ internalType: 'address', name: 'user', type: 'address' }],
+    name: 'liquidityData',
+    outputs: [
+      {
+        components: [
+          { internalType: 'uint256', name: 'borrowable', type: 'uint256' },
+          { internalType: 'uint256', name: 'maxDebt', type: 'uint256' },
+          { internalType: 'uint256', name: 'debt', type: 'uint256' },
+        ],
+        internalType: 'struct Types.LiquidityData',
+        name: '',
+        type: 'tuple',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
 } as const
-
-export async function getMarketsContracts(ctx: BaseContext, lens: Contract): Promise<Contract[]> {
-  const contracts: Contract[] = []
-
-  const marketsContractsRes = await call({
-    ctx,
-    target: lens.address,
-    abi: abi.getAllMarkets,
-  })
-
-  const underlyingsRes = await multicall({
-    ctx,
-    calls: marketsContractsRes.map((token) => ({ target: token })),
-    abi: abi.underlyings_assets,
-  })
-
-  for (let idx = 0; idx < underlyingsRes.length; idx++) {
-    const market = marketsContractsRes[idx]
-    const underlying = underlyingsRes[idx]
-
-    if (!underlying.success) {
-      continue
-    }
-
-    contracts.push({
-      chain: ctx.chain,
-      address: market,
-      underlyings: [underlying.output],
-    })
-  }
-
-  return contracts
-}
 
 export async function getLendBorrowBalances(
   ctx: BalancesContext,
@@ -143,6 +141,56 @@ export async function getLendBorrowBalances(
   return balances
 }
 
+export async function getLendBorrowBalancesAaveV3(
+  ctx: BalancesContext,
+  markets: Contract[],
+  comptroller: Contract,
+): Promise<Balance[]> {
+  const balances: Balance[] = []
+
+  const [lendBalancesRes, borrowBalancesRes] = await Promise.all([
+    multicall({
+      ctx,
+      calls: markets.map((market) => ({ target: comptroller.address, params: [market.address, ctx.address] } as const)),
+      abi: abi.collateralBalance,
+    }),
+    multicall({
+      ctx,
+      calls: markets.map((market) => ({ target: comptroller.address, params: [market.address, ctx.address] } as const)),
+      abi: abi.borrowBalance,
+    }),
+  ])
+
+  for (const [index, market] of markets.entries()) {
+    const lendBalanceRes = lendBalancesRes[index]
+    const borrowBalanceRes = borrowBalancesRes[index]
+
+    if (!lendBalanceRes.success || !borrowBalanceRes.success) {
+      continue
+    }
+
+    const lend: Balance = {
+      ...market,
+      amount: lendBalanceRes.output,
+      underlyings: undefined,
+      rewards: undefined,
+      category: 'lend',
+    }
+
+    const borrow: Balance = {
+      ...market,
+      amount: borrowBalanceRes.output,
+      underlyings: undefined,
+      rewards: undefined,
+      category: 'borrow',
+    }
+
+    balances.push(lend, borrow)
+  }
+
+  return balances
+}
+
 export async function getUserHealthFactor(ctx: BalancesContext, morphoLens: Contract): Promise<number | undefined> {
   const userHealthFactorRes = await call({
     ctx,
@@ -156,4 +204,14 @@ export async function getUserHealthFactor(ctx: BalancesContext, morphoLens: Cont
   }
 
   return Number(userHealthFactorRes) / 1e18
+}
+
+export async function getUserHealthFactorV3(ctx: BalancesContext, comptroller: Contract): Promise<number | undefined> {
+  const healthFactor = await call({ ctx, target: comptroller.address, params: [ctx.address], abi: abi.liquidityData })
+
+  if (healthFactor.debt === 0n) {
+    return undefined
+  }
+
+  return Number(healthFactor.maxDebt) / Number(healthFactor.debt)
 }

--- a/src/adapters/morpho-aave/ethereum/balances.ts
+++ b/src/adapters/morpho-aave/ethereum/balances.ts
@@ -47,44 +47,6 @@ const abi = {
     stateMutability: 'view',
     type: 'function',
   },
-  collateralBalance: {
-    inputs: [
-      { internalType: 'address', name: 'underlying', type: 'address' },
-      { internalType: 'address', name: 'user', type: 'address' },
-    ],
-    name: 'collateralBalance',
-    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-    stateMutability: 'view',
-    type: 'function',
-  },
-  borrowBalance: {
-    inputs: [
-      { internalType: 'address', name: 'underlying', type: 'address' },
-      { internalType: 'address', name: 'user', type: 'address' },
-    ],
-    name: 'borrowBalance',
-    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-    stateMutability: 'view',
-    type: 'function',
-  },
-  liquidityData: {
-    inputs: [{ internalType: 'address', name: 'user', type: 'address' }],
-    name: 'liquidityData',
-    outputs: [
-      {
-        components: [
-          { internalType: 'uint256', name: 'borrowable', type: 'uint256' },
-          { internalType: 'uint256', name: 'maxDebt', type: 'uint256' },
-          { internalType: 'uint256', name: 'debt', type: 'uint256' },
-        ],
-        internalType: 'struct Types.LiquidityData',
-        name: '',
-        type: 'tuple',
-      },
-    ],
-    stateMutability: 'view',
-    type: 'function',
-  },
 } as const
 
 export async function getLendBorrowBalances(
@@ -141,56 +103,6 @@ export async function getLendBorrowBalances(
   return balances
 }
 
-export async function getLendBorrowBalancesAaveV3(
-  ctx: BalancesContext,
-  markets: Contract[],
-  comptroller: Contract,
-): Promise<Balance[]> {
-  const balances: Balance[] = []
-
-  const [lendBalancesRes, borrowBalancesRes] = await Promise.all([
-    multicall({
-      ctx,
-      calls: markets.map((market) => ({ target: comptroller.address, params: [market.address, ctx.address] } as const)),
-      abi: abi.collateralBalance,
-    }),
-    multicall({
-      ctx,
-      calls: markets.map((market) => ({ target: comptroller.address, params: [market.address, ctx.address] } as const)),
-      abi: abi.borrowBalance,
-    }),
-  ])
-
-  for (const [index, market] of markets.entries()) {
-    const lendBalanceRes = lendBalancesRes[index]
-    const borrowBalanceRes = borrowBalancesRes[index]
-
-    if (!lendBalanceRes.success || !borrowBalanceRes.success) {
-      continue
-    }
-
-    const lend: Balance = {
-      ...market,
-      amount: lendBalanceRes.output,
-      underlyings: undefined,
-      rewards: undefined,
-      category: 'lend',
-    }
-
-    const borrow: Balance = {
-      ...market,
-      amount: borrowBalanceRes.output,
-      underlyings: undefined,
-      rewards: undefined,
-      category: 'borrow',
-    }
-
-    balances.push(lend, borrow)
-  }
-
-  return balances
-}
-
 export async function getUserHealthFactor(ctx: BalancesContext, morphoLens: Contract): Promise<number | undefined> {
   const userHealthFactorRes = await call({
     ctx,
@@ -204,14 +116,4 @@ export async function getUserHealthFactor(ctx: BalancesContext, morphoLens: Cont
   }
 
   return Number(userHealthFactorRes) / 1e18
-}
-
-export async function getUserHealthFactorV3(ctx: BalancesContext, comptroller: Contract): Promise<number | undefined> {
-  const healthFactor = await call({ ctx, target: comptroller.address, params: [ctx.address], abi: abi.liquidityData })
-
-  if (healthFactor.debt === 0n) {
-    return undefined
-  }
-
-  return Number(healthFactor.maxDebt) / Number(healthFactor.debt)
 }

--- a/src/adapters/morpho-aave/ethereum/contract.ts
+++ b/src/adapters/morpho-aave/ethereum/contract.ts
@@ -1,0 +1,67 @@
+import type { BaseContext, Contract } from '@lib/adapter'
+import { call } from '@lib/call'
+import { multicall } from '@lib/multicall'
+
+const abi = {
+  getAllMarkets: {
+    inputs: [],
+    name: 'getAllMarkets',
+    outputs: [{ internalType: 'address[]', name: 'marketsCreated', type: 'address[]' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  underlyings_assets: {
+    inputs: [],
+    name: 'UNDERLYING_ASSET_ADDRESS',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  marketsCreated: {
+    inputs: [],
+    name: 'marketsCreated',
+    outputs: [{ internalType: 'address[]', name: '', type: 'address[]' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+export async function getMarketsContracts(ctx: BaseContext, lens: Contract): Promise<Contract[]> {
+  const contracts: Contract[] = []
+
+  const marketsContractsRes = await call({
+    ctx,
+    target: lens.address,
+    abi: abi.getAllMarkets,
+  })
+
+  const underlyingsRes = await multicall({
+    ctx,
+    calls: marketsContractsRes.map((token) => ({ target: token })),
+    abi: abi.underlyings_assets,
+  })
+
+  for (let idx = 0; idx < underlyingsRes.length; idx++) {
+    const market = marketsContractsRes[idx]
+    const underlying = underlyingsRes[idx]
+
+    if (!underlying.success) {
+      continue
+    }
+
+    contracts.push({
+      chain: ctx.chain,
+      address: market,
+      underlyings: [underlying.output],
+    })
+  }
+
+  return contracts
+}
+
+export async function getMarketsContractsMorphoAaveV3(ctx: BaseContext, comptroller: Contract): Promise<Contract[]> {
+  return ((await call({ ctx, target: comptroller.address, abi: abi.marketsCreated })) || []).map((market) => ({
+    chain: ctx.chain,
+    address: market,
+  }))
+}

--- a/src/adapters/morpho-aave/ethereum/contract.ts
+++ b/src/adapters/morpho-aave/ethereum/contract.ts
@@ -58,10 +58,3 @@ export async function getMarketsContracts(ctx: BaseContext, lens: Contract): Pro
 
   return contracts
 }
-
-export async function getMarketsContractsMorphoAaveV3(ctx: BaseContext, comptroller: Contract): Promise<Contract[]> {
-  return ((await call({ ctx, target: comptroller.address, abi: abi.marketsCreated })) || []).map((market) => ({
-    chain: ctx.chain,
-    address: market,
-  }))
-}

--- a/src/adapters/morpho-aave/ethereum/index.ts
+++ b/src/adapters/morpho-aave/ethereum/index.ts
@@ -1,30 +1,59 @@
-import type { BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { getMarketsContracts, getMarketsContractsMorphoAaveV3 } from '@adapters/morpho-aave/ethereum/contract'
+import type { BalancesGroup, BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
 
-import { getLendBorrowBalances, getMarketsContracts, getUserHealthFactor } from './balances'
+import {
+  getLendBorrowBalances,
+  getLendBorrowBalancesAaveV3,
+  getUserHealthFactor,
+  getUserHealthFactorV3,
+} from './balances'
 
 const lens: Contract = {
   chain: 'ethereum',
   address: '0x507fa343d0a90786d86c7cd885f5c49263a91ff4',
 }
 
+const morphoAave3Proxy: Contract = {
+  chain: 'ethereum',
+  address: '0x33333aea097c193e66081e930c33020272b33333',
+}
+
 export const getContracts = async (ctx: BaseContext) => {
-  const markets = await getMarketsContracts(ctx, lens)
+  const [markets, marketsV3] = await Promise.all([
+    getMarketsContracts(ctx, lens),
+    getMarketsContractsMorphoAaveV3(ctx, morphoAave3Proxy),
+  ])
 
   return {
-    contracts: { markets },
+    contracts: { markets, marketsV3 },
   }
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const [balances, healthFactor] = await Promise.all([
-    resolveBalances<typeof getContracts>(ctx, contracts, {
-      markets: (...args) => getLendBorrowBalances(...args, lens),
-    }),
-    getUserHealthFactor(ctx, lens),
-  ])
+  const [group0Promise, group1Promise] = [
+    Promise.all([
+      resolveBalances<typeof getContracts>(ctx, contracts, {
+        markets: (...args) => getLendBorrowBalances(...args, lens),
+      }),
+      getUserHealthFactor(ctx, lens),
+    ]),
+    Promise.all([
+      resolveBalances<typeof getContracts>(ctx, contracts, {
+        marketsV3: (...args) => getLendBorrowBalancesAaveV3(...args, morphoAave3Proxy),
+      }),
+      getUserHealthFactorV3(ctx, morphoAave3Proxy),
+    ]),
+  ]
+
+  const [group0, group1] = await Promise.all([group0Promise, group1Promise])
+
+  const balancesGroups: BalancesGroup[] = [
+    { balances: group0[0], healthFactor: group0[1] },
+    { balances: group1[0], healthFactor: group1[1] },
+  ]
 
   return {
-    groups: [{ balances, healthFactor }],
+    groups: balancesGroups,
   }
 }

--- a/src/adapters/morpho-aavev3/ethereum/balance.ts
+++ b/src/adapters/morpho-aavev3/ethereum/balance.ts
@@ -1,0 +1,104 @@
+import type { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { call } from '@lib/call'
+import { multicall } from '@lib/multicall'
+
+const abi = {
+  collateralBalance: {
+    inputs: [
+      { internalType: 'address', name: 'underlying', type: 'address' },
+      { internalType: 'address', name: 'user', type: 'address' },
+    ],
+    name: 'collateralBalance',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  borrowBalance: {
+    inputs: [
+      { internalType: 'address', name: 'underlying', type: 'address' },
+      { internalType: 'address', name: 'user', type: 'address' },
+    ],
+    name: 'borrowBalance',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  liquidityData: {
+    inputs: [{ internalType: 'address', name: 'user', type: 'address' }],
+    name: 'liquidityData',
+    outputs: [
+      {
+        components: [
+          { internalType: 'uint256', name: 'borrowable', type: 'uint256' },
+          { internalType: 'uint256', name: 'maxDebt', type: 'uint256' },
+          { internalType: 'uint256', name: 'debt', type: 'uint256' },
+        ],
+        internalType: 'struct Types.LiquidityData',
+        name: '',
+        type: 'tuple',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+export async function getLendBorrowBalancesAaveV3(
+  ctx: BalancesContext,
+  markets: Contract[],
+  comptroller: Contract,
+): Promise<Balance[]> {
+  const balances: Balance[] = []
+
+  const [lendBalancesRes, borrowBalancesRes] = await Promise.all([
+    multicall({
+      ctx,
+      calls: markets.map((market) => ({ target: comptroller.address, params: [market.address, ctx.address] } as const)),
+      abi: abi.collateralBalance,
+    }),
+    multicall({
+      ctx,
+      calls: markets.map((market) => ({ target: comptroller.address, params: [market.address, ctx.address] } as const)),
+      abi: abi.borrowBalance,
+    }),
+  ])
+
+  for (const [index, market] of markets.entries()) {
+    const lendBalanceRes = lendBalancesRes[index]
+    const borrowBalanceRes = borrowBalancesRes[index]
+
+    if (!lendBalanceRes.success || !borrowBalanceRes.success) {
+      continue
+    }
+
+    const lend: Balance = {
+      ...market,
+      amount: lendBalanceRes.output,
+      underlyings: undefined,
+      rewards: undefined,
+      category: 'lend',
+    }
+
+    const borrow: Balance = {
+      ...market,
+      amount: borrowBalanceRes.output,
+      underlyings: undefined,
+      rewards: undefined,
+      category: 'borrow',
+    }
+
+    balances.push(lend, borrow)
+  }
+
+  return balances
+}
+
+export async function getUserHealthFactorV3(ctx: BalancesContext, comptroller: Contract): Promise<number | undefined> {
+  const healthFactor = await call({ ctx, target: comptroller.address, params: [ctx.address], abi: abi.liquidityData })
+
+  if (healthFactor.debt === 0n) {
+    return undefined
+  }
+
+  return Number(healthFactor.maxDebt) / Number(healthFactor.debt)
+}

--- a/src/adapters/morpho-aavev3/ethereum/contract.ts
+++ b/src/adapters/morpho-aavev3/ethereum/contract.ts
@@ -1,0 +1,33 @@
+import type { BaseContext, Contract } from '@lib/adapter'
+import { call } from '@lib/call'
+
+const abi = {
+  getAllMarkets: {
+    inputs: [],
+    name: 'getAllMarkets',
+    outputs: [{ internalType: 'address[]', name: 'marketsCreated', type: 'address[]' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  underlyings_assets: {
+    inputs: [],
+    name: 'UNDERLYING_ASSET_ADDRESS',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  marketsCreated: {
+    inputs: [],
+    name: 'marketsCreated',
+    outputs: [{ internalType: 'address[]', name: '', type: 'address[]' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+export async function getMarketsContractsMorphoAaveV3(ctx: BaseContext, comptroller: Contract): Promise<Contract[]> {
+  return ((await call({ ctx, target: comptroller.address, abi: abi.marketsCreated })) || []).map((market) => ({
+    chain: ctx.chain,
+    address: market,
+  }))
+}

--- a/src/adapters/morpho-aavev3/ethereum/index.ts
+++ b/src/adapters/morpho-aavev3/ethereum/index.ts
@@ -1,16 +1,15 @@
-import { getMarketsContracts } from '@adapters/morpho-aave/ethereum/contract'
+import { getLendBorrowBalancesAaveV3, getUserHealthFactorV3 } from '@adapters/morpho-aavev3/ethereum/balance'
+import { getMarketsContractsMorphoAaveV3 } from '@adapters/morpho-aavev3/ethereum/contract'
 import type { BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
 
-import { getLendBorrowBalances, getUserHealthFactor } from './balances'
-
-const lens: Contract = {
+const morphoAave3Proxy: Contract = {
   chain: 'ethereum',
-  address: '0x507fa343d0a90786d86c7cd885f5c49263a91ff4',
+  address: '0x33333aea097c193e66081e930c33020272b33333',
 }
 
 export const getContracts = async (ctx: BaseContext) => {
-  const markets = await getMarketsContracts(ctx, lens)
+  const markets = await getMarketsContractsMorphoAaveV3(ctx, morphoAave3Proxy)
 
   return {
     contracts: { markets },
@@ -20,9 +19,9 @@ export const getContracts = async (ctx: BaseContext) => {
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
   const [balances, healthFactor] = await Promise.all([
     resolveBalances<typeof getContracts>(ctx, contracts, {
-      markets: (...args) => getLendBorrowBalances(...args, lens),
+      markets: (...args) => getLendBorrowBalancesAaveV3(...args, morphoAave3Proxy),
     }),
-    getUserHealthFactor(ctx, lens),
+    getUserHealthFactorV3(ctx, morphoAave3Proxy),
   ])
 
   return {

--- a/src/adapters/morpho-aavev3/index.ts
+++ b/src/adapters/morpho-aavev3/index.ts
@@ -1,0 +1,10 @@
+import type { Adapter } from '@lib/adapter'
+
+import * as ethereum from './ethereum'
+
+const adapter: Adapter = {
+  id: 'morpho-aavev3',
+  ethereum,
+}
+
+export default adapter


### PR DESCRIPTION
Added Morpho-Aave v3 logic based on @pragneshmangukiya's work with some refactorings #680 

- [x] store contracts
- [x] lend/borrow/health

`pnpm run adapter morpho-aave ethereum 0xd0b8dfcf9da999db981a60a8da6584e8e52b757c`

![ma-0xd0b8dfcf9da999db981a60a8da6584e8e52b757c](https://github.com/llamafolio/llamafolio-api/assets/110820448/d7a9ab4e-feb1-45f1-8659-fb08d749ac12)
