### PR TITLE
feat:Adapter,Blueprint,ethereum

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -150,6 +150,7 @@
         "blast",
         "bloom",
         "blueberry-lend",
+        "blueprint",
         "blur",
         "cap-finance",
         "cat-in-a-box",

--- a/src/adapters/blueprint/ethereum/index.ts
+++ b/src/adapters/blueprint/ethereum/index.ts
@@ -1,0 +1,34 @@
+import { getPoolsBalances } from '@adapters/uniswap-v3/common/pools'
+import type { AdapterConfig, Contract, GetBalancesHandler } from '@lib/adapter'
+import { resolveBalances } from '@lib/balance'
+
+export const factory: Contract = {
+  chain: 'ethereum',
+  address: '0xe777c3da43ec554ec845649323215afaa34d6c23',
+}
+
+export const nonFungiblePositionManager: Contract = {
+  chain: 'ethereum',
+  address: '0xdC6F8E434a7E0db46D416b6959d8175DAFa5be53',
+}
+
+export const getContracts = async () => {
+  return {
+    contracts: { nonFungiblePositionManager },
+  }
+}
+
+export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
+  const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
+    nonFungiblePositionManager: (ctx, nonFungiblePositionManager) =>
+      getPoolsBalances(ctx, nonFungiblePositionManager, factory),
+  })
+
+  return {
+    groups: [{ balances }],
+  }
+}
+
+export const config: AdapterConfig = {
+  startDate: 1707868800,
+}

--- a/src/adapters/blueprint/index.ts
+++ b/src/adapters/blueprint/index.ts
@@ -1,0 +1,10 @@
+import type { Adapter } from '@lib/adapter'
+
+import * as ethereum from './ethereum'
+
+const adapter: Adapter = {
+  id: 'blueprint',
+  ethereum: ethereum,
+}
+
+export default adapter

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -59,6 +59,7 @@ import biswap from '@adapters/biswap'
 import blast from '@adapters/blast'
 import bloom from '@adapters/bloom'
 import blueberryLend from '@adapters/blueberry-lend'
+import blueprint from '@adapters/blueprint'
 import blur from '@adapters/blur'
 import capFinance from '@adapters/cap-finance'
 import catInABox from '@adapters/cat-in-a-box'
@@ -452,6 +453,7 @@ export const adapters: Adapter[] = [
   blast,
   bloom,
   blueberryLend,
+  blueprint,
   blur,
   capFinance,
   catInABox,


### PR DESCRIPTION
`pnpm run adapter blueprint ethereum 0x13d079048a83dd7524aa19c9528a7eeac22fa638`

![blueprint-0x13d079048a83dd7524aa19c9528a7eeac22fa638](https://github.com/llamafolio/llamafolio-api/assets/110820448/0ccda129-1e81-4457-a137-786f9b89fccb)
