### PR TITLE
feat: Adapter, silo-finance, add missing contract

### DIFF
--- a/src/adapters/silo-finance/ethereum/index.ts
+++ b/src/adapters/silo-finance/ethereum/index.ts
@@ -35,6 +35,7 @@ const siloVaults: `0x${string}`[] = [
   '0x58f93cb4ef4e3428066c848ec4d054edd68441af',
   '0x6926e507339eca2b01bede825d762f4ea19e13c2',
   '0x0bce613ef6a197e8c56be525cf173c27b49ac47d',
+  // '0x96efdf95cc47fe90e8f63d2f5ef9fb8b180daeb9',
 ]
 
 const routers: Contract[] = [

--- a/src/adapters/silo-finance/ethereum/index.ts
+++ b/src/adapters/silo-finance/ethereum/index.ts
@@ -35,7 +35,7 @@ const siloVaults: `0x${string}`[] = [
   '0x58f93cb4ef4e3428066c848ec4d054edd68441af',
   '0x6926e507339eca2b01bede825d762f4ea19e13c2',
   '0x0bce613ef6a197e8c56be525cf173c27b49ac47d',
-  // '0x96efdf95cc47fe90e8f63d2f5ef9fb8b180daeb9',
+  '0x96efdf95cc47fe90e8f63d2f5ef9fb8b180daeb9',
 ]
 
 const routers: Contract[] = [


### PR DESCRIPTION
`pnpm run adapter-balances silo-finance ethereum 0x7a16ff8270133f063aab6c9977183d9e72835428`

### **BEFORE**
![before-0x7a16ff8270133f063aab6c9977183d9e72835428](https://github.com/llamafolio/llamafolio-api/assets/110820448/c7b10120-8f33-4ad7-bbe5-948c23997267)

### **NOW**
![now-0x7a16ff8270133f063aab6c9977183d9e72835428](https://github.com/llamafolio/llamafolio-api/assets/110820448/789c481c-e737-4b1d-974a-0bc8655bdc02)
