### PR TITLE
feat: aggregate balances by adapter

### DIFF
--- a/src/handlers/getBalances.ts
+++ b/src/handlers/getBalances.ts
@@ -168,9 +168,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
   const client = connect()
 
   try {
-    const balancesGroups = await selectLatestBalancesGroupsByFromAddress(client, address)
-
-    const updatedAt = balancesGroups[0]?.timestamp ? new Date(balancesGroups[0]?.timestamp).getTime() : undefined
+    const { updatedAt, balancesGroups } = await selectLatestBalancesGroupsByFromAddress(client, address)
 
     let status: Status = 'success'
     if (updatedAt === undefined) {
@@ -185,7 +183,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
 
     const balancesResponse: BalancesResponse = {
       status,
-      updatedAt: updatedAt === undefined ? undefined : Math.floor(updatedAt / 1000),
+      updatedAt,
       groups: formattedBalancesGroups,
     }
 

--- a/src/handlers/updateBalances.ts
+++ b/src/handlers/updateBalances.ts
@@ -1,6 +1,6 @@
 import { adapterById } from '@adapters/index'
 import type { ClickHouseClient } from '@clickhouse/client'
-import type { Balance } from '@db/balances'
+import type { BalanceStorable } from '@db/balances'
 import { insertBalances } from '@db/balances'
 import { getContractsInteractions, groupContracts } from '@db/contracts'
 import type { BalancesContext } from '@lib/adapter'
@@ -37,7 +37,7 @@ export async function updateBalances(client: ClickHouseClient, address: `0x${str
   console.log('Interacted with protocols:', adapterIds)
 
   const now = new Date()
-  const balances: Balance[] = []
+  const balances: BalanceStorable[] = []
 
   // Run adapters `getBalances` only with the contracts the user interacted with
   await Promise.all(


### PR DESCRIPTION
<!-- 🦙🦙 Thanks for contributing ! 🦙🦙 -->

<!-- Please specify the adapter id in the title -->

<!-- If you're creating a new adapter, please make sure the `links` field is well specified: this info will help us review it -->

## Summary

<!-- Which issues will be closed? (if applicable) -->

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

This denormalized structure has many advantages compared to the previous one:
- grouping balances per adapter / per chain / per day / per user ensures that balances get correctly replaced by the ReplacingMergeTree engine if we make changes to an adapter
- ensures we're only storing daily balances for each user (not xxx balances if we update it  many times a day)
- easily access latest balances
- easily access historical balances and make it easier to run backfill jobs per adapter

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
