### PR TITLE
feat: Adapter, ondo-finance

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -205,6 +205,7 @@
         "nf3-ape",
         "nodedao",
         "olympus-dao",
+        "ondo-finance",
         "onyx-protocol",
         "opyn-squeeth",
         "origin-defi",

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -133,6 +133,7 @@ import nexusMutual from '@adapters/nexus-mutual'
 import nf3Ape from '@adapters/nf3-ape'
 import nodedao from '@adapters/nodedao'
 import olympusDao from '@adapters/olympus-dao'
+import ondoFinance from '@adapters/ondo-finance'
 import onyxProtocol from '@adapters/onyx-protocol'
 import opynSqueeth from '@adapters/opyn-squeeth'
 import originDefi from '@adapters/origin-defi'
@@ -373,6 +374,7 @@ export const adapters: Adapter[] = [
   nf3Ape,
   nodedao,
   olympusDao,
+  ondoFinance,
   onyxProtocol,
   opynSqueeth,
   originDefi,

--- a/src/adapters/ondo-finance/ethereum/balance.ts
+++ b/src/adapters/ondo-finance/ethereum/balance.ts
@@ -1,0 +1,36 @@
+import type { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { call } from '@lib/call'
+import { abi as erc20Abi } from '@lib/erc20'
+import type { Token } from '@lib/token'
+
+const abi = {
+  lastSetMintExchangeRate: {
+    inputs: [],
+    name: 'lastSetMintExchangeRate',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+const USDC: Token = {
+  chain: 'ethereum',
+  address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+  decimals: 6,
+  symbol: 'USDC',
+}
+
+export async function getOUSGStakeBalance(ctx: BalancesContext, staker: Contract, manager: Contract): Promise<Balance> {
+  const [balances, exchangeRate] = await Promise.all([
+    call({ ctx, target: staker.address, params: [ctx.address], abi: erc20Abi.balanceOf }),
+    call({ ctx, target: manager.address, abi: abi.lastSetMintExchangeRate }),
+  ])
+
+  return {
+    ...staker,
+    amount: balances,
+    underlyings: [{ ...USDC, decimals: 18, amount: (balances * exchangeRate) / BigInt(Math.pow(10, 18)) }],
+    rewards: undefined,
+    category: 'stake',
+  }
+}

--- a/src/adapters/ondo-finance/ethereum/index.ts
+++ b/src/adapters/ondo-finance/ethereum/index.ts
@@ -1,0 +1,30 @@
+import { getOUSGStakeBalance } from '@adapters/ondo-finance/ethereum/balance'
+import type { Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+const OUSG: Contract = {
+  chain: 'ethereum',
+  address: '0x1b19c19393e2d034d8ff31ff34c81252fcbbee92',
+  underlyings: ['0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'],
+}
+
+const cashManager: Contract = {
+  chain: 'ethereum',
+  address: '0x3501883a646f1F8417BcB62162372550954D618f',
+}
+
+export const getContracts = () => {
+  return {
+    contracts: { OUSG },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    OUSG: (...args) => getOUSGStakeBalance(...args, cashManager),
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/ondo-finance/index.ts
+++ b/src/adapters/ondo-finance/index.ts
@@ -1,0 +1,10 @@
+import type { Adapter } from '@lib/adapter'
+
+import * as ethereum from './ethereum'
+
+const adapter: Adapter = {
+  id: 'ondo-finance',
+  ethereum,
+}
+
+export default adapter


### PR DESCRIPTION
> Add `Ondo-finance` on `ethereum`

### **STAKE**

`pnpm run adapter-balances ondo-finance ethereum 0x1dd7950c266fb1be96180a8fdb0591f70200e018`

![ousg-stake-0x1dd7950c266fb1be96180a8fdb0591f70200e018](https://github.com/llamafolio/llamafolio-api/assets/110820448/197a9db0-659a-43f2-8338-3bc87716dc16)
