### PR TITLE
fix across (missing reward + using share instead of assetBalance)

### DIFF
--- a/src/adapters/across/ethereum/index.ts
+++ b/src/adapters/across/ethereum/index.ts
@@ -31,14 +31,14 @@ export const getContracts = async (ctx: BaseContext) => {
   ])
 
   return {
-    contracts: { pairs, pools, manager },
+    contracts: { pairs, pools },
   }
 }
 
 export const getBalances: GetBalancesHandler<typeof getContracts> = async (ctx, contracts) => {
   const balances = await resolveBalances<typeof getContracts>(ctx, contracts, {
     pairs: getPairsBalances,
-    pools: (...args) => getAcrossBalances(...args, manager, masterChef),
+    pools: (...args) => getAcrossBalances(...args, masterChef),
   })
 
   return {

--- a/src/adapters/across/ethereum/v2/balance.ts
+++ b/src/adapters/across/ethereum/v2/balance.ts
@@ -143,6 +143,7 @@ async function getAcrossUnderlyingsBalances(ctx: BalancesContext, pools: Contrac
       const pool = pools[index]
       const amount = pool.amount
       const rawUnderlying = pool.underlyings?.[0] as Contract
+      const reward = pool.rewards?.[0] as Contract
 
       const [{ output: totalSupply }, { output: tokenBalance }] = res.inputOutputPairs
       const [_lpToken, _isEnabled, _lastLpFeeUpdate, utilizedReserves, liquidReserves] = tokenBalance
@@ -154,7 +155,7 @@ async function getAcrossUnderlyingsBalances(ctx: BalancesContext, pools: Contrac
         ...pool,
         amount,
         underlyings,
-        rewards: undefined,
+        rewards: [reward],
         category: 'lp',
       }
     },
@@ -216,7 +217,6 @@ async function getUserPendingRewards(
   return mapSuccessFilter(userPendingRewards, (res: any, index) => {
     const pool = pools[index]
     const reward = rewardToken || (pool.rewards?.[0] as Contract)
-
     return [{ ...reward, amount: res.output }]
   })
 }


### PR DESCRIPTION
`pnpm run adapter-balances across ethereum 0xb72ed8401892466ea8af528c1af1d0524bc5e105`

![image](https://github.com/llamafolio/llamafolio-api/assets/110820448/2e312441-4803-48cf-8c01-4cee1fea42ff)