### PR TITLE
fix: updateBalances handler adapter timeout

### DIFF
--- a/src/lib/adapter.ts
+++ b/src/lib/adapter.ts
@@ -16,6 +16,8 @@ import isEqual from 'lodash/isEqual'
 import type { Logger } from 'pino'
 import type { PublicClient } from 'viem'
 
+export const GET_BALANCES_TIMEOUT = 15_000
+
 export interface BaseContext {
   logger?: Logger
   module?: string


### PR DESCRIPTION
<!-- 🦙🦙 Thanks for contributing ! 🦙🦙 -->

<!-- Please specify the adapter id in the title -->

<!-- If you're creating a new adapter, please make sure the `links` field is well specified: this info will help us review it -->

## Summary

<!-- Which issues will be closed? (if applicable) -->

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

add timeout for each adapter#getBalances during an update to make sure one adapter doesn't timeout the entire Lambda

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
