### PR TITLE
fix: Adapter Convex-Finance

### DIFF
--- a/src/adapters/convex-finance/ethereum/index.ts
+++ b/src/adapters/convex-finance/ethereum/index.ts
@@ -9,7 +9,7 @@ import { getCvxCrvStakeBalance, getCVXStakeBalance } from './stake'
 
 const threeCrv: Token = {
   chain: 'ethereum',
-  address: '0x7091dbb7fcbA54569eF1387Ac89Eb2a5C9F6d2EA',
+  address: '0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490',
   decimals: 18,
   symbol: '3CRV',
 }

--- a/src/adapters/convex-finance/ethereum/stake.ts
+++ b/src/adapters/convex-finance/ethereum/stake.ts
@@ -17,7 +17,7 @@ const abi = {
 
 const threeCrv: Token = {
   chain: 'ethereum',
-  address: '0x7091dbb7fcbA54569eF1387Ac89Eb2a5C9F6d2EA',
+  address: '0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490',
   decimals: 18,
   symbol: '3CRV',
 }


### PR DESCRIPTION
3CRV address was not correct in crvCVXRewards which prevented the display of logo and price on Llamafolio