### PR TITLE
adapter swell: predeposit l2 pendle pt

### DIFF
--- a/src/adapters/swell/ethereum/balance.ts
+++ b/src/adapters/swell/ethereum/balance.ts
@@ -1,3 +1,5 @@
+import { getPendleBalances } from '@adapters/pendle/common/balance'
+import { getPendlePools } from '@adapters/pendle/common/pool'
 import type { Balance, BalancesContext, Contract } from '@lib/adapter'
 import type { Category } from '@lib/category'
 import { abi as erc20Abi } from '@lib/erc20'
@@ -41,14 +43,64 @@ export async function getSwellBalances(ctx: BalancesContext, contracts: Contract
     .map((balanceOf, index) => {
       const rate = rates[index]
       if (!rate.success || !balanceOf.success) return null
-
+      const amount = (balanceOf.output * rate.output) / parseEther('1.0')
       return {
         ...contracts[index],
         amount: balanceOf.output,
-        underlyings: [{ ...WETH, amount: (balanceOf.output * rate.output) / parseEther('1.0') }],
+        underlyings: [{ ...WETH, amount }],
         rewards: undefined,
+        balanceUSD: amount * BigInt(3500),
         category: 'farm' as Category,
       }
     })
     .filter(isNotNullish)
+}
+
+const SimpleStakingERC20 = {
+  stakedBalances: {
+    inputs: [
+      { internalType: 'address', name: '', type: 'address' },
+      { internalType: 'contract IERC20', name: '', type: 'address' },
+    ],
+    name: 'stakedBalances',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  } as const,
+}
+
+const depositContract = '0x38d43a6cb8da0e855a42fb6b0733a0498531d774'
+
+export async function getSwellL2Balances(ctx: BalancesContext, contracts: Contract[]): Promise<Balance[]> {
+  return getSwellL2BalancesPendle(ctx, contracts)
+}
+
+async function getSwellL2BalancesPendle(ctx: BalancesContext, contracts: Contract[]): Promise<Balance[]> {
+  const userStakedBalances = (
+    await Promise.all([
+      multicall({
+        ctx,
+        calls: contracts.map((contract) => ({
+          target: depositContract,
+          params: [ctx.address, contract.address] as any,
+        })),
+        abi: SimpleStakingERC20.stakedBalances,
+      }),
+    ])
+  )[0].filter((balance) => balance.success && balance.output > BigInt(0))
+  const tokenWithBalance = userStakedBalances.map((balance) => {
+    return balance.input.params[1]
+  })
+  const pendlePools = (await getPendlePools(ctx)).filter((pool) => tokenWithBalance.includes(pool.address))
+
+  const depositContractCTX = ctx
+  depositContractCTX.address = depositContract
+  const balances = (await getPendleBalances(depositContractCTX, pendlePools))[1]
+
+  const updatedBalances = balances.map((balance) => {
+    const stakedBalance = userStakedBalances.find((stakedBalance) => stakedBalance.input.params[1] === balance.address)
+    const amount = stakedBalance && stakedBalance.output ? stakedBalance.output : BigInt(0)
+    return { ...balance, amount }
+  })
+  return updatedBalances
 }

--- a/src/adapters/swell/ethereum/balance.ts
+++ b/src/adapters/swell/ethereum/balance.ts
@@ -69,11 +69,22 @@ const SimpleStakingERC20 = {
   } as const,
 }
 
+// This is the contract where users predeposit their tokens for Swell L2
 const depositContract = '0x38d43a6cb8da0e855a42fb6b0733a0498531d774'
 
 export async function getSwellL2Balances(ctx: BalancesContext, contracts: Contract[]): Promise<Balance[]> {
   return getSwellL2BalancesPendle(ctx, contracts)
 }
