### PR TITLE
fix: fallback to eth_call if Multicall not deployed at block

### DIFF
--- a/scripts/test-multicall.ts
+++ b/scripts/test-multicall.ts
@@ -1,0 +1,53 @@
+import '../environment'
+
+import type { BaseContext } from '@lib/adapter'
+import { call } from '@lib/call'
+import { abi } from '@lib/erc20'
+import { multicall } from '@lib/multicall'
+
+async function main() {
+  const ctx: BaseContext = { chain: 'ethereum', adapterId: '' }
+  // NOTE: Multicall3 deployed at 14_353_601
+  const beforeMulticall3Ctx: BaseContext = { chain: 'ethereum', adapterId: '', blockNumber: 14_353_600 }
+
+  const [symbol0A] = await multicall({
+    ctx: beforeMulticall3Ctx,
+    abi: abi.symbol,
+    calls: [
+      {
+        // USDT, deployed long before Multicall3
+        target: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+      },
+    ],
+  })
+
+  const [symbol0B] = await multicall({
+    ctx: ctx,
+    abi: abi.symbol,
+    calls: [
+      {
+        // USDT, deployed long before Multicall3
+        target: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+      },
+    ],
+  })
+
+  const symbol0C = await call({
+    ctx,
+    abi: abi.symbol,
+    target: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+  })
+
+  console.log(symbol0A.output)
+  console.log(symbol0B.output)
+  console.log(symbol0C)
+}
+
+main()
+  .then(() => {
+    process.exit(0)
+  })
+  .catch((e) => {
+    console.error(e)
+    process.exit(1)
+  })


### PR DESCRIPTION
<!-- 🦙🦙 Thanks for contributing ! 🦙🦙 -->

<!-- Please specify the adapter id in the title -->

<!-- If you're creating a new adapter, please make sure the `links` field is well specified: this info will help us review it -->

## Summary

<!-- Which issues will be closed? (if applicable) -->

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

fix: https://github.com/llamafolio/llamafolio-api/issues/1261

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
