### PR TITLE
feat: Fix Stargate (SGETH to WETH) + add Base

### DIFF
--- a/src/adapters/stargate/base/index.ts
+++ b/src/adapters/stargate/base/index.ts
@@ -1,0 +1,44 @@
+import type { BalancesContext, BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+import type { Token } from '@lib/token'
+
+import { getStargateLpContracts } from '../common/contract'
+import { getStargateFarmBalances } from '../common/farm'
+import { getStargateLPBalances } from '../common/lp'
+
+const STG: Token = {
+  chain: 'base',
+  address: '0xE3B53AF74a4BF62Ae5511055290838050bf764Df',
+  decimals: 18,
+  symbol: 'STG',
+}
+
+// https://stargateprotocol.gitbook.io/stargate/developers/contract-addresses/mainnet
+const lpStakings: Contract[] = [
+  { chain: 'base', address: '0x4c80e24119cfb836cdf0a6b53dc23f04f7e652ca', rewards: [STG] },
+  { chain: 'base', address: '0x28fc411f9e1c480ad312b3d9c60c22b965015c6b', rewards: [STG] },
+]
+
+const farmStakings: Contract[] = [{ chain: 'base', address: '0x06eb48763f117c7be887296cdcdfad2e4092739c' }]
+
+export const getContracts = async (ctx: BaseContext) => {
+  const pools = await getStargateLpContracts(ctx, lpStakings)
+
+  return {
+    contracts: { pools },
+  }
+}
+
+const stargateBalances = async (ctx: BalancesContext, pools: Contract[]) => {
+  return Promise.all([getStargateLPBalances(ctx, pools), getStargateFarmBalances(ctx, pools, farmStakings)])
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    pools: stargateBalances,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/stargate/common/contract.ts
+++ b/src/adapters/stargate/common/contract.ts
@@ -11,6 +11,13 @@ const abi = {
   },
 } as const
 
+const ETH: { [key: string]: `0x${string}`[] } = {
+  arbitrum: ['0x82cbecf39bee528b5476fe6d1550af59a9db6fc0', '0x82af49447d8a07e3bd95bd0d56f35241523fbab1'],
+  base: ['0x224d8fd7ab6ad4c6eb4611ce56ef35dec2277f03', '0x4200000000000000000000000000000000000006'],
+  ethereum: ['0x72E2F4830b9E45d52F80aC08CB2bEC0FeF72eD9c', '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'],
+  optimism: ['0xb69c8cbcd90a39d8d3d3ccf0a3e968511c3856a0', '0x4200000000000000000000000000000000000006'],
+}
+
 export async function getStargateLpContracts(ctx: BaseContext, lpStakers: Contract[]): Promise<Contract[]> {
   const contracts: Contract[] = []
 
@@ -28,7 +35,11 @@ export async function getStargateLpContracts(ctx: BaseContext, lpStakers: Contra
       continue
     }
 
-    contracts.push({ ...lpStaker, underlyings: [underlyingRes.output] })
+    // replace SGETH to WETH
+    const fmtUnderlyings =
+      ETH[ctx.chain][0].toLowerCase() === underlyingRes.output.toLowerCase() ? ETH[ctx.chain][1] : underlyingRes.output
+
+    contracts.push({ ...lpStaker, underlyings: [fmtUnderlyings] })
   }
 
   return contracts

--- a/src/adapters/stargate/index.ts
+++ b/src/adapters/stargate/index.ts
@@ -2,6 +2,7 @@ import type { Adapter } from '@lib/adapter'
 
 import * as arbitrum from './arbitrum'
 import * as avalanche from './avalanche'
+import * as base from './base'
 import * as bsc from './bsc'
 import * as ethereum from './ethereum'
 import * as fantom from './fantom'
@@ -17,6 +18,7 @@ const adapter: Adapter = {
   fantom,
   optimism,
   polygon,
+  base,
 }
 
 export default adapter


### PR DESCRIPTION
> Fix an issue for chains using ETH as gas, Stargate transform ETH into SGETH to distinguish them, but we could not recover the price by Defillama, so i replaced SGETH with WETH for these chains

- [x] add Base


`pnpm run adapter stargate optimism 0x4dea9e918c6289a52cd469cac652727b7b412cd2`
BEFORE FIX

![sgeth_op_0x4dea9e918c6289a52cd469cac652727b7b412cd2](https://github.com/llamafolio/llamafolio-api/assets/110820448/5be79c55-6c22-4cd1-baee-d7967b0c059e)

AFTER FIX
![op_fixed_sg_0x4dea9e918c6289a52cd469cac652727b7b412cd2](https://github.com/llamafolio/llamafolio-api/assets/110820448/0111c6dd-8ac4-49ba-b39b-e9d9e345aac8)


BASE
_LP_

`pnpm run adapter stargate base 0x81eab64e630c4a2e3e849268a6b64cb76d1c8109`

![sg_base_lp_0x81eab64e630c4a2e3e849268a6b64cb76d1c8109](https://github.com/llamafolio/llamafolio-api/assets/110820448/05709972-ffde-42ce-81d7-8feefaef7afb)


_FARM_

`pnpm run adapter stargate base 0x816a0e727027cf5a15bed81d5b580bde829bd33b`

![sg_base_farm_0x816a0e727027cf5a15bed81d5b580bde829bd33b](https://github.com/llamafolio/llamafolio-api/assets/110820448/539fb8ea-80af-426d-a6bd-4b157d501264)

