### PR TITLE
Update:Adapter,Ether.fi, nodeStaking + weETH + eETH

### DIFF
--- a/src/adapters/ether.fi/ethereum/index.ts
+++ b/src/adapters/ether.fi/ethereum/index.ts
@@ -1,22 +1,50 @@
+import { getNodeEtherFiBalances } from '@adapters/ether.fi/ethereum/node'
 import type { Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
+import { getSingleStakeBalance } from '@lib/stake'
 
-import { getEtherBalances } from './stake'
+import { getEtherBalances, getWeETHBalance } from './stake'
+
+const manager: Contract = {
+  chain: 'ethereum',
+  address: '0x3d320286E014C3e1ce99Af6d6B00f0C1D63E3000',
+}
+
+const nodeStaker: Contract = {
+  chain: 'ethereum',
+  address: '0xb49e4420ea6e35f98060cd133842dbea9c27e479',
+  token: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+}
 
 const staker: Contract = {
   chain: 'ethereum',
   address: '0x7623e9dc0da6ff821ddb9ebaba794054e078f8c4',
 }
 
+const eETH: Contract = {
+  chain: 'ethereum',
+  address: '0x35fa164735182de50811e8e2e824cfb9b6118ac2',
+  token: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+}
+
+const weETH: Contract = {
+  chain: 'ethereum',
+  address: '0xcd5fe23c85820f7b72d0926fc9b05b43e359b7ee',
+  token: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+}
+
 export const getContracts = () => {
   return {
-    contracts: { staker },
+    contracts: { staker, manager, eETH, weETH },
   }
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
   const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    manager: (...args) => getNodeEtherFiBalances(...args, nodeStaker),
     staker: getEtherBalances,
+    weETH: getWeETHBalance,
+    eETH: getSingleStakeBalance,
   })
 
   return {

--- a/src/adapters/ether.fi/ethereum/node.ts
+++ b/src/adapters/ether.fi/ethereum/node.ts
@@ -1,0 +1,62 @@
+import type { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { mapSuccessFilter, rangeBI } from '@lib/array'
+import { call } from '@lib/call'
+import { multicall } from '@lib/multicall'
+
+const abi = {
+  nextMintTokenId: {
+    inputs: [],
+    name: 'nextMintTokenId',
+    outputs: [{ internalType: 'uint32', name: '', type: 'uint32' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  balanceOfBatch: {
+    inputs: [
+      { internalType: 'address[]', name: 'accounts', type: 'address[]' },
+      { internalType: 'uint256[]', name: 'ids', type: 'uint256[]' },
+    ],
+    name: 'balanceOfBatch',
+    outputs: [{ internalType: 'uint256[]', name: '', type: 'uint256[]' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  valueOf: {
+    inputs: [{ internalType: 'uint256', name: '_tokenId', type: 'uint256' }],
+    name: 'valueOf',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+export async function getNodeEtherFiBalances(
+  ctx: BalancesContext,
+  _manager: Contract,
+  nodeStaker: Contract,
+): Promise<Balance[]> {
+  const tokenIdsLength = await call({ ctx, target: nodeStaker.address, abi: abi.nextMintTokenId })
+
+  const userTokensIdsRes = await call({
+    ctx,
+    target: nodeStaker.address,
+    params: [Array(tokenIdsLength).fill(ctx.address), rangeBI(0n, BigInt(tokenIdsLength))],
+    abi: abi.balanceOfBatch,
+  })
+
+  const userTokenIds = userTokensIdsRes.flatMap((tokenId, i) => (tokenId !== 0n ? [BigInt(i)] : []))
+
+  const tokenIdValues = await multicall({
+    ctx,
+    calls: userTokenIds.map((id) => ({ target: nodeStaker.address, params: [id] }) as const),
+    abi: abi.valueOf,
+  })
+
+  return mapSuccessFilter(tokenIdValues, (res) => ({
+    ...nodeStaker,
+    amount: res.output,
+    underlyings: undefined,
+    rewards: undefined,
+    category: 'stake',
+  }))
+}


### PR DESCRIPTION
`pnpm run adapter-balances ether.fi ethereum 0xccf343eef0c5f2590ee30efc9f564b33aeb3c7e6`

![ethers fi-0xccf343eef0c5f2590ee30efc9f564b33aeb3c7e6](https://github.com/llamafolio/llamafolio-api/assets/110820448/b3ce0261-fad4-46dc-8865-b284d3cb5945)
