### PR TITLE
fix: Adapter, Morphex

### DIFF
--- a/src/adapters/morphex/fantom/balance.ts
+++ b/src/adapters/morphex/fantom/balance.ts
@@ -160,10 +160,13 @@ export async function getMorphexStakeMPXBalances(
   if (!underlyings) {
     return
   }
+
+  console.log(contract)
+
   const [stakedBalance, claimableEsToken, claimableNativeToken, underlyingsBalancesRes] = await Promise.all([
     call({ ctx, target: contract.address, params: [ctx.address], abi: abi.stakedAmounts }),
     call({ ctx, target: contract.address, params: [ctx.address], abi: abi.claimable }),
-    call({ ctx, target: contract.address, abi: erc20Abi.totalSupply }),
+    call({ ctx, target: contract.rewarder, params: [ctx.address], abi: abi.claimable }),
     multicall({
       ctx,
       calls: underlyings.map(
@@ -173,8 +176,8 @@ export async function getMorphexStakeMPXBalances(
     }),
   ])
 
-  underlyings.forEach((underlying, underlyingIdx) => {
-    ;(underlying as Balance).amount = underlyingsBalancesRes[underlyingIdx].success
+  underlyings.forEach((underlying: Contract, underlyingIdx) => {
+    underlying.amount = underlyingsBalancesRes[underlyingIdx].success
       ? underlyingsBalancesRes[underlyingIdx].output
       : 0n
   })

--- a/src/adapters/morphex/fantom/balance.ts
+++ b/src/adapters/morphex/fantom/balance.ts
@@ -161,8 +161,6 @@ export async function getMorphexStakeMPXBalances(
     return
   }
 
-  console.log(contract)
-
   const [stakedBalance, claimableEsToken, claimableNativeToken, underlyingsBalancesRes] = await Promise.all([
     call({ ctx, target: contract.address, params: [ctx.address], abi: abi.stakedAmounts }),
     call({ ctx, target: contract.address, params: [ctx.address], abi: abi.claimable }),


### PR DESCRIPTION
There was a wrong call as we can see on this SS

> abi call function was  `TotalSupply` instead of `Claimable` for `contract.rewarder` (address)

`pnpm run adapter-balances morphex fantom 0x19145b49fd5e4c345822a4a83fe5543c5bbb785c`

![wrong_call](https://github.com/llamafolio/llamafolio-api/assets/110820448/96a58b00-794d-4e1d-ab84-d20c6e6b3d5d)

### **BEFORE**

![wrong-rewards-0x19145b49fd5e4c345822a4a83fe5543c5bbb785c](https://github.com/llamafolio/llamafolio-api/assets/110820448/390132a6-8a58-4003-b10b-579d9df21506)

### **NOW**

![fixed](https://github.com/llamafolio/llamafolio-api/assets/110820448/f2f821b6-50ea-40c2-9ed1-d1d1d12d859c)
