### PR TITLE
feat: Adapter, Yama Finance

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -351,6 +351,7 @@
         "wombat-exchange",
         "woofi",
         "x2y2",
+        "yama-finance",
         "yearn-finance",
         "yoshi-exchange",
         "zerolend",

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -277,6 +277,7 @@ import wigoswap from '@adapters/wigoswap'
 import wombatExchange from '@adapters/wombat-exchange'
 import woofi from '@adapters/woofi'
 import x2y2 from '@adapters/x2y2'
+import yamaFinance from '@adapters/yama-finance'
 import yearnFinance from '@adapters/yearn-finance'
 import yoshiExchange from '@adapters/yoshi-exchange'
 import zerolend from '@adapters/zerolend'
@@ -563,6 +564,7 @@ export const adapters: Adapter[] = [
   wombatExchange,
   woofi,
   x2y2,
+  yamaFinance,
   yearnFinance,
   yoshiExchange,
   zerolend,

--- a/src/adapters/yama-finance/arbitrum/CDP.ts
+++ b/src/adapters/yama-finance/arbitrum/CDP.ts
@@ -1,0 +1,138 @@
+import type { BalancesContext, BaseContext, BorrowBalance, Contract, LendBalance } from '@lib/adapter'
+import { mapMultiSuccessFilter, mapSuccessFilter, rangeBI } from '@lib/array'
+import { call } from '@lib/call'
+import { parseFloatBI } from '@lib/math'
+import { multicall } from '@lib/multicall'
+import type { Token } from '@lib/token'
+import { isNotNullish } from '@lib/type'
+
+const abi = {
+  collateralTypes: {
+    inputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    name: 'collateralTypes',
+    outputs: [
+      { internalType: 'contract IERC20', name: 'token', type: 'address' },
+      { internalType: 'contract IPriceSource', name: 'priceSource', type: 'address' },
+      { internalType: 'uint256', name: 'debtFloor', type: 'uint256' },
+      { internalType: 'uint256', name: 'debtCeiling', type: 'uint256' },
+      { internalType: 'uint256', name: 'collateralRatio', type: 'uint256' },
+      { internalType: 'uint256', name: 'interestRate', type: 'uint256' },
+      { internalType: 'uint256', name: 'totalCollateral', type: 'uint256' },
+      { internalType: 'uint256', name: 'lastUpdateTime', type: 'uint256' },
+      { internalType: 'uint256', name: 'initialDebt', type: 'uint256' },
+      { internalType: 'uint256', name: 'cumulativeInterest', type: 'uint256' },
+      { internalType: 'bool', name: 'borrowingEnabled', type: 'bool' },
+      { internalType: 'bool', name: 'allowlistEnabled', type: 'bool' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  getOwnedVaults: {
+    inputs: [{ internalType: 'address', name: 'owner', type: 'address' }],
+    name: 'getOwnedVaults',
+    outputs: [{ internalType: 'uint256[]', name: 'ownedVaults_', type: 'uint256[]' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  getCollateralToken: {
+    inputs: [{ internalType: 'uint256', name: 'vaultId', type: 'uint256' }],
+    name: 'getCollateralToken',
+    outputs: [{ internalType: 'contract IERC20', name: 'collateralToken', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  getCollateralAmount: {
+    inputs: [{ internalType: 'uint256', name: 'vaultId', type: 'uint256' }],
+    name: 'getCollateralAmount',
+    outputs: [{ internalType: 'uint256', name: 'collateralAmount', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  getDebt: {
+    inputs: [{ internalType: 'uint256', name: 'vaultId', type: 'uint256' }],
+    name: 'getDebt',
+    outputs: [{ internalType: 'uint256', name: 'debt', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+const USDT: Token = {
+  chain: 'arbitrum',
+  address: '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9',
+  decimals: 6,
+  symbol: 'USDT',
+}
+
+export async function getCDPCollateralAssets(ctx: BaseContext, CDP: Contract): Promise<Contract[]> {
+  const COLLATERAL_TYPES_LENGTH = 6n
+
+  const collateralTypesRes = await multicall({
+    ctx,
+    calls: rangeBI(0n, COLLATERAL_TYPES_LENGTH).map((i) => ({ target: CDP.address, params: [i] }) as const),
+    abi: abi.collateralTypes,
+  })
+
+  return mapSuccessFilter(collateralTypesRes, (res) => {
+    const [token, _, __, ___, MCR] = res.output
+
+    return { chain: ctx.chain, address: token, MCR: parseFloatBI(MCR, 18), collateralId: res.input.params[0] }
+  })
+}
+
+export async function getCDPBalances(ctx: BalancesContext, CDP: Contract, assets: Contract[]) {
+  const userOwnedVaultsIds = await call({ ctx, target: CDP.address, params: [ctx.address], abi: abi.getOwnedVaults })
+
+  const [getCollateralTokensRes, getCollateralBalancesRes, getDebtBalancesRes] = await Promise.all([
+    multicall({
+      ctx,
+      calls: userOwnedVaultsIds.map((vaultId) => ({ target: CDP.address, params: [vaultId] }) as const),
+      abi: abi.getCollateralToken,
+    }),
+    multicall({
+      ctx,
+      calls: userOwnedVaultsIds.map((vaultId) => ({ target: CDP.address, params: [vaultId] }) as const),
+      abi: abi.getCollateralAmount,
+    }),
+    multicall({
+      ctx,
+      calls: userOwnedVaultsIds.map((vaultId) => ({ target: CDP.address, params: [vaultId] }) as const),
+      abi: abi.getDebt,
+    }),
+  ])
+
+  return mapMultiSuccessFilter(
+    getCollateralTokensRes.map((_, i) => [
+      getCollateralTokensRes[i],
+      getCollateralBalancesRes[i],
+      getDebtBalancesRes[i],
+    ]),
+
+    (res) => {
+      const [{ output: token }, { output: lendBalance }, { output: borrowBalance }] = res.inputOutputPairs
+
+      const collateral = assets.find((asset) => asset.address.toLowerCase() === token.toLowerCase())
+
+      if (!collateral) return null
+
+      const lend: LendBalance = {
+        ...collateral,
+        amount: lendBalance,
+        underlyings: undefined,
+        rewards: undefined,
+        category: 'lend',
+      }
+
+      const borrow: BorrowBalance = {
+        ...USDT,
+        decimals: 18,
+        amount: borrowBalance,
+        underlyings: undefined,
+        rewards: undefined,
+        category: 'borrow',
+      }
+
+      return { balances: [lend, borrow] }
+    },
+  ).filter(isNotNullish)
+}

--- a/src/adapters/yama-finance/arbitrum/balance.ts
+++ b/src/adapters/yama-finance/arbitrum/balance.ts
@@ -1,0 +1,31 @@
+import type { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { call } from '@lib/call'
+import { abi as erc20Abi } from '@lib/erc20'
+import { parseEther } from 'viem'
+
+const abi = {
+  value: {
+    inputs: [],
+    name: 'value',
+    outputs: [{ internalType: 'uint256', name: 'value_', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+export async function getYamaStakeBalances(ctx: BalancesContext, staker: Contract): Promise<Balance> {
+  const underlying = staker.underlyings?.[0] as Contract
+
+  const [balanceOf, value] = await Promise.all([
+    call({ ctx, target: staker.address, params: [ctx.address], abi: erc20Abi.balanceOf }),
+    call({ ctx, target: staker.address, abi: abi.value }),
+  ])
+
+  return {
+    ...staker,
+    amount: balanceOf,
+    underlyings: [{ ...underlying, amount: (balanceOf * value) / parseEther('1.0'), decimals: 18 }],
+    rewards: undefined,
+    category: 'stake',
+  }
+}

--- a/src/adapters/yama-finance/arbitrum/index.ts
+++ b/src/adapters/yama-finance/arbitrum/index.ts
@@ -1,6 +1,6 @@
+import { getYamaStakeBalances } from '@adapters/yama-finance/arbitrum/balance'
 import type { Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
-import { getSingleStakeBalances } from '@lib/stake'
 import type { Token } from '@lib/token'
 
 const USDT: Token = {
@@ -18,14 +18,14 @@ const USDT_YL: Contract = {
 
 export const getContracts = async () => {
   return {
-    contracts: { assets: [USDT_YL] },
+    contracts: { USDT_YL },
     revalidate: 60 * 60,
   }
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
   const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
-    assets: getSingleStakeBalances,
+    USDT_YL: getYamaStakeBalances,
   })
 
   return {

--- a/src/adapters/yama-finance/arbitrum/index.ts
+++ b/src/adapters/yama-finance/arbitrum/index.ts
@@ -1,0 +1,34 @@
+import type { Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+import { getSingleStakeBalances } from '@lib/stake'
+import type { Token } from '@lib/token'
+
+const USDT: Token = {
+  chain: 'arbitrum',
+  address: '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
+  decimals: 6,
+  symbol: 'USDT',
+}
+
+const USDT_YL: Contract = {
+  chain: 'arbitrum',
+  address: '0x3296EE4Fa62D0D78B1999617886E969a22653383',
+  underlyings: [USDT],
+}
+
+export const getContracts = async () => {
+  return {
+    contracts: { compounders: [USDT_YL] },
+    revalidate: 60 * 60,
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    compounders: getSingleStakeBalances,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/yama-finance/arbitrum/index.ts
+++ b/src/adapters/yama-finance/arbitrum/index.ts
@@ -18,14 +18,14 @@ const USDT_YL: Contract = {
 
 export const getContracts = async () => {
   return {
-    contracts: { compounders: [USDT_YL] },
+    contracts: { assets: [USDT_YL] },
     revalidate: 60 * 60,
   }
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
   const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
-    compounders: getSingleStakeBalances,
+    assets: getSingleStakeBalances,
   })
 
   return {

--- a/src/adapters/yama-finance/arbitrum/index.ts
+++ b/src/adapters/yama-finance/arbitrum/index.ts
@@ -1,34 +1,55 @@
 import { getYamaStakeBalances } from '@adapters/yama-finance/arbitrum/balance'
-import type { Contract, GetBalancesHandler } from '@lib/adapter'
+import { getCDPBalances, getCDPCollateralAssets } from '@adapters/yama-finance/arbitrum/CDP'
+import type { BaseContext, Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
+import { getSingleStakeBalance } from '@lib/stake'
 import type { Token } from '@lib/token'
 
 const USDT: Token = {
   chain: 'arbitrum',
-  address: '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
+  address: '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9',
   decimals: 6,
   symbol: 'USDT',
 }
 
 const USDT_YL: Contract = {
   chain: 'arbitrum',
-  address: '0x3296EE4Fa62D0D78B1999617886E969a22653383',
+  address: '0x3296ee4fa62d0d78b1999617886e969a22653383',
   underlyings: [USDT],
 }
 
-export const getContracts = async () => {
+const YAMA: Contract = {
+  chain: 'arbitrum',
+  address: '0x7a88b57bf741a3950e53421eaa6c1a3c89d066f9',
+  symbol: 'YAMA',
+  decimals: 18,
+  underlyings: [USDT],
+}
+
+const CDP: Contract = {
+  chain: 'arbitrum',
+  address: '0x1cd97ee98f3423222f7b4cddb383f2ee2907e628',
+}
+
+export const getContracts = async (ctx: BaseContext) => {
+  const collateralAssets = await getCDPCollateralAssets(ctx, CDP)
+
   return {
-    contracts: { USDT_YL },
+    contracts: { USDT_YL, YAMA, CDP, collateralAssets },
     revalidate: 60 * 60,
   }
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
-  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
-    USDT_YL: getYamaStakeBalances,
-  })
+  const [vaultsBalancesGroups, balances] = await Promise.all([
+    getCDPBalances(ctx, CDP, contracts.collateralAssets || []),
+    resolveBalances<typeof getContracts>(ctx, contracts, {
+      USDT_YL: getYamaStakeBalances,
+      YAMA: getSingleStakeBalance,
+    }),
+  ])
 
   return {
-    groups: [{ balances }],
+    groups: [...vaultsBalancesGroups, { balances }],
   }
 }

--- a/src/adapters/yama-finance/index.ts
+++ b/src/adapters/yama-finance/index.ts
@@ -1,0 +1,10 @@
+import type { Adapter } from '@lib/adapter'
+
+import * as arbitrum from './arbitrum'
+
+const adapter: Adapter = {
+  id: 'yama-finance',
+  arbitrum: arbitrum,
+}
+
+export default adapter


### PR DESCRIPTION
<!-- 🦙🦙 Thanks for contributing ! 🦙🦙 -->

<!-- Please specify the adapter id in the title -->

<!-- If you're creating a new adapter, please make sure the `links` field is well specified: this info will help us review it -->

## Summary

<!-- Which issues will be closed? (if applicable) -->

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

Add [Yama Finance](https://defillama.com/protocol/yama-finance) adapter. This only takes care of Arbitrum (Lend) which has the highest TVL, instead of Polygon that seems abandoned with less than $15 TVL.

`pnpm run adapter yama-finance arbitrum 0x7bfee91193d9df2ac0bfe90191d40f23c773c060`

> Note: I cross-checked the results and data with DeBank at https://debank.com/profile/0x7bfee91193d9df2ac0bfe90191d40f23c773c060?chain=arb

<img width="1046" alt="Screenshot 2023-11-16 at 6 55 10 PM" src="https://github.com/llamafolio/llamafolio-api/assets/16455953/9db5d74c-8675-4b73-8c81-18dabc618338">

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
