### PR TITLE
Feat:Adapter,Blast

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -118,6 +118,7 @@
         "bifrost-liquid-staking",
         "binance-staked-eth",
         "biswap",
+        "blast",
         "blur",
         "cap-finance",
         "cat-in-a-box",

--- a/src/adapters/blast/ethereum/balance.ts
+++ b/src/adapters/blast/ethereum/balance.ts
@@ -1,0 +1,50 @@
+import type { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { call } from '@lib/call'
+
+const abi = {
+  balanceOf: {
+    inputs: [{ internalType: 'address', name: 'user', type: 'address' }],
+    name: 'balanceOf',
+    outputs: [
+      { internalType: 'uint256', name: 'ethBalance', type: 'uint256' },
+      { internalType: 'uint256', name: 'usdBalance', type: 'uint256' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+const WETH: Contract = {
+  chain: 'ethereum',
+  address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+  decimals: 18,
+  symbol: 'WETH',
+}
+
+const DAI: Contract = {
+  chain: 'ethereum',
+  address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+  decimals: 18,
+  symbol: 'DAI',
+}
+
+function getBalance(contract: Contract, amount: bigint): Balance {
+  return {
+    ...contract,
+    amount: amount,
+    underlyings: undefined,
+    rewards: undefined,
+    category: 'stake',
+  }
+}
+
+export async function getBlastDepositBalances(ctx: BalancesContext, staker: Contract) {
+  const [ethAmount, daiAmount] = await call({
+    ctx,
+    target: staker.address,
+    params: [ctx.address],
+    abi: abi.balanceOf,
+  })
+
+  return [getBalance(WETH, ethAmount), getBalance(DAI, daiAmount)]
+}

--- a/src/adapters/blast/ethereum/index.ts
+++ b/src/adapters/blast/ethereum/index.ts
@@ -1,0 +1,24 @@
+import { getBlastDepositBalances } from '@adapters/blast/ethereum/balance'
+import type { Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+const staker: Contract = {
+  chain: 'ethereum',
+  address: '0x5f6ae08b8aeb7078cf2f96afb089d7c9f51da47d',
+}
+
+export const getContracts = () => {
+  return {
+    contracts: { staker },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    staker: getBlastDepositBalances,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/blast/index.ts
+++ b/src/adapters/blast/index.ts
@@ -1,0 +1,10 @@
+import type { Adapter } from '@lib/adapter'
+
+import * as ethereum from './ethereum'
+
+const adapter: Adapter = {
+  id: 'blast',
+  ethereum: ethereum,
+}
+
+export default adapter

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -43,6 +43,7 @@ import benqiStakedAvax from '@adapters/benqi-staked-avax'
 import bifrostLiquidStaking from '@adapters/bifrost-liquid-staking'
 import binanceStakedEth from '@adapters/binance-staked-eth'
 import biswap from '@adapters/biswap'
+import blast from '@adapters/blast'
 import blur from '@adapters/blur'
 import capFinance from '@adapters/cap-finance'
 import catInABox from '@adapters/cat-in-a-box'
@@ -345,6 +346,7 @@ export const adapters: Adapter[] = [
   bifrostLiquidStaking,
   binanceStakedEth,
   biswap,
+  blast,
   blur,
   capFinance,
   catInABox,


### PR DESCRIPTION
`pnpm run adapter blast ethereum 0x27c79a01878962ce0b6126af6e184c06d36c8f37`

![blast-0x27c79a01878962ce0b6126af6e184c06d36c8f37](https://github.com/llamafolio/llamafolio-api/assets/110820448/f137bf2d-8e72-4b0e-aa4c-aa27f688207b)
