### PR TITLE
fix: balances underlyings value can be 0

### DIFF
--- a/src/lib/balance.ts
+++ b/src/lib/balance.ts
@@ -187,6 +187,11 @@ function isPricedBalanceInRange(balance: PricedBalance, key: 'balanceUSD' | 'cla
   return value != null && value >= MIN_BALANCE_USD && value <= MAX_BALANCE_USD
 }
 
+function isPricedBalanceLtMax(balance: PricedBalance, key: 'balanceUSD' | 'claimableUSD' = 'balanceUSD') {
+  const value = balance[key]
+  return value != null && value <= MAX_BALANCE_USD
+}
+
 export function sanitizePricedBalances<T extends PricedBalance>(balances: T[]) {
   const sanitizedBalances: T[] = []
 
@@ -200,7 +205,7 @@ export function sanitizePricedBalances<T extends PricedBalance>(balances: T[]) {
     balance.rewards = balance.rewards?.filter(
       (reward) => isPricedBalanceInRange(reward, 'balanceUSD') || isPricedBalanceInRange(reward, 'claimableUSD'),
     )
-    balance.underlyings = balance.underlyings?.filter((underlying) => isPricedBalanceInRange(underlying))
+    balance.underlyings = balance.underlyings?.filter((underlying) => isPricedBalanceLtMax(underlying))
 
     sanitizedBalances.push(balance)
   }


### PR DESCRIPTION
<!-- 🦙🦙 Thanks for contributing ! 🦙🦙 -->

<!-- Please specify the adapter id in the title -->

<!-- If you're creating a new adapter, please make sure the `links` field is well specified: this info will help us review it -->

## Summary

<!-- Which issues will be closed? (if applicable) -->

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

It's possible for LP values to have underlyings with amount at 0 (ex: uniswap-v3), we should not assume underlyings to have a special value (but a sane one to avoid massive balances)

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
