### PR TITLE
fix: stale balances timestamp

### DIFF
--- a/src/lib/balance.ts
+++ b/src/lib/balance.ts
@@ -10,6 +10,7 @@ import type {
 import type { Category } from '@lib/category'
 import { ADDRESS_ZERO } from '@lib/contract'
 import { getBalancesOf } from '@lib/erc20'
+import { unixFromDate } from '@lib/fmt'
 import { parseFloatBI } from '@lib/math'
 import { multicall } from '@lib/multicall'
 import { providers } from '@lib/providers'
@@ -330,10 +331,10 @@ export const BALANCE_UPDATE_THRESHOLD_SEC = 5 * 60
 /**
  * At the moment, balances are considered "stale" if they haven't been updated in the last x minutes.
  * Later, we can use more advanced strategies using transactions events, scheduled updates etc
- * @param lastUpdateTimestamp
+ * @param lastUpdateTimestamp unix timestamp (in seconds)
  */
 export function areBalancesStale(lastUpdateTimestamp: number) {
-  const now = new Date().getTime()
+  const now = unixFromDate(new Date())
 
-  return now - lastUpdateTimestamp > BALANCE_UPDATE_THRESHOLD_SEC * 1000
+  return now - lastUpdateTimestamp > BALANCE_UPDATE_THRESHOLD_SEC
 }

--- a/src/lib/fmt.ts
+++ b/src/lib/fmt.ts
@@ -105,7 +105,7 @@ export function fromDateTime(date: string) {
 }
 
 export function unixFromDateTime(date: string) {
-  return dayjs(date, 'YYYY-MM-DD HH:mm:ss').unix()
+  return dayjs.utc(date, 'YYYY-MM-DD HH:mm:ss').unix()
 }
 
 export function unixFromDate(date: Date) {


### PR DESCRIPTION
<!-- 🦙🦙 Thanks for contributing ! 🦙🦙 -->

<!-- Please specify the adapter id in the title -->

<!-- If you're creating a new adapter, please make sure the `links` field is well specified: this info will help us review it -->

## Summary

<!-- Which issues will be closed? (if applicable) -->

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

force using UTC date and compare Unix timestamps in seconds instead of JS milliseconds

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
