### PR TITLE
feat: Adapter, Radiant-v2 on BSC

### DIFF
--- a/src/adapters/radiant-v2/bsc/index.ts
+++ b/src/adapters/radiant-v2/bsc/index.ts
@@ -1,0 +1,68 @@
+import { getLendingPoolBalances } from '@adapters/radiant-v2/arbitrum/lendingPool'
+import { getMultiFeeDistributionContracts } from '@adapters/radiant-v2/arbitrum/multifee'
+import { getMultiFeeDistributionBalancesBSC } from '@adapters/radiant-v2/bsc/multifee'
+import { getLendingPoolContracts as getAaveLendingPoolContracts } from '@lib/aave/v2/lending'
+import type { BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+import type { Token } from '@lib/token'
+
+const lendingPoolContract: Contract = {
+  name: 'LendingPool',
+  displayName: 'Radiant Lending',
+  chain: 'bsc',
+  address: '0xd50Cf00b6e600Dd036Ba8eF475677d816d6c4281',
+}
+
+const multiFeeDistributionContract: Contract = {
+  name: 'MultiFeeDistribution',
+  displayName: 'Radiant multiFeeDistribution',
+  chain: 'bsc',
+  address: '0x4FD9F7C5ca0829A656561486baDA018505dfcB5E',
+}
+
+const chefIncentivesControllerContract: Contract = {
+  name: 'ChefIncentivesController',
+  displayName: 'Radiant incentives controller',
+  chain: 'bsc',
+  address: '0x7C16aBb090d3FB266E9d17F60174B632f4229933',
+}
+
+const radiantToken: Token = {
+  chain: 'bsc',
+  address: '0xf7DE7E8A6bd59ED41a4b5fe50278b3B7f31384dF',
+  symbol: 'RDNT',
+  decimals: 18,
+}
+
+const WBNB_RDNT: Contract = {
+  chain: 'bsc',
+  address: '0x346575fc7f07e6994d76199e41d13dc1575322e1',
+  underlyings: ['0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c', '0xf7de7e8a6bd59ed41a4b5fe50278b3b7f31384df'],
+}
+
+export const getContracts = async (ctx: BaseContext) => {
+  const [pools, fmtMultifeeDistributionContract] = await Promise.all([
+    getAaveLendingPoolContracts(ctx, lendingPoolContract),
+    getMultiFeeDistributionContracts(ctx, multiFeeDistributionContract, WBNB_RDNT),
+  ])
+
+  return {
+    contracts: { pools, fmtMultifeeDistributionContract },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    pools: (...args) => getLendingPoolBalances(...args, chefIncentivesControllerContract, radiantToken),
+    fmtMultifeeDistributionContract: (...args) =>
+      getMultiFeeDistributionBalancesBSC(...args, {
+        multiFeeDistribution: multiFeeDistributionContract,
+        lendingPool: lendingPoolContract,
+        stakingToken: WBNB_RDNT,
+      }),
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/radiant-v2/bsc/multifee.ts
+++ b/src/adapters/radiant-v2/bsc/multifee.ts
@@ -1,0 +1,249 @@
+import type { Balance, BalancesContext, BaseContext, Contract } from '@lib/adapter'
+import { mapSuccessFilter } from '@lib/array'
+import { call } from '@lib/call'
+import { sumBI } from '@lib/math'
+import { multicall } from '@lib/multicall'
+import type { Token } from '@lib/token'
+import { getUnderlyingBalances } from '@lib/uniswap/v2/pair'
+
+const abi = {
+  UNDERLYING_ASSET_ADDRESS: {
+    inputs: [],
+    name: 'UNDERLYING_ASSET_ADDRESS',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  claimableRewards: {
+    inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
+    name: 'claimableRewards',
+    outputs: [
+      {
+        components: [
+          { internalType: 'address', name: 'token', type: 'address' },
+          { internalType: 'uint256', name: 'amount', type: 'uint256' },
+        ],
+        internalType: 'struct IFeeDistribution.RewardData[]',
+        name: 'rewardsData',
+        type: 'tuple[]',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  earnedBalances: {
+    inputs: [{ internalType: 'address', name: 'user', type: 'address' }],
+    name: 'earnedBalances',
+    outputs: [
+      { internalType: 'uint256', name: 'total', type: 'uint256' },
+      { internalType: 'uint256', name: 'unlocked', type: 'uint256' },
+      {
+        components: [
+          { internalType: 'uint256', name: 'amount', type: 'uint256' },
+          { internalType: 'uint256', name: 'unlockTime', type: 'uint256' },
+          { internalType: 'uint256', name: 'penalty', type: 'uint256' },
+        ],
+        internalType: 'struct EarnedBalance[]',
+        name: 'earningsData',
+        type: 'tuple[]',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  lockedBalances: {
+    inputs: [{ internalType: 'address', name: 'user', type: 'address' }],
+    name: 'lockedBalances',
+    outputs: [
+      { internalType: 'uint256', name: 'total', type: 'uint256' },
+      { internalType: 'uint256', name: 'unlockable', type: 'uint256' },
+      { internalType: 'uint256', name: 'locked', type: 'uint256' },
+      { internalType: 'uint256', name: 'lockedWithMultiplier', type: 'uint256' },
+      {
+        components: [
+          { internalType: 'uint256', name: 'amount', type: 'uint256' },
+          { internalType: 'uint256', name: 'unlockTime', type: 'uint256' },
+          { internalType: 'uint256', name: 'multiplier', type: 'uint256' },
+          { internalType: 'uint256', name: 'duration', type: 'uint256' },
+        ],
+        internalType: 'struct LockedBalance[]',
+        name: 'lockData',
+        type: 'tuple[]',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  rewardConverter: {
+    inputs: [],
+    name: 'rewardConverter',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  viewPendingRewards: {
+    inputs: [{ internalType: 'address', name: '_user', type: 'address' }],
+    name: 'viewPendingRewards',
+    outputs: [
+      { internalType: 'address[]', name: 'tokens', type: 'address[]' },
+      { internalType: 'uint256[]', name: 'amts', type: 'uint256[]' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  getPoolTokens: {
+    inputs: [{ internalType: 'bytes32', name: 'poolId', type: 'bytes32' }],
+    name: 'getPoolTokens',
+    outputs: [
+      { internalType: 'contract IERC20[]', name: 'tokens', type: 'address[]' },
+      { internalType: 'uint256[]', name: 'balances', type: 'uint256[]' },
+      { internalType: 'uint256', name: 'lastChangeBlock', type: 'uint256' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+const radiantToken: Token = {
+  chain: 'bsc',
+  address: '0xf7DE7E8A6bd59ED41a4b5fe50278b3B7f31384dF',
+  symbol: 'RDNT',
+  decimals: 18,
+}
+
+export interface GetMultiFeeDistributionBalancesParams {
+  lendingPool: Contract
+  multiFeeDistribution: Contract
+  stakingToken: Contract
+}
+
+export async function getMultiFeeDistributionContracts(
+  ctx: BaseContext,
+  multiFeeDistribution: Contract,
+  stakingToken: Contract,
+): Promise<Contract> {
+  const claimableRewards = await call({
+    ctx,
+    target: multiFeeDistribution.address,
+    // any addresses could return reward addresses
+    params: [multiFeeDistribution.address],
+    abi: abi.claimableRewards,
+  })
+
+  const underlyingsTokensRes = await multicall({
+    ctx,
+    calls: claimableRewards.map((reward) => ({ target: reward.token })),
+    abi: abi.UNDERLYING_ASSET_ADDRESS,
+  })
+
+  return {
+    ...stakingToken,
+    address: multiFeeDistribution.address,
+    token: stakingToken.address,
+    rewards: mapSuccessFilter(underlyingsTokensRes, (token) => token.output),
+  }
+}
+
+export async function getMultiFeeDistributionBalancesBSC(
+  ctx: BalancesContext,
+  multiFeeDistributionContract: Contract,
+  params: GetMultiFeeDistributionBalancesParams,
+): Promise<Balance[] | undefined> {
+  const vestBalances: Balance[] = []
+  const lockBalances: Balance[] = []
+
+  const contract = multiFeeDistributionContract
+  const rewards = contract.rewards as Contract[]
+  const underlyings = contract.underlyings as Contract[]
+  const token = params.stakingToken
+
+  if (!rewards || !underlyings || !token) {
+    return
+  }
+
+  const [lockedBalances, earnedBalances, rewardConverter] = await Promise.all([
+    call({ ctx, target: params.multiFeeDistribution.address, params: [ctx.address], abi: abi.lockedBalances }),
+    call({ ctx, target: params.multiFeeDistribution.address, params: [ctx.address], abi: abi.earnedBalances }),
+    call({ ctx, target: params.multiFeeDistribution.address, abi: abi.rewardConverter }),
+  ])
+  const [total, _unlockable, _locked, _lockedWithMultiplier, lockData] = lockedBalances
+  const [_total, _unlocked, earningsData] = earnedBalances
+
+  const pendingRewards = await call({
+    ctx,
+    target: rewardConverter,
+    params: [ctx.address],
+    abi: abi.viewPendingRewards,
+  })
+  const [_tokens, amts] = pendingRewards
+
+  // Locker
+  const sumLocked = sumBI((lockData || []).map((lockData) => lockData.amount))
+  const expiredLocked = total - sumLocked
+
+  lockBalances.push({
+    chain: ctx.chain,
+    address: token.address,
+    symbol: contract.symbol,
+    decimals: contract.decimals,
+    underlyings,
+    rewards: undefined,
+    amount: expiredLocked,
+    claimable: expiredLocked,
+    category: 'lock',
+  })
+
+  for (let lockIdx = 0; lockIdx < lockData.length; lockIdx++) {
+    const lockedBalance = lockData[lockIdx]
+    const { amount, unlockTime } = lockedBalance
+
+    lockBalances.push({
+      chain: ctx.chain,
+      address: token.address,
+      symbol: contract.symbol,
+      decimals: contract.decimals,
+      underlyings,
+      rewards: undefined,
+      amount,
+      unlockAt: Number(unlockTime),
+      claimable: 0n,
+      category: 'lock',
+    })
+  }
+
+  // Vester
+  for (let vestIdx = 0; vestIdx < earningsData.length; vestIdx++) {
+    const earnedBalance = earningsData[vestIdx]
+    const { amount, unlockTime } = earnedBalance
+
+    vestBalances.push({
+      chain: ctx.chain,
+      address: radiantToken.address,
+      symbol: radiantToken.symbol,
+      decimals: radiantToken.decimals,
+      underlyings: undefined,
+      rewards: undefined,
+      amount,
+      unlockAt: Number(unlockTime),
+      category: 'vest',
+    })
+  }
+
+  for (let rewardIdx = 0; rewardIdx < rewards.length; rewardIdx++) {
+    const reward = rewards[rewardIdx]
+    const pendingReward = amts[rewardIdx]
+
+    vestBalances.push({
+      chain: ctx.chain,
+      address: reward.address,
+      symbol: reward.symbol,
+      decimals: reward.decimals,
+      underlyings: undefined,
+      rewards: undefined,
+      amount: pendingReward,
+      category: 'reward',
+    })
+  }
+
+  return [...vestBalances, ...(await getUnderlyingBalances(ctx, lockBalances))]
+}

--- a/src/adapters/radiant-v2/index.ts
+++ b/src/adapters/radiant-v2/index.ts
@@ -1,10 +1,12 @@
 import type { Adapter } from '@lib/adapter'
 
 import * as arbitrum from './arbitrum'
+import * as bsc from './bsc'
 
 const adapter: Adapter = {
   id: 'radiant-v2',
   arbitrum,
+  bsc,
 }
 
 export default adapter


### PR DESCRIPTION
- [x] store contracts
- [x] lend
- [x] lock
- [x] vest


`pnpm run adapter-balances radiant-v2 bsc 0x59a661f1c909ca13ba3e9114bfdd81e5a420705d`

![radiant-bsc-0x59a661f1c909ca13ba3e9114bfdd81e5a420705d](https://github.com/llamafolio/llamafolio-api/assets/110820448/00a595b1-25cd-4c43-97ae-08ed24837a73)


