### PR TITLE
fix: Adapter Gravita-Protocol

### DIFF
--- a/src/adapters/gravita-protocol/ethereum/index.ts
+++ b/src/adapters/gravita-protocol/ethereum/index.ts
@@ -7,12 +7,7 @@ const StabilityPool: Contract = {
   chain: 'ethereum',
   address: '0x4f39f12064d83f6dd7a2bdb0d53af8be560356a6',
   token: '0x15f74458aE0bFdAA1a96CA1aa779D715Cc1Eefe4',
-  rewards: [
-    '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
-    '0xae78736Cd615f374D3085123A210448E74Fc6393',
-    '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0',
-    '0xB9D7DdDca9a4AC480991865EfEf82E01273F79C3',
-  ],
+  rewards: ['0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0', '0xae78736Cd615f374D3085123A210448E74Fc6393'],
 }
 
 const borrowerOperations: Contract = {

--- a/src/adapters/gravita-protocol/ethereum/stake.ts
+++ b/src/adapters/gravita-protocol/ethereum/stake.ts
@@ -11,7 +11,10 @@ const abi = {
     type: 'function',
   },
   getDepositorGains: {
-    inputs: [{ internalType: 'address', name: '_depositor', type: 'address' }],
+    inputs: [
+      { internalType: 'address', name: '_depositor', type: 'address' },
+      { internalType: 'address[]', name: '_assets', type: 'address[]' },
+    ],
     name: 'getDepositorGains',
     outputs: [
       { internalType: 'address[]', name: '', type: 'address[]' },
@@ -30,9 +33,16 @@ const GRAI: Token = {
 }
 
 export async function getGravitaStakeBalance(ctx: BalancesContext, staker: Contract): Promise<Balance> {
+  const rewardsAddresses: `0x${string}`[] = staker.rewards!.map((reward) => (reward as Contract).address)
+
   const [userDeposit, userPendingRewards] = await Promise.all([
     call({ ctx, target: staker.address, params: [ctx.address], abi: abi.deposits }),
-    call({ ctx, target: staker.address, params: [ctx.address], abi: abi.getDepositorGains }),
+    call({
+      ctx,
+      target: staker.address,
+      params: [ctx.address, rewardsAddresses],
+      abi: abi.getDepositorGains,
+    }),
   ])
 
   const fmtRewards = staker.rewards?.map((reward, idx) => {


### PR DESCRIPTION
Stake logic was not functional since rewards calls were reverted due to an error in the abi used.

`pnpm run adapter-balances gravita-protocol ethereum 0x3ec6732676db7996c1b34e64b0503f941025cb63`

![gravita-protocol-0x3ec6732676db7996c1b34e64b0503f941025cb63](https://github.com/llamafolio/llamafolio-api/assets/110820448/352f18f8-6e2f-43de-8e5f-adc097eee5b9)

BEFORE

![gravita-0x3ec6732676db7996c1b34e64b0503f941025cb63](https://github.com/llamafolio/llamafolio-api/assets/110820448/5aa50756-f957-4121-b078-92235d034eda)


NOW

![now](https://github.com/llamafolio/llamafolio-api/assets/110820448/997937fc-12d3-43aa-99e5-70a28bd621a3)
