### PR TITLE
Feat: Adapter, Inverse-finance contracts

### DIFF
--- a/src/adapters/inverse-finance/ethereum/index.ts
+++ b/src/adapters/inverse-finance/ethereum/index.ts
@@ -12,6 +12,9 @@ const contracts: Contract[] = [
   { chain: 'ethereum', address: '0xb516247596ca36bf32876199fbdcad6b3322330b' },
   { chain: 'ethereum', address: '0x7cd3ab8354289bef52c84c2bf0a54e3608e66b37' },
   { chain: 'ethereum', address: '0x743a502cf0e213f6fee56cd9c6b03de7fa951dcf' },
+  { chain: 'ethereum', address: '0x27b6c301fd441f3345d61b7a4245e1f823c3f9c4' },
+  { chain: 'ethereum', address: '0x93685185666c8d34ad4c574b3dbf41231bbfb31b' },
+  { chain: 'ethereum', address: '0x63df5e23db45a2066508318f172ba45b9cd37035' },
 ]
 
 // Deprecated -> https://docs.inverse.finance/inverse-finance/technical/smart-contracts


### PR DESCRIPTION
> Add missing contracts on Inverse-Finance

`pnpm run adapter inverse-finance ethereum 0x7a16ff8270133f063aab6c9977183d9e72835428`

### **BEFORE**

![before-0x7a16ff8270133f063aab6c9977183d9e72835428](https://github.com/llamafolio/llamafolio-api/assets/110820448/71768eb0-157a-44cf-a45b-3ce74cffb49c)

### **NOW**

![now-0x7a16ff8270133f063aab6c9977183d9e72835428](https://github.com/llamafolio/llamafolio-api/assets/110820448/b58ef291-6182-4b03-82d2-de2578fe1196)
