### PR TITLE
feat: Adapter Convex-Finance

### DIFF
--- a/src/adapters/convex-finance/ethereum/index.ts
+++ b/src/adapters/convex-finance/ethereum/index.ts
@@ -7,6 +7,13 @@ import { getConvexGaugesBalances } from './balance'
 import { getPoolsContracts } from './pool'
 import { getCvxCrvStakeBalance, getCVXStakeBalance } from './stake'
 
+const threeCrv: Token = {
+  chain: 'ethereum',
+  address: '0x7091dbb7fcbA54569eF1387Ac89Eb2a5C9F6d2EA',
+  decimals: 18,
+  symbol: '3CRV',
+}
+
 const cvxCRV: Token = {
   chain: 'ethereum',
   address: '0x62b9c7356a2dc64a1969e19c23e4f579f9810aa7',
@@ -73,7 +80,8 @@ const cvxCRVStaker: Contract = {
   chain: 'ethereum',
   address: '0x3fe65692bfcd0e6cf84cb1e7d24108e434a7587e',
   underlyings: [cvxCRV],
-  rewards: [CRV, CVX],
+  rewards: [CRV, CVX, threeCrv],
+  rewarder: '0x7091dbb7fcbA54569eF1387Ac89Eb2a5C9F6d2EA',
 }
 
 export const getContracts = async (ctx: BaseContext) => {


### PR DESCRIPTION
Add missing 3CRV rewards on crvCVX stake

`pnpm run adapter-balances convex-finance ethereum 0xf929122994e177079c924631ba13fb280f5cd1f9`


### **BEFORE**
![cvx-before](https://github.com/llamafolio/llamafolio-api/assets/110820448/8dd2775c-ec76-4a63-b3ff-500e0587eb7a)

### **NOW**
![convex-missingrewards-0xf929122994e177079c924631ba13fb280f5cd1f9](https://github.com/llamafolio/llamafolio-api/assets/110820448/6b6dee1f-777d-4161-b5e1-cb29250a8d2e)
