### PR TITLE
feat: store yield pools in r2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OUTSIDE_CONTRIBUTOR='true'

--- a/.github/workflows/refresh-r2.yml
+++ b/.github/workflows/refresh-r2.yml
@@ -11,7 +11,7 @@ on:
     #        │  │  │ │ │
     #        │  │  │ │ │
     #        *  *  * * *
-    - cron: '0 */2 * * *'
+    - cron: '0 */2 * * *' # Every 2 hours
   repository_dispatch: # REST API
     types:
       - 'refresh-r2'
@@ -29,14 +29,14 @@ jobs:
   refresh-nft-collections:
     name: 'DefiLlama NFT Collections'
     runs-on: [ubuntu-latest]
-    timeout-minutes: 5
+    timeout-minutes: 4
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - name: '[Download] DefiLlama NFT Collections'
+      - name: '[Download] nft.llama.fi/collections'
         run: |
           curl --request GET \
             --silent \
@@ -56,4 +56,32 @@ jobs:
             CLOUDFLARE_AWS_SECRET_ACCESS_KEY="${{ secrets.CLOUDFLARE_AWS_SECRET_ACCESS_KEY }}" \
             /bin/bash ${{ github.workspace }}/scripts/r2/upload.sh
 
-# TODO: Add job to refresh NFT prices R2 object
+  refresh-yield-pools:
+    name: 'DefiLlama Yield Pools'
+    runs-on: [ubuntu-latest]
+    timeout-minutes: 4
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: '[Download] yields.llama.fi/poolsOld'
+        run: |
+          curl --request GET \
+            --silent \
+            --show-error \
+            --fail \
+            --url 'https://yields.llama.fi/poolsOld' \
+            --header 'Accept: application/json' \
+            --header 'Content-Type: application/json' \
+            --output "/${{ runner.temp }}/llama_yields_pools_old.json"
+
+      - name: '[Upload] Cloudflare R2'
+        run: |
+          FILE_PATH="/${{ runner.temp }}/llama_yields_pools_old.json" \
+            UPLOAD_PATH="yield/llama_yields_pools_old.json" \
+            CLOUDFLARE_S3_URL="${{ env.CLOUDFLARE_S3_URL }}/llamafolio" \
+            CLOUDFLARE_AWS_ACCESS_KEY_ID="${{ secrets.CLOUDFLARE_AWS_ACCESS_KEY_ID }}" \
+            CLOUDFLARE_AWS_SECRET_ACCESS_KEY="${{ secrets.CLOUDFLARE_AWS_SECRET_ACCESS_KEY }}" \
+            /bin/bash ${{ github.workspace }}/scripts/r2/upload.sh

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,9 +2,10 @@
 
 1. Fork the repository
 2. Create your feature branch: `git checkout -b my-new-feature`
-3. Commit your changes: `git commit -m "Add some feature"`
-4. Push to the branch: `git push origin my-new-feature`
-5. Submit a pull request.
+3. Copy `.env.example` to `.env` and fill in the missing values if any
+4. Commit your changes: `git commit -m "Add some feature"`
+5. Push to the branch: `git push origin my-new-feature`
+6. Submit a pull request.
 
 ## How to create your adapter
 
@@ -13,11 +14,11 @@
 3. Scaffold your adapter with `pnpm run create-adapter {defillama-id}`
 4. Retrieve all contracts holding users' funds in the `getContracts()` method
 5. Retrieve all balances in the `getBalances()` method of the adapter
-6. Be sure to use multicall when possible, LlamaFolio runs thousands of adapters and it is important they run as quickly as possible
-7. If your protocol is a fork of a known protocol, you will likely have a helper in the library (Uniswap v2/AAVE v2 etc)
+6. Be sure to use `multicall` when possible, **LlamaFolio** runs thousands of adapters and it is important they run as quickly as possible
+7. If your protocol is a fork of a known protocol, you will likely have a helper in the library (`Uniswap v2`/`AAVE v2` etc)
 
 ## Testing your adapter
 
 1. Run your adapter `pnpm run adapter wallet ethereum 0x000000` with a few different addresses to make sure it behaves as expected
 2. Run the test suite to make sure there is no missing metadata
-3. Make sure your adapter runs in under 15 seconds, if it doesn't, explain why and try to improve it if possible
+3. Make sure your adapter runs in ***under 15 seconds***. If it doesn't, explain why and try to improve it if possible

--- a/environment.ts
+++ b/environment.ts
@@ -15,13 +15,12 @@ export const environmentSchema = z.object({
   ARBITRUM_RPC: z.string().optional(),
   OPTIMISM_RPC: z.string().optional(),
   IS_OFFLINE: z.literal('true').or(z.literal('false')).optional(),
+  OUTSIDE_CONTRIBUTOR: z.union([z.literal('true'), z.literal('false')]).default('false'),
   API_URL: z.string().optional(),
   AWS_GATEWAY_API_ID_DEV: z.string().optional(),
   AWS_GATEWAY_API_ID_PROD: z.string().optional(),
   SENTRY_DSN: z.string().optional(),
-  //
   CLOUDFLARE_R2_PUBLIC_URL: z.string().optional(),
-
   NFTPORT_API_KEY: z.string().optional(),
   OPENSEA_API_KEY: z.string().optional(),
   ALCHEMY_API_KEY: z.string().optional(),
@@ -30,6 +29,8 @@ export const environmentSchema = z.object({
   INFURA_API_KEY_SECRET: z.string().optional(),
   CENTER_API_KEY: z.string().optional(),
   RESERVOIR_API_KEY: z.string().optional(),
+  QUICKNODE_API_KEY: z.string().optional(),
+  QUICKNODE_HTTP_URL: z.string().optional(),
 })
 
 export type Environment = z.infer<typeof environmentSchema>

--- a/src/db/yields.ts
+++ b/src/db/yields.ts
@@ -1,5 +1,7 @@
+import { environment } from '@environment'
 import { sliceIntoChunks } from '@lib/array'
 import type { Chain } from '@lib/chains'
+import { raise } from '@lib/error'
 import type { PoolClient } from 'pg'
 import format from 'pg-format'
 
@@ -55,7 +57,11 @@ function extractAddress(str: string) {
 }
 
 export async function fetchYields() {
-  const yieldsRes = await fetch('https://yields.llama.fi/poolsOld')
+  const url = environment.OUTSIDE_CONTRIBUTOR
+    ? 'https://yields.llama.fi/poolsOld'
+    : `${environment.CLOUDFLARE_R2_PUBLIC_URL}/yield/llama_yields_pools_old.json` ??
+      raise('missing CLOUDFLARE_R2_PUBLIC_URL')
+  const yieldsRes = await fetch(url)
   if (!yieldsRes.ok) {
     throw new Error('failed to fetch yields')
   }

--- a/test/routes.sh
+++ b/test/routes.sh
@@ -121,4 +121,4 @@ curl --head \
   --silent \
   --show-error \
   --fail \
-  --url $CLOUDFLARE_R2_PUBLIC_URL/nft/llama_nft_collections.json
+  --url $API_URL/nfts/0xb53F052f717A340147F71Fdd9659C2C008b35A52


### PR DESCRIPTION
As part of the discussion related to https://github.com/llamafolio/llamafolio-api/issues/626, https://yields.llama.fi/poolsOld is a large payload so understandably takes time to retrieve. Storing it in R2 allows for radically fast read performance.

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
