### PR TITLE
Feat:Adapter,Asymmetry-Finance,Ethereum

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -100,6 +100,7 @@
         "arc-swap",
         "arrakis-finance",
         "asymetrix-protocol",
+        "asymmetry-finance",
         "atlantis-loans",
         "atlas-usv",
         "aura",

--- a/src/adapters/asymmetry-finance/ethereum/index.ts
+++ b/src/adapters/asymmetry-finance/ethereum/index.ts
@@ -1,0 +1,25 @@
+import { getsafETHBalance } from '@adapters/asymmetry-finance/ethereum/stake'
+import type { Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+const safETH: Contract = {
+  chain: 'ethereum',
+  address: '0x6732efaf6f39926346bef8b821a04b6361c4f3e5',
+  underlyings: ['0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'],
+}
+
+export const getContracts = () => {
+  return {
+    contracts: { safETH },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    safETH: getsafETHBalance,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}

--- a/src/adapters/asymmetry-finance/ethereum/stake.ts
+++ b/src/adapters/asymmetry-finance/ethereum/stake.ts
@@ -1,0 +1,38 @@
+import type { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { call } from '@lib/call'
+import { abi as erc20Abi } from '@lib/erc20'
+import { parseFloatBI } from '@lib/math'
+
+const abi = {
+  approxPrice: {
+    inputs: [{ internalType: 'bool', name: '_validate', type: 'bool' }],
+    name: 'approxPrice',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+} as const
+
+const WETH: Contract = {
+  chain: 'ethereum',
+  address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+  decimals: 18,
+  symbol: 'WETH',
+}
+
+export async function getsafETHBalance(ctx: BalancesContext, staker: Contract): Promise<Balance> {
+  const [userShare, pricePerFullShare] = await Promise.all([
+    call({ ctx, target: staker.address, params: [ctx.address], abi: erc20Abi.balanceOf }),
+    call({ ctx, target: staker.address, params: [true], abi: abi.approxPrice }),
+  ])
+
+  const userAsset = Number(userShare) * parseFloatBI(pricePerFullShare, 18)
+
+  return {
+    ...staker,
+    amount: userShare,
+    underlyings: [{ ...WETH, amount: BigInt(userAsset) }],
+    rewards: undefined,
+    category: 'stake',
+  }
+}

--- a/src/adapters/asymmetry-finance/index.ts
+++ b/src/adapters/asymmetry-finance/index.ts
@@ -1,0 +1,10 @@
+import type { Adapter } from '@lib/adapter'
+
+import * as ethereum from './ethereum'
+
+const adapter: Adapter = {
+  id: 'asymmetry-finance',
+  ethereum: ethereum,
+}
+
+export default adapter

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -25,6 +25,7 @@ import arbitrumExchange from '@adapters/arbitrum-exchange'
 import arcSwap from '@adapters/arc-swap'
 import arrakisFinance from '@adapters/arrakis-finance'
 import asymetrixProtocol from '@adapters/asymetrix-protocol'
+import asymmetryFinance from '@adapters/asymmetry-finance'
 import atlantisLoans from '@adapters/atlantis-loans'
 import atlasUsv from '@adapters/atlas-usv'
 import aura from '@adapters/aura'
@@ -340,6 +341,7 @@ export const adapters: Adapter[] = [
   arcSwap,
   arrakisFinance,
   asymetrixProtocol,
+  asymmetryFinance,
   atlantisLoans,
   atlasUsv,
   aura,


### PR DESCRIPTION
`pnpm run adapter asymmetry-finance ethereum 0xf7b10d603907658f690da534e9b7dbc4dab3e2d6`

![asymmetry-finance-0xf7b10d603907658f690da534e9b7dbc4dab3e2d6](https://github.com/llamafolio/llamafolio-api/assets/110820448/cb767e5a-deaa-463b-8365-d8116d6d5dc3)