+
+/**
+ * This function is used to get the balances of the user in the Pendle pools in the Swell L2 contract
+ * We first get the staked balances of the user in the deposit contract.
+ * Then we get the list of pt from pendle pools that the user could stake in.
+ * Finally we set the balances of the user in the pendle pools and return them.
+ * @param ctx
+ * @param contracts
+ * @returns
+ */
 
 async function getSwellL2BalancesPendle(ctx: BalancesContext, contracts: Contract[]): Promise<Balance[]> {
   const userStakedBalances = (

--- a/src/adapters/swell/ethereum/common.ts
+++ b/src/adapters/swell/ethereum/common.ts
@@ -21,6 +21,12 @@ interface TokenListResponse {
   }
 }
 
+/**
+ * This returns a list of tokens that are accepted by Swell in there predeposit l2 contract.
+ * There is no way to get this info onchain.
+ * @returns {Promise<SwellApiToken[]>}
+ */
+
 export async function getAcceptedTokens(): Promise<SwellApiToken[]> {
   try {
     const resp = await fetch(
@@ -34,6 +40,12 @@ export async function getAcceptedTokens(): Promise<SwellApiToken[]> {
   }
 }
 
+/**
+ * The Swell API format is different from the contract format. We convert the chainId (int) to
+ * the chainName (string) and the address to lowercase.
+ * @param tokens
+ * @returns
+ */
 export function fromSwellApiTokenToContract(tokens: SwellApiToken[]): Contract[] {
   return tokens.map((token) => ({
     chain: chainByChainId[token.chainId].id as Chain,

--- a/src/adapters/swell/ethereum/common.ts
+++ b/src/adapters/swell/ethereum/common.ts
@@ -1,0 +1,43 @@
+import type { Contract } from '@lib/adapter'
+import { type Chain, chainByChainId } from '@lib/chains'
+
+type SwellTags = 'LST' | 'Pendle' | 'AVS' | 'Eigenpie' | 'LRT'
+
+interface SwellApiToken {
+  chainId: number
+  address: string
+  symbol: string
+  name: string
+  decimals: number
+  logoUri: string
+  tags: SwellTags[]
+}
+
+interface TokenListResponse {
+  tokenList: {
+    name: string
+    timestamp: number
+    tokens: SwellApiToken[]
+  }
+}
+
+export async function getAcceptedTokens(): Promise<SwellApiToken[]> {
+  try {
+    const resp = await fetch(
+      'https://v3-lst.svc.swellnetwork.io/swell.v3.PreDepositService/TokenList?connect=v1&encoding=json&message=%7B%7D',
+    )
+    const data: TokenListResponse = await resp.json()
+    return data.tokenList.tokens
+  } catch (e) {
+    console.error('Failed to fetch token list from Swell:', e)
+    return []
+  }
+}
+
+export function fromSwellApiTokenToContract(tokens: SwellApiToken[]): Contract[] {
+  return tokens.map((token) => ({
+    chain: chainByChainId[token.chainId].id as Chain,
+    address: token.address.toLowerCase() as `0x${string}`,
+    decimals: token.decimals,
+  }))
+}


### PR DESCRIPTION
<!-- 🦙🦙 Thanks for contributing ! 🦙🦙 -->

<!-- Please specify the adapter id in the title -->

<!-- If you're creating a new adapter, please make sure the `links` field is well specified: this info will help us review it -->

## Summary

<!-- Which issues will be closed? (if applicable) -->

<!-- What changes are being made? -->
add a new type of contracts for swell adapter: SwellL2PreDeposit and the functions to get the amount of tokens deposited by the user. This is done by querying the contract at address 0x38d43a6cb8da0e855a42fb6b0733a0498531d774 and it's ```function stakedBalances(address user, address token) view```.
The list of token to check is obtained by querying the swell API, there is no clean way to get this info onchain, aside querying all past events. 
<!-- Why are these changes necessary? -->
Llamafolio doesn't display the pt from pendle deposited on Swell L2 predeposit contract.

## Checklist

- [x] I checked my changes for obvious issues, debug statements and commented code
- [x] I tested adapter results with the CLI

<!-- Feel free to add additional comments. -->
