### PR TITLE
feat:Adapter,9inch,ethereum

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -91,6 +91,7 @@
       "options": [
         "0vix",
         "1inch-network",
+        "9inch",
         "aave-v2",
         "aave-v3",
         "abracadabra",

--- a/src/adapters/9inch/ethereum/index.ts
+++ b/src/adapters/9inch/ethereum/index.ts
@@ -1,0 +1,38 @@
+import type { AdapterConfig, BaseContext, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+import { getPairsContracts } from '@lib/uniswap/v2/factory'
+import { getPairsBalances } from '@lib/uniswap/v2/pair'
+
+export const getContracts = async (ctx: BaseContext, props: any) => {
+  const offset = props.pairOffset || 0
+  const limit = 1000
+
+  const { pairs, allPairsLength } = await getPairsContracts({
+    ctx,
+    factoryAddress: '0xcbae5c3f8259181eb7e2309bc4c72fdf02dd56d8',
+    offset,
+    limit,
+  })
+
+  return {
+    contracts: { pairs },
+    revalidate: 60 * 60,
+    revalidateProps: {
+      pairOffset: Math.min(offset + limit, allPairsLength),
+    },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    pairs: getPairsBalances,
+  })
+
+  return {
+    groups: [{ balances: balances.map((balance) => ({ ...balance, decimals: 18 })) }],
+  }
+}
+
+export const config: AdapterConfig = {
+  startDate: 1699920000,
+}

--- a/src/adapters/9inch/index.ts
+++ b/src/adapters/9inch/index.ts
@@ -1,0 +1,10 @@
+import type { Adapter } from '@lib/adapter'
+
+import * as ethereum from './ethereum'
+
+const adapter: Adapter = {
+  id: '9inch',
+  ethereum: ethereum,
+}
+
+export default adapter

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,5 +1,6 @@
 import _0vix from '@adapters/0vix'
 import _1inchNetwork from '@adapters/1inch-network'
+import _9inch from '@adapters/9inch'
 import aaveV2 from '@adapters/aave-v2'
 import aaveV3 from '@adapters/aave-v3'
 import abracadabra from '@adapters/abracadabra'
@@ -385,6 +386,7 @@ import type { Adapter } from '@lib/adapter'
 export const adapters: Adapter[] = [
   _0vix,
   _1inchNetwork,
+  _9inch,
   aaveV2,
   aaveV3,
   abracadabra,


### PR DESCRIPTION
`pnpm run adapter 9inch ethereum 0x3fefd06828689252a69207718985b9a78350561f`

![9inch_0x3fefd06828689252a69207718985b9a78350561f](https://github.com/llamafolio/llamafolio-api/assets/110820448/800e7f28-8368-42f0-805d-bb04cf41b9b2)
