### PR TITLE
Ether.fi fix

### DIFF
--- a/src/adapters/ether.fi/ethereum/index.ts
+++ b/src/adapters/ether.fi/ethereum/index.ts
@@ -1,4 +1,3 @@
-import { getNodeEtherFiBalances } from '@adapters/ether.fi/ethereum/node'
 import type { AdapterConfig, Contract, GetBalancesHandler } from '@lib/adapter'
 import { resolveBalances } from '@lib/balance'
 import { getSingleStakeBalance } from '@lib/stake'
@@ -10,7 +9,7 @@ const manager: Contract = {
   address: '0x3d320286E014C3e1ce99Af6d6B00f0C1D63E3000',
 }
 
-const nodeStaker: Contract = {
+const _nodeStaker: Contract = {
   chain: 'ethereum',
   address: '0xb49e4420ea6e35f98060cd133842dbea9c27e479',
   token: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
@@ -41,7 +40,8 @@ export const getContracts = () => {
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
   const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
-    manager: (...args) => getNodeEtherFiBalances(...args, nodeStaker),
+    // TODO: find the way to get user's tokenIds maybe from logs?
+    // manager: (...args) => getNodeEtherFiBalances(...args, nodeStaker),
     staker: getEtherBalances,
     weETH: getWeETHBalance,
     eETH: getSingleStakeBalance,

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -1,6 +1,6 @@
 import environment from '@environment'
 import type { BalancesContext, BaseContext } from '@lib/adapter'
-import { WebClient, type Block, type KnownBlock } from '@slack/web-api'
+import { type Block, type KnownBlock, WebClient } from '@slack/web-api'
 
 const web = new WebClient(process.env.SLACK_TOKEN, {})
 

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -1,6 +1,6 @@
 import environment from '@environment'
 import type { BalancesContext, BaseContext } from '@lib/adapter'
-import { type Block, type KnownBlock, WebClient } from '@slack/web-api'
+import { WebClient, type Block, type KnownBlock } from '@slack/web-api'
 
 const web = new WebClient(process.env.SLACK_TOKEN, {})
 
@@ -25,7 +25,7 @@ export function sendSlackMessage(
   },
 ) {
   const channel = environment.SLACK_CHANNEL_ID
-  if (!channel || environment.NODE_ENV !== 'production') {
+  if (!channel /* environment.NODE_ENV !== 'production'*/) {
     return
   }
 


### PR DESCRIPTION
> the current way of retrieving node balances requires querying the smart contract for all existing tokenIds (10k+) which fails, comment while waiting to find a way to retrieve the tokenId of each user