### PR TITLE
fix: curve-dex on ethereum

### DIFF
--- a/src/adapters/curve-dex/ethereum/lpBalance.ts
+++ b/src/adapters/curve-dex/ethereum/lpBalance.ts
@@ -6,10 +6,12 @@ export async function getLpCurveBalances(
   ctx: BalancesContext,
   pools: Contract[],
   registry: Contract,
-): Promise<Balance[]> {
+): Promise<Balance[] | undefined> {
   const balances: Balance[] = []
 
   const lpBalances = await getPoolsBalances(ctx, pools, registry)
+
+  if (!lpBalances) return
 
   for (const lpBalance of lpBalances) {
     const underlyings = lpBalance.underlyings as Contract[]


### PR DESCRIPTION
> Add handling error

> Fix missing pools --> We were filtering the pools according to the responses to different calls including gaugeType and poolName which led to losing pools

### **BEFORE**
![before-0x7a16ff8270133f063aab6c9977183d9e72835428](https://github.com/llamafolio/llamafolio-api/assets/110820448/2a24e93b-adf6-4c54-9ef3-770284c57c51)

### **NOW**
![now-0x7a16ff8270133f063aab6c9977183d9e72835428](https://github.com/llamafolio/llamafolio-api/assets/110820448/0a78760b-55b6-41f8-85bc-473d02ce6ac5)

