### PR TITLE
fix: balances sanitize consider underlyings and rewards

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "llamafolio-api",
   "version": "0.0.1",
   "description": "LlamaFolio API",
-  "type": "module",
   "scripts": {
     "adapter": "tsx scripts/run-adapter.ts",
     "build": "tsx scripts/build-adapters.ts",

--- a/src/handlers/getBalancesTokens.ts
+++ b/src/handlers/getBalancesTokens.ts
@@ -7,7 +7,7 @@ import { getContractsInteractions, groupContracts } from '@db/contracts'
 import { badRequest, serverError, success } from '@handlers/response'
 import type { BalancesContext, PricedBalance } from '@lib/adapter'
 import { groupBy } from '@lib/array'
-import { isBalanceUSDGtZero, sanitizeBalances, sortBalances, sumBalances } from '@lib/balance'
+import { sanitizeBalances, sanitizePricedBalances, sortBalances, sumBalances } from '@lib/balance'
 import { isHex } from '@lib/buf'
 import type { Chain } from '@lib/chains'
 import { chainById, chains as allChains } from '@lib/chains'
@@ -114,17 +114,17 @@ export const handler: APIGatewayProxyHandler = async (event, _context) => {
 
     const pricedBalances = await getPricedBalances(sanitizedBalances)
 
-    const nonZeroPricedBalances = pricedBalances.filter(isBalanceUSDGtZero)
+    const sanitizedPricedBalances = sanitizePricedBalances(pricedBalances)
 
     const hrend = process.hrtime(hrstart)
 
     console.log(
-      `getPricedBalances ${sanitizedBalances.length} balances, found ${nonZeroPricedBalances.length} balances in %ds %dms`,
+      `getPricedBalances ${sanitizedBalances.length} balances, found ${sanitizedPricedBalances.length} balances in %ds %dms`,
       hrend[0],
       hrend[1] / 1000000,
     )
 
-    const pricedBalancesByChain = groupBy(nonZeroPricedBalances, 'chain')
+    const pricedBalancesByChain = groupBy(sanitizedPricedBalances, 'chain')
 
     const now = new Date()
 

--- a/src/lib/price.ts
+++ b/src/lib/price.ts
@@ -157,3 +157,7 @@ export async function getPricedBalances(balances: Balance[]): Promise<(Balance |
 
   return pricedBalances
 }
+
+export function isPricedBalance(balance: Balance | PricedBalance): balance is PricedBalance {
+  return (balance as PricedBalance).price != null
+}


### PR DESCRIPTION
<!-- 🦙🦙 Thanks for contributing ! 🦙🦙 -->

<!-- Please specify the adapter id in the title -->

<!-- If you're creating a new adapter, please make sure the `links` field is well specified: this info will help us review it -->

## Summary

<!-- Which issues will be closed? (if applicable) -->

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

fix few edge cases and reuse function:
- return balances if failed to fetch price of token but underlyings worked correctly
- return balances if unstaked tokens but still have some unclaimed rewards

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
