### PR TITLE
Feat: Adapter, Channels-Finance (compound forks)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -117,6 +117,7 @@
         "cat-in-a-box",
         "cega",
         "chainlink",
+        "channels-finance",
         "charm-finance",
         "coinbase-wrapped-staked-eth",
         "coinwind",

--- a/src/adapters/channels-finance/arbitrum/index.ts
+++ b/src/adapters/channels-finance/arbitrum/index.ts
@@ -1,0 +1,31 @@
+import type { BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+import { getMarketsBalances, getMarketsContracts } from '@lib/compound/v2/market'
+
+const comptroller: Contract = {
+  chain: 'arbitrum',
+  address: '0x3C13b172bf8BE5b873EB38553feC50F78c826284',
+}
+
+export const getContracts = async (ctx: BaseContext) => {
+  const markets = await getMarketsContracts(ctx, {
+    comptrollerAddress: comptroller.address,
+  })
+
+  return {
+    contracts: {
+      markets,
+    },
+    revalidate: 60 * 60,
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    markets: getMarketsBalances,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/channels-finance/bsc/index.ts
+++ b/src/adapters/channels-finance/bsc/index.ts
@@ -1,0 +1,51 @@
+import type { BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+import { getMarketsBalances, getMarketsContracts } from '@lib/compound/v2/market'
+
+const comptroller: Contract = {
+  chain: 'bsc',
+  address: '0x8Cd2449Ed0469D90a7C4321DF585e7913dd6E715',
+}
+
+const comptroller_v1: Contract = {
+  chain: 'bsc',
+  address: '0xfc518333f4bc56185bdd971a911fce03dee4fc8c',
+}
+
+export const getContracts = async (ctx: BaseContext) => {
+  const [markets, markets_v1] = await Promise.all([
+    getMarketsContracts(ctx, {
+      comptrollerAddress: comptroller.address,
+      underlyingAddressByMarketAddress: {
+        // // cBNB -> BNB
+        '0x14e134365f754496fbc70906b8611b8b49f66dd4': '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c',
+      },
+    }),
+    getMarketsContracts(ctx, {
+      comptrollerAddress: comptroller_v1.address,
+      underlyingAddressByMarketAddress: {
+        // // cBNB -> BNB
+        '0x14e134365f754496fbc70906b8611b8b49f66dd4': '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c',
+      },
+    }),
+  ])
+
+  return {
+    contracts: {
+      markets,
+      markets_v1,
+    },
+    revalidate: 60 * 60,
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    markets: getMarketsBalances,
+    markets_v1: getMarketsBalances,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/channels-finance/index.ts
+++ b/src/adapters/channels-finance/index.ts
@@ -1,0 +1,12 @@
+import type { Adapter } from '@lib/adapter'
+
+import * as bsc from './bsc'
+import * as arbitrum from './arbitrum'
+
+const adapter: Adapter = {
+  id: 'channels-finance',
+  bsc: bsc,
+  arbitrum: arbitrum,
+}
+
+export default adapter

--- a/src/adapters/channels-finance/index.ts
+++ b/src/adapters/channels-finance/index.ts
@@ -1,7 +1,7 @@
 import type { Adapter } from '@lib/adapter'
 
-import * as bsc from './bsc'
 import * as arbitrum from './arbitrum'
+import * as bsc from './bsc'
 
 const adapter: Adapter = {
   id: 'channels-finance',

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -44,6 +44,7 @@ import capFinance from '@adapters/cap-finance'
 import catInABox from '@adapters/cat-in-a-box'
 import cega from '@adapters/cega'
 import chainlink from '@adapters/chainlink'
+import channelsFinance from '@adapters/channels-finance'
 import charmFinance from '@adapters/charm-finance'
 import coinbaseWrappedStakedEth from '@adapters/coinbase-wrapped-staked-eth'
 import coinwind from '@adapters/coinwind'
@@ -314,6 +315,7 @@ export const adapters: Adapter[] = [
   catInABox,
   cega,
   chainlink,
+  channelsFinance,
   charmFinance,
   coinbaseWrappedStakedEth,
   coinwind,


### PR DESCRIPTION
### **BSC**
`pnpm run adapter-balances channels-finance bsc 0xfc8fe5ced7ce60bffbadadffce2989e4b4c68ff4`

![bsc-c-0xfc8fe5ced7ce60bffbadadffce2989e4b4c68ff4](https://github.com/llamafolio/llamafolio-api/assets/110820448/ec4d9477-30d3-47df-a8cb-ba87e06203a3)

`pnpm run adapter-balances channels-finance bsc 0x5eac4a9c2fb481e016a526b4fc3aa8205f72ddb9`

![bsc-c-0x5eac4a9c2fb481e016a526b4fc3aa8205f72ddb9](https://github.com/llamafolio/llamafolio-api/assets/110820448/ad154e16-2301-4447-afa6-7c56df594f1b)


### **ARBITRUM**
`pnpm run adapter-balances channels-finance arbitrum 0xf4b93a76bfedbaa5dd58c37c438bde519e881b37`

![channels-lend-0xf4b93a76bfedbaa5dd58c37c438bde519e881b37](https://github.com/llamafolio/llamafolio-api/assets/110820448/08865b9a-dcbe-47a8-a65a-76ae3effc2c0)
