### PR TITLE
feat:Adapter,Vector-reserve,ethereum

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -450,6 +450,7 @@
         "vapordex",
         "vault-tech",
         "vector-finance",
+        "vector-reserve",
         "velodrome-v1",
         "velodrome-v2",
         "venus",

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -359,6 +359,7 @@ import valasFinance from '@adapters/valas-finance'
 import vapordex from '@adapters/vapordex'
 import vaultTech from '@adapters/vault-tech'
 import vectorFinance from '@adapters/vector-finance'
+import vectorReserve from '@adapters/vector-reserve'
 import velodromeV1 from '@adapters/velodrome-v1'
 import velodromeV2 from '@adapters/velodrome-v2'
 import venus from '@adapters/venus'
@@ -745,6 +746,7 @@ export const adapters: Adapter[] = [
   vapordex,
   vaultTech,
   vectorFinance,
+  vectorReserve,
   velodromeV1,
   velodromeV2,
   venus,

--- a/src/adapters/vector-reserve/ethereum/balance.ts
+++ b/src/adapters/vector-reserve/ethereum/balance.ts
@@ -1,0 +1,28 @@
+import type { Balance, BalancesContext, Contract } from '@lib/adapter'
+import { call } from '@lib/call'
+import { abi as erc20Abi } from '@lib/erc20'
+
+const WETH: Contract = {
+  chain: 'ethereum',
+  address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+  decimals: 18,
+  symbol: 'WETH',
+}
+
+export async function getVectorReserveBalance(ctx: BalancesContext, staker: Contract): Promise<Balance> {
+  const [shareBalance, totalSupply, tokenBalance] = await Promise.all([
+    call({ ctx, target: staker.address, params: [ctx.address], abi: erc20Abi.balanceOf }),
+    call({ ctx, target: staker.address, abi: erc20Abi.totalSupply }),
+    call({ ctx, target: staker.token!, params: [staker.address], abi: erc20Abi.balanceOf }),
+  ])
+
+  const underlyings = [{ ...WETH, amount: (shareBalance * tokenBalance) / totalSupply }]
+
+  return {
+    ...staker,
+    amount: shareBalance,
+    underlyings,
+    rewards: undefined,
+    category: 'stake',
+  }
+}

--- a/src/adapters/vector-reserve/ethereum/index.ts
+++ b/src/adapters/vector-reserve/ethereum/index.ts
@@ -1,0 +1,51 @@
+import { getVectorReserveBalance } from '@adapters/vector-reserve/ethereum/balance'
+import type { AdapterConfig, Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+import { getSingleStakeBalance } from '@lib/stake'
+
+const sVEC: Contract = {
+  chain: 'ethereum',
+  address: '0x66d5c66e7c83e0682d947176534242c9f19b3365',
+  token: '0x1bb9b64927e0c5e207c9db4093b3738eef5d8447',
+  decimals: 9,
+  symbol: 'VEC',
+}
+
+const vETH: Contract = {
+  chain: 'ethereum',
+  address: '0x38d64ce1bdf1a9f24e0ec469c9cade61236fb4a0',
+  token: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+  decimals: 18,
+  symbol: 'vETH',
+}
+
+const svETH: Contract = {
+  chain: 'ethereum',
+  address: '0x6733f0283711f225a447e759d859a70b0c0fd2bc',
+  token: '0x38d64ce1bdf1a9f24e0ec469c9cade61236fb4a0',
+  underlyings: ['0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'],
+  decimals: 18,
+  symbol: 'svETH',
+}
+
+export const getContracts = () => {
+  return {
+    contracts: { sVEC, vETH, svETH },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    sVEC: getSingleStakeBalance,
+    vETH: getSingleStakeBalance,
+    svETH: getVectorReserveBalance,
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}
+
+export const config: AdapterConfig = {
+  startDate: 1706745600,
+}

--- a/src/adapters/vector-reserve/index.ts
+++ b/src/adapters/vector-reserve/index.ts
@@ -1,0 +1,10 @@
+import type { Adapter } from '@lib/adapter'
+
+import * as ethereum from './ethereum'
+
+const adapter: Adapter = {
+  id: 'vector-reserve',
+  ethereum: ethereum,
+}
+
+export default adapter


### PR DESCRIPTION
`pnpm run adapter vector-reserve ethereum 0xfdc28cd1bfebf3033870c0344b4e0bee639be9b1`

![vec-0xfdc28cd1bfebf3033870c0344b4e0bee639be9b1](https://github.com/llamafolio/llamafolio-api/assets/110820448/f6e7ff43-f288-40de-80c0-65200d526cee)

`pnpm run adapter vector-reserve ethereum 0xba12222222228d8ba445958a75a0704d566bf2c8`

![veth-0xba12222222228d8ba445958a75a0704d566bf2c8](https://github.com/llamafolio/llamafolio-api/assets/110820448/c1aa4e8c-e3f5-4f7b-9fc5-0d8d58664d9d)
