### PR TITLE
feat: Adapter, Vesper

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -301,6 +301,7 @@
         "velodrome",
         "venus",
         "verse",
+        "vesper",
         "wallet",
         "wepiggy",
         "whiteheart",

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -229,6 +229,7 @@ import vector from '@adapters/vector'
 import velodrome from '@adapters/velodrome'
 import venus from '@adapters/venus'
 import verse from '@adapters/verse'
+import vesper from '@adapters/vesper'
 import wallet from '@adapters/wallet'
 import wepiggy from '@adapters/wepiggy'
 import whiteheart from '@adapters/whiteheart'
@@ -474,6 +475,7 @@ export const adapters: Adapter[] = [
   velodrome,
   venus,
   verse,
+  vesper,
   wallet,
   wepiggy,
   whiteheart,

--- a/src/adapters/vesper/avalanche/index.ts
+++ b/src/adapters/vesper/avalanche/index.ts
@@ -1,0 +1,24 @@
+import { getVesperStakeBalances } from '@adapters/vesper/common/balance'
+import { getVesperStakeContracts } from '@adapters/vesper/common/pool'
+import type { BaseContext, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+const STAKING_URL = 'https://api-avalanche.vesper.finance/pools?stages=prod'
+
+export const getContracts = async (ctx: BaseContext) => {
+  const pools = await getVesperStakeContracts(ctx, STAKING_URL)
+
+  return {
+    contracts: { pools },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    pools: getVesperStakeBalances,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/vesper/common/balance.ts
+++ b/src/adapters/vesper/common/balance.ts
@@ -1,0 +1,95 @@
+import type { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { call } from '@lib/call'
+import { abi as erc20Abi } from '@lib/erc20'
+import { multicall } from '@lib/multicall'
+
+const abi = {
+  pricePerShare: {
+    inputs: [],
+    name: 'pricePerShare',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  claimable: {
+    inputs: [{ internalType: 'address', name: '_account', type: 'address' }],
+    name: 'claimable',
+    outputs: [
+      { internalType: 'address[]', name: '_rewardTokens', type: 'address[]' },
+      { internalType: 'uint256[]', name: '_claimableAmounts', type: 'uint256[]' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  getPricePerShare: {
+    inputs: [],
+    name: 'getPricePerShare',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+export async function getVesperStakeBalances(ctx: BalancesContext, pools: Contract[]): Promise<Balance[]> {
+  const balances: Balance[] = []
+
+  const [userBalancesRes, exchangeRatesRes] = await Promise.all([
+    multicall({
+      ctx,
+      calls: pools.map((pool) => ({ target: pool.address, params: [ctx.address] }) as const),
+      abi: erc20Abi.balanceOf,
+    }),
+    multicall({
+      ctx,
+      calls: pools.map((pool) => ({ target: pool.address }) as const),
+      abi: abi.pricePerShare,
+    }),
+  ])
+
+  for (const [index, pool] of pools.entries()) {
+    const underlying = pool.underlyings?.[0] as Contract
+    const userBalanceRes = userBalancesRes[index]
+    const exchangeRateRes = exchangeRatesRes[index]
+
+    if (!underlying || !userBalanceRes.success || !exchangeRateRes.success) {
+      continue
+    }
+
+    const fmtUnderlyings = {
+      ...underlying,
+      amount: (userBalanceRes.output * exchangeRateRes.output) / BigInt(Math.pow(10, 18)),
+    }
+
+    balances.push({
+      ...pool,
+      amount: userBalanceRes.output,
+      underlyings: [fmtUnderlyings],
+      rewards: undefined,
+      category: 'stake',
+    })
+  }
+
+  return balances
+}
+
+export async function getvVSPStakeBalance(ctx: BalancesContext, pool: Contract): Promise<Balance> {
+  const balances: Balance[] = []
+
+  const [userBalance, exchangeRate] = await Promise.all([
+    call({ ctx, target: pool.address, params: [ctx.address], abi: erc20Abi.balanceOf }),
+    call({ ctx, target: pool.address, abi: abi.getPricePerShare }),
+  ])
+
+  const fmtUnderlyings = {
+    ...(pool.underlyings?.[0] as Contract),
+    amount: (userBalance * exchangeRate) / BigInt(Math.pow(10, 18)),
+  }
+
+  return {
+    ...pool,
+    amount: userBalance,
+    underlyings: [fmtUnderlyings],
+    rewards: undefined,
+    category: 'stake',
+  }
+}

--- a/src/adapters/vesper/common/pool.ts
+++ b/src/adapters/vesper/common/pool.ts
@@ -1,0 +1,14 @@
+import type { BaseContext, Contract } from '@lib/adapter'
+
+export async function getVesperStakeContracts(ctx: BaseContext, url: string): Promise<Contract[]> {
+  const response = await fetch(url)
+  const vaults: any[] = await response.json()
+
+  return vaults.map((vault) => ({
+    chain: ctx.chain,
+    name: vault.name,
+    address: vault.address,
+    underlyings: [vault.collateral.address],
+    rewarder: vault.rewardsContractAddress,
+  }))
+}

--- a/src/adapters/vesper/ethereum/index.ts
+++ b/src/adapters/vesper/ethereum/index.ts
@@ -1,0 +1,31 @@
+import { getVesperStakeBalances, getvVSPStakeBalance } from '@adapters/vesper/common/balance'
+import { getVesperStakeContracts } from '@adapters/vesper/common/pool'
+import type { BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+const STAKING_URL = 'https://api.vesper.finance/pools?stages=prod'
+
+const vVSP: Contract = {
+  chain: 'ethereum',
+  address: '0xbA4cFE5741b357FA371b506e5db0774aBFeCf8Fc',
+  underlyings: ['0x1b40183efb4dd766f11bda7a7c3ad8982e998421'],
+}
+
+export const getContracts = async (ctx: BaseContext) => {
+  const pools = await getVesperStakeContracts(ctx, STAKING_URL)
+
+  return {
+    contracts: { pools, vVSP },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    pools: getVesperStakeBalances,
+    vVSP: getvVSPStakeBalance,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/vesper/index.ts
+++ b/src/adapters/vesper/index.ts
@@ -1,0 +1,16 @@
+import type { Adapter } from '@lib/adapter'
+
+import * as ethereum from './ethereum'
+import * as optimism from './optimism'
+import * as avalanche from './avalanche'
+import * as polygon from './polygon'
+
+const adapter: Adapter = {
+  id: 'vesper',
+  ethereum,
+  optimism,
+  avalanche,
+  polygon,
+}
+
+export default adapter

--- a/src/adapters/vesper/index.ts
+++ b/src/adapters/vesper/index.ts
@@ -1,8 +1,8 @@
 import type { Adapter } from '@lib/adapter'
 
+import * as avalanche from './avalanche'
 import * as ethereum from './ethereum'
 import * as optimism from './optimism'
-import * as avalanche from './avalanche'
 import * as polygon from './polygon'
 
 const adapter: Adapter = {

--- a/src/adapters/vesper/optimism/index.ts
+++ b/src/adapters/vesper/optimism/index.ts
@@ -1,0 +1,24 @@
+import { getVesperStakeBalances } from '@adapters/vesper/common/balance'
+import { getVesperStakeContracts } from '@adapters/vesper/common/pool'
+import type { BaseContext, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+const STAKING_URL = 'https://api-optimism.vesper.finance/pools'
+
+export const getContracts = async (ctx: BaseContext) => {
+  const pools = await getVesperStakeContracts(ctx, STAKING_URL)
+
+  return {
+    contracts: { pools },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    pools: getVesperStakeBalances,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/vesper/polygon/index.ts
+++ b/src/adapters/vesper/polygon/index.ts
@@ -1,0 +1,24 @@
+import { getVesperStakeBalances } from '@adapters/vesper/common/balance'
+import { getVesperStakeContracts } from '@adapters/vesper/common/pool'
+import type { BaseContext, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+const STAKING_URL = 'https://api-polygon.vesper.finance/pools?stages=prod'
+
+export const getContracts = async (ctx: BaseContext) => {
+  const pools = await getVesperStakeContracts(ctx, STAKING_URL)
+
+  return {
+    contracts: { pools },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    pools: getVesperStakeBalances,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}


### PR DESCRIPTION
> Add Vesper adapter on several chains

### **Ethereum**
`npm run adapter vesper ethereum 0x698137c473bc1f0ea9b85ade45caf64ef2df48d6`

![vesper-0x698137c473bc1f0ea9b85ade45caf64ef2df48d6](https://github.com/llamafolio/llamafolio-api/assets/110820448/e1b2dfc9-6081-419b-83b9-25c61e70beaa)

`npm run adapter vesper ethereum 0xc17cbb210b2dd44bb07d55212c6de6961404ec94`

![vesper-0xc17cbb210b2dd44bb07d55212c6de6961404ec94](https://github.com/llamafolio/llamafolio-api/assets/110820448/0b83703c-d017-4acc-ae71-b17cf7f64506)


### **Optimism**
`npm run adapter vesper optimism 0x4fd49322ccc93078baf8011b70abc58ffe1a181b`

![vesper-op-0x4fd49322ccc93078baf8011b70abc58ffe1a181b](https://github.com/llamafolio/llamafolio-api/assets/110820448/392fd017-09e5-4124-8e0b-6a664dd7d846)


### **Polygon**
`npm run adapter vesper polygon 0x041550d216b0eec58d2cbc34798b26ba2c0f2b37`

![vesper-poly-0x041550d216b0eec58d2cbc34798b26ba2c0f2b37](https://github.com/llamafolio/llamafolio-api/assets/110820448/626ad35b-e959-4690-9b8d-2080ceff78e5)


### **Avalanche**
`npm run adapter vesper avalanche 0xdee08599414228dc21e8f0b8b87f674162e82e0a`

![vesper-avax-0xdee08599414228dc21e8f0b8b87f674162e82e0a](https://github.com/llamafolio/llamafolio-api/assets/110820448/89add525-cfec-40e0-a155-1187188da2d2)


